### PR TITLE
Feat/extra route paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,24 @@ GET /_laravel-brain
 
 LaravelBrain recursively scans your entire `routes/` directory — not just `web.php` and `api.php`. Any PHP file under `routes/**` is analyzed, including versioned files like `routes/v1/users.php` or module-specific files like `routes/modules/admin.php`.
 
+For **modular, DDD, or package-style projects** where routes are registered from service providers outside the `routes/` directory, publish the config and add glob patterns:
+
+```bash
+php artisan vendor:publish --tag=laravel-brain-config
+```
+
+```php
+// config/laravel-brain.php
+return [
+    'route_paths' => [
+        'app/Modules/*/routes/*.php',
+        // 'app/Domain/*/routes/*.php',
+    ],
+];
+```
+
+Patterns are relative to the project root and merged with the standard `routes/` scan. Overlapping paths are deduplicated automatically.
+
 ### Call chain tracing
 
 From each controller action, the tracer follows:

--- a/config/laravel-brain.php
+++ b/config/laravel-brain.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Extra Route Paths
+    |--------------------------------------------------------------------------
+    |
+    | Glob patterns (relative to the project root) for additional route files
+    | to scan. The standard routes/ directory is always included. Add patterns
+    | here for modular, DDD, or package-style project structures where routes
+    | are registered from service providers outside the routes/ directory.
+    |
+    | Examples:
+    |   'app/Modules/*/routes/*.php'
+    |   'app/Domain/*/routes/*.php'
+    |
+    */
+
+    'route_paths' => [],
+
+];

--- a/config/laravel-brain.php
+++ b/config/laravel-brain.php
@@ -12,12 +12,11 @@ return [
     | here for modular, DDD, or package-style project structures where routes
     | are registered from service providers outside the routes/ directory.
     |
-    | Examples:
-    |   'app/Modules/*/routes/*.php'
-    |   'app/Domain/*/routes/*.php'
-    |
     */
 
+    // Examples:
+    //   'app/Modules/*/routes/*.php'
+    //   'app/Domain/*/routes/*.php'
     'route_paths' => [],
 
 ];

--- a/src/Analysis/ProjectAnalyzer.php
+++ b/src/Analysis/ProjectAnalyzer.php
@@ -82,7 +82,8 @@ class ProjectAnalyzer
         $this->emit('project:start', ['name' => $projectName, 'message' => "Analyzing project: {$projectName}"]);
 
         $this->emit('step:start', ['step' => 'routes', 'label' => 'Scanning routes', 'message' => '  → Scanning routes...']);
-        $routes = $this->routeAnalyzer->analyze($projectRoot);
+        $extraGlobs = function_exists('config') ? (array) config('laravel-brain.route_paths', []) : [];
+        $routes = $this->routeAnalyzer->analyze($projectRoot, $extraGlobs);
         $this->emit('step:done', ['step' => 'routes', 'count' => count($routes), 'unit' => 'route', 'message' => '    Found '.count($routes).' route(s)']);
 
         $this->emit('step:start', ['step' => 'middleware', 'label' => 'Scanning middleware', 'message' => '  → Scanning middleware...']);

--- a/src/Analysis/RouteAnalyzer.php
+++ b/src/Analysis/RouteAnalyzer.php
@@ -36,12 +36,13 @@ class RouteAnalyzer
     }
 
     /**
+     * @param  string[]  $extraGlobs  Glob patterns relative to $projectRoot for additional route files
      * @return RouteDefinition[]
      */
-    public function analyze(string $projectRoot): array
+    public function analyze(string $projectRoot, array $extraGlobs = []): array
     {
         $routes = [];
-        $routeFiles = $this->findRouteFiles($projectRoot);
+        $routeFiles = $this->findRouteFiles($projectRoot, $extraGlobs);
 
         foreach ($routeFiles as $file) {
             $parsed = $this->parser->parse($file);
@@ -55,21 +56,35 @@ class RouteAnalyzer
         return $routes;
     }
 
-    private function findRouteFiles(string $projectRoot): array
+    /**
+     * @param  string[]  $extraGlobs  Glob patterns relative to $projectRoot
+     * @return string[]
+     */
+    private function findRouteFiles(string $projectRoot, array $extraGlobs = []): array
     {
-        $routesDir = rtrim($projectRoot, '/').'/routes';
-        if (! is_dir($routesDir)) {
-            return [];
+        $root = rtrim($projectRoot, '/');
+        $files = [];
+
+        // Always scan the standard routes/ directory
+        $routesDir = $root.'/routes';
+        if (is_dir($routesDir)) {
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($routesDir, \FilesystemIterator::SKIP_DOTS)
+            );
+
+            foreach ($iterator as $entry) {
+                if ($entry->isFile() && $entry->getExtension() === 'php') {
+                    $files[] = $entry->getPathname();
+                }
+            }
         }
 
-        $files = [];
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($routesDir, \FilesystemIterator::SKIP_DOTS)
-        );
-
-        foreach ($iterator as $entry) {
-            if ($entry->isFile() && $entry->getExtension() === 'php') {
-                $files[] = $entry->getPathname();
+        // Scan any extra glob patterns, deduplicating against already-found files
+        foreach ($extraGlobs as $pattern) {
+            foreach (glob($root.'/'.$pattern) ?: [] as $file) {
+                if (! in_array($file, $files, true)) {
+                    $files[] = $file;
+                }
             }
         }
 

--- a/src/LaravelBrainServiceProvider.php
+++ b/src/LaravelBrainServiceProvider.php
@@ -11,10 +11,16 @@ class LaravelBrainServiceProvider extends ServiceProvider
 {
     public function boot(): void
     {
+        $this->mergeConfigFrom(__DIR__.'/../config/laravel-brain.php', 'laravel-brain');
+
         // Only register routes and commands in local environment for security
         if (! $this->app->isLocal()) {
             return;
         }
+
+        $this->publishes([
+            __DIR__.'/../config/laravel-brain.php' => config_path('laravel-brain.php'),
+        ], 'laravel-brain-config');
 
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'laravel-brain');
         $this->commands([ScanCommand::class]);

--- a/tests/Unit/RouteAnalyzerTest.php
+++ b/tests/Unit/RouteAnalyzerTest.php
@@ -47,7 +47,24 @@ it('applies prefix from nested group', function () use ($fixtureProject) {
     expect($adminRoute->middlewares)->toContain('role:admin');
 });
 
-it('finds 5 routes total', function () use ($fixtureProject) {
+it('finds 5 routes total without extra globs', function () use ($fixtureProject) {
     $routes = (new RouteAnalyzer)->analyze($fixtureProject);
+    expect(count($routes))->toBe(5);
+});
+
+it('discovers module routes when an extra glob is provided', function () use ($fixtureProject) {
+    $routes = (new RouteAnalyzer)->analyze($fixtureProject, ['app/Modules/*/routes/*.php']);
+
+    expect(count($routes))->toBe(7); // 5 standard + 2 from module fixture
+
+    $register = findRoute($routes, fn ($r) => str_contains($r->uri, 'register'));
+    expect($register)->not->toBeNull();
+    expect($register->method)->toBe('POST');
+    expect($register->uri)->toBe('/api/v1/auth/register');
+});
+
+it('does not duplicate routes when a glob overlaps the routes/ directory', function () use ($fixtureProject) {
+    $routes = (new RouteAnalyzer)->analyze($fixtureProject, ['routes/*.php']);
+
     expect(count($routes))->toBe(5);
 });

--- a/tests/fixtures/laravel-project/app/Modules/Auth/routes/api.php
+++ b/tests/fixtures/laravel-project/app/Modules/Auth/routes/api.php
@@ -1,0 +1,9 @@
+<?php
+
+use App\Http\Controllers\AuthController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware('api')->prefix('api/v1')->group(function () {
+    Route::post('auth/register', [AuthController::class, 'register']);
+    Route::post('auth/login', [AuthController::class, 'login']);
+});


### PR DESCRIPTION
 ## Problem                                                                                                                                          
                                                                                                                                                      
  `RouteAnalyzer::findRouteFiles()` hard-codes the top-level `routes/` directory as the only scan root. Routes registered from service providers      
  outside that directory — common in modular, DDD, and package-style Laravel projects — are silently ignored.                                         
                                                                                                             
  For example, none of these are discovered today:                                                                                                    
  - `app/Modules/Auth/routes/api.php`                                                                                                                 
  - `app/Domain/Billing/routes/api.php`
                                                                                                                                                      
  ## Solution                                                                                                                                         
             
  Add an optional published config (`config/laravel-brain.php`) with a `route_paths` key that accepts glob patterns relative to the project root. The 
  standard `routes/` directory is always scanned; extra patterns are additive and deduplicated.                                                       
                                                                                               
  ```php                                                                                                                                              
  // config/laravel-brain.php                            
  return [                   
      'route_paths' => [
          'app/Modules/*/routes/*.php',
      ],                               
  ];                                                                                                                                                  
    
  No breaking changes — projects that don't publish the config get identical behaviour.                                                               
                                                                                                                                                      
  Changes
                                                                                                                                                      
  - config/laravel-brain.php — new config file with route_paths key                                                                                   
  - LaravelBrainServiceProvider — merges config defaults, publishes via laravel-brain-config tag
  - RouteAnalyzer::analyze() — accepts $extraGlobs parameter                                                                                          
  - RouteAnalyzer::findRouteFiles() — scans extra globs with deduplication                                                                            
  - ProjectAnalyzer::analyze() — reads config('laravel-brain.route_paths') and threads it through                                                     
  - tests/fixtures/.../app/Modules/Auth/routes/api.php — new fixture for module-style routes                                                          
  - RouteAnalyzerTest — 3 new tests: no extra globs (regression), module discovery, overlap dedup                                                     
  - README.md — updated route discovery section with usage example                