### PR TITLE
Remove hard limitation when using local memory init

### DIFF
--- a/src/Commands/ScanCommand.php
+++ b/src/Commands/ScanCommand.php
@@ -23,7 +23,7 @@ class ScanCommand extends Command
     {
         $memoryLimit = $this->normalizeMemoryLimit($this->option('memory-limit'));
 
-        if($memoryLimit === self::FAILURE) {
+        if ($memoryLimit === self::FAILURE) {
             return $memoryLimit;
         }
 
@@ -127,38 +127,34 @@ class ScanCommand extends Command
 
     private function normalizeMemoryLimit($option): string|int
     {
-        $memory = trim((string) $option);
+        $memory = strtoupper(trim((string) $option));
 
         if ($memory === '-1') {
             return -1;
         }
 
-        if (preg_match('/^([+-]?\d+)([kmgt]?)$/i', $memory, $matches)) {
-            $value = (int) $matches[1];
-            $unit = strtoupper($matches[2]);
+        if (! preg_match('/^(\d+)([KMGT]?)$/', $memory, $matches)) {
+            $this->error('Invalid memory limit format. Example: 1024M, 1G, 2G or -1.');
 
-            if ($unit === '') {
-                $unit = 'M';
-            }
-
-            if ($value <= 0) {
-                $this->error('Invalid memory limit. The value must be a positive number or -1.');
-                return self::FAILURE;
-            }
-
-            $bytes = $this->convertToBytes($value, $unit);
-            $minimumBytes = 1024 * 1024 * 1024; // 1024M in bytes
-
-            if ($bytes < $minimumBytes) {
-                $this->error('The memory limit must be at least 1024M (or equivalent).');
-                return self::FAILURE;
-            }
-
-            return $value . $unit;
+            return self::FAILURE;
         }
 
-        $this->error('Invalid memory limit format. Example: 1024, 1G, 2G or -1.');
-        return self::FAILURE;
+        $value = (int) $matches[1];
+        $unit = $matches[2] ?: 'M';
+
+        if ($value <= 0) {
+            $this->error('Invalid memory limit. The value must be a positive number or -1.');
+
+            return self::FAILURE;
+        }
+
+        if ($this->convertToBytes($value, $unit) < (1024 ** 3)) {
+            $this->error("The memory limit must be at least 1024M (Current: {$value}{$unit}).");
+
+            return self::FAILURE;
+        }
+
+        return "{$value}{$unit}";
     }
 
     private function convertToBytes(int $value, string $unit): int

--- a/src/Commands/ScanCommand.php
+++ b/src/Commands/ScanCommand.php
@@ -20,8 +20,6 @@ class ScanCommand extends Command
 
     public function handle(): int
     {
-        ini_set('memory_limit', '1024M');
-
         $projectPath = base_path();
 
         if ($this->option('watch')) {

--- a/src/Commands/ScanCommand.php
+++ b/src/Commands/ScanCommand.php
@@ -11,7 +11,8 @@ class ScanCommand extends Command
 {
     protected $signature = 'brain:scan
                             {--watch : Watch for PHP file changes and auto-rescan}
-                            {--interval=3 : Poll interval in seconds (watch mode only)}';
+                            {--interval=3 : Poll interval in seconds (watch mode only)}
+                            {--memory=1024M : Increase memory limit for scanning. Example: 1024M}';
 
     protected $description = 'Analyze this Laravel project and open the interactive graph viewer';
 
@@ -20,6 +21,14 @@ class ScanCommand extends Command
 
     public function handle(): int
     {
+        $memory = $this->setMemoryLimit($this->option('memory'));
+
+        if($memory === self::FAILURE) {
+            return $memory;
+        }
+
+        ini_set('memory_limit', $memory);
+
         $projectPath = base_path();
 
         if ($this->option('watch')) {
@@ -112,6 +121,55 @@ class ScanCommand extends Command
         }
 
         return $label;
+    }
+
+    // ── Memory Option ─────────────────────────────────────────────────────────
+
+    private function setMemoryLimit($option): string|int
+    {
+        $memory = trim((string) $option);
+
+        if ($memory === '-1') {
+            return -1;
+        }
+
+        if (preg_match('/^\s*([+-]?\d+)\s*([kmgt]?)\s*$/i', $memory, $matches)) {
+            $value = (int) $matches[1];
+            $unit = strtoupper($matches[2]);
+
+            if ($unit === '') {
+                $unit = 'M';
+            }
+
+            if ($value <= 0) {
+                $this->error('Invalid memory limit. The value must be a positive number or -1.');
+                return self::FAILURE;
+            }
+
+            $bytes = $this->convertToBytes($value, $unit);
+            $minimumBytes = 1024 * 1024 * 1024; // 1024M in bytes
+
+            if ($bytes < $minimumBytes) {
+                $this->error('The memory limit must be at least 1024M (or equivalent).');
+                return self::FAILURE;
+            }
+
+            return $value . $unit;
+        }
+
+        $this->error('Invalid memory limit format. Example: 1024, 1G, 2G or -1.');
+        return self::FAILURE;
+    }
+
+    private function convertToBytes(int $value, string $unit): int
+    {
+        return match ($unit) {
+            'K' => $value * 1024,
+            'M' => $value * 1024 * 1024,
+            'G' => $value * 1024 * 1024 * 1024,
+            'T' => $value * 1024 * 1024 * 1024 * 1024,
+            default => $value,
+        };
     }
 
     // ── Shared scan logic ─────────────────────────────────────────────────────

--- a/src/Commands/ScanCommand.php
+++ b/src/Commands/ScanCommand.php
@@ -12,7 +12,7 @@ class ScanCommand extends Command
     protected $signature = 'brain:scan
                             {--watch : Watch for PHP file changes and auto-rescan}
                             {--interval=3 : Poll interval in seconds (watch mode only)}
-                            {--memory=1024M : Increase memory limit for scanning. Example: 1024M}';
+                            {--memory-limit=1024M : Increase memory limit for scanning. Example: 1024M}';
 
     protected $description = 'Analyze this Laravel project and open the interactive graph viewer';
 
@@ -21,13 +21,13 @@ class ScanCommand extends Command
 
     public function handle(): int
     {
-        $memory = $this->setMemoryLimit($this->option('memory'));
+        $memoryLimit = $this->normalizeMemoryLimit($this->option('memory-limit'));
 
-        if($memory === self::FAILURE) {
-            return $memory;
+        if($memoryLimit === self::FAILURE) {
+            return $memoryLimit;
         }
 
-        ini_set('memory_limit', $memory);
+        ini_set('memory_limit', $memoryLimit);
 
         $projectPath = base_path();
 
@@ -125,7 +125,7 @@ class ScanCommand extends Command
 
     // ── Memory Option ─────────────────────────────────────────────────────────
 
-    private function setMemoryLimit($option): string|int
+    private function normalizeMemoryLimit($option): string|int
     {
         $memory = trim((string) $option);
 
@@ -133,7 +133,7 @@ class ScanCommand extends Command
             return -1;
         }
 
-        if (preg_match('/^\s*([+-]?\d+)\s*([kmgt]?)\s*$/i', $memory, $matches)) {
+        if (preg_match('/^([+-]?\d+)([kmgt]?)$/i', $memory, $matches)) {
             $value = (int) $matches[1];
             $unit = strtoupper($matches[2]);
 
@@ -164,10 +164,10 @@ class ScanCommand extends Command
     private function convertToBytes(int $value, string $unit): int
     {
         return match ($unit) {
-            'K' => $value * 1024,
-            'M' => $value * 1024 * 1024,
-            'G' => $value * 1024 * 1024 * 1024,
-            'T' => $value * 1024 * 1024 * 1024 * 1024,
+            'K' => $value * (1024 ** 1),
+            'M' => $value * (1024 ** 2),
+            'G' => $value * (1024 ** 3),
+            'T' => $value * (1024 ** 4),
             default => $value,
         };
     }


### PR DESCRIPTION
When I tried to scan with big project, unfortunately this line as blocker even though I tried to use from `php -d memory_limit=-1`, rather than put hard limit, better use limit on artisan or set from the php.ini