### PR TITLE
[CHORE] Test Improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,13 @@ name: CI
 on:
   push:
     branches: [ "main", "master" ]
+
   pull_request:
     branches: [ "main", "master" ]
 
 jobs:
-  laravel-pint:
+
+  PHP:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -23,46 +25,14 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-interaction --no-progress
 
-      - name: Run Pint
-        run: ./vendor/bin/pint --test
+      - name: Laravel Pint - Lint test
+        run: composer test:lint
 
-  phpstan:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - name: PHPStan - Static Analysis test
+        run: composer test:types
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.3'
-          extensions: dom, curl, libxml, mbstring, zip
-          coverage: none
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-interaction --no-progress
-
-      - name: Run PHPStan
-        run: ./vendor/bin/phpstan analyse
-
-  tests:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.3'
-          extensions: dom, curl, libxml, mbstring, zip
-          coverage: none
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-interaction --no-progress
-
-      - name: Run Tests
-        run: ./vendor/bin/pest
+      - name: Pest - Unit test
+        run: composer test:unit
 
   frontend:
     runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,21 @@
             "LaraMint\\LaravelBrain\\Tests\\": "tests/"
         }
     },
+    "scripts": {
+        "lint": [
+            "pint --parallel"
+        ],
+        "test:lint": [
+            "pint --parallel --test"
+        ],
+        "test:unit": "pest --order-by=random",
+        "test:types": "phpstan",
+        "test": [
+            "@test:lint",
+            "@test:unit",
+            "@test:types"
+        ]
+    },
     "extra": {
         "laravel": {
             "providers": [

--- a/composer.json
+++ b/composer.json
@@ -28,13 +28,13 @@
     },
     "scripts": {
         "lint": [
-            "pint --parallel"
+            "./vendor/bin/pint --parallel"
         ],
         "test:lint": [
-            "pint --parallel --test"
+            "./vendor/bin/pint --parallel --test"
         ],
-        "test:unit": "pest --order-by=random",
-        "test:types": "phpstan",
+        "test:unit": "./vendor/bin/pest --order-by=random",
+        "test:types": "./vendor/bin/phpstan analyse --memory-limit 512M",
         "test": [
             "@test:lint",
             "@test:unit",

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -1,0 +1,9 @@
+<?php
+
+arch()->preset()->php();
+
+arch()->preset()->security()->ignoring('md5');
+
+arch()
+    ->expect(['dd', 'dump', 'ray', 'die', 'var_dump',  'ds'])
+    ->not->toBeUsed();

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -1,5 +1,0 @@
-<?php
-
-test('example', function () {
-    expect(true)->toBeTrue();
-});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -27,8 +27,16 @@ pest()->extend(TestCase::class)->in('Unit');
 |
 */
 
-expect()->extend('toBeOne', function () {
-    return $this->toBe(1);
+expect()->extend('toBeNonEmptyArray', function () {
+    return $this->toBeArray()->not->toBeEmpty();
+});
+
+expect()->extend('andArrayFirstElement', function () {
+    expect($this->value)->toBeNonEmptyArray();
+
+    $this->value = array_first($this->value);
+
+    return $this;
 });
 
 /*
@@ -42,7 +50,20 @@ expect()->extend('toBeOne', function () {
 |
 */
 
-function something()
-{
-    // ..
+if (! function_exists('fixture')) {
+    /**
+     * Returns fixture file or directory path
+     *
+     * @throws RuntimeException if the file or directory does not exist.
+     */
+    function fixture(string $fixture): string
+    {
+        $path = __DIR__.str_replace('/', DIRECTORY_SEPARATOR, '//fixtures/'.$fixture);
+
+        if (! file_exists($path)) {
+            throw new RuntimeException("Directory or file missing {$path}]");
+        }
+
+        return $path;
+    }
 }

--- a/tests/Unit/ContainerBindingAnalyzerTest.php
+++ b/tests/Unit/ContainerBindingAnalyzerTest.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 
 use LaraMint\LaravelBrain\Analysis\ContainerBindingAnalyzer;
 
-$fixtureProject = __DIR__.'/../fixtures/laravel-project';
-
-it('extracts singleton bindings from fixture AppServiceProvider', function () use ($fixtureProject) {
-    $registry = (new ContainerBindingAnalyzer)->analyze($fixtureProject);
+it('extracts singleton bindings from fixture AppServiceProvider', function () {
+    $registry = (new ContainerBindingAnalyzer)->analyze(fixture('laravel-project'));
     $rec = $registry->get('App\Contracts\ThingRepositoryInterface');
 
-    expect($rec)->not->toBeNull();
-    expect($rec->concreteFqcn)->toBe('App\Repositories\SqlThingRepository');
-    expect($rec->providerFqcn)->toBe('App\Providers\AppServiceProvider');
-    expect($rec->kind)->toBe('singleton');
+    expect($rec)
+        ->concreteFqcn->toBe('App\Repositories\SqlThingRepository')
+        ->providerFqcn->toBe('App\Providers\AppServiceProvider')
+        ->kind->toBe('singleton');
 });

--- a/tests/Unit/ControllerAnalyzerTest.php
+++ b/tests/Unit/ControllerAnalyzerTest.php
@@ -1,22 +1,42 @@
 <?php
 
+use App\Http\Controllers\V3\AbstractThingController;
+use LaraMint\LaravelBrain\Analysis\CallChainEdge;
 use LaraMint\LaravelBrain\Analysis\ControllerAnalyzer;
+use LaraMint\LaravelBrain\Analysis\ControllerDefinition;
 use LaraMint\LaravelBrain\Analysis\ControllerMiddleware;
 use LaraMint\LaravelBrain\Analysis\MethodTracer;
 use LaraMint\LaravelBrain\Analysis\RouteAnalyzer;
 
-$fixtureProject = __DIR__.'/../fixtures/laravel-project';
+test('HasMiddleware::appliesToAction() respects only/except parameters', function () {
 
-it('resolves controller files from routes', function () use ($fixtureProject) {
-    $routes = (new RouteAnalyzer)->analyze($fixtureProject);
-    $controllers = (new ControllerAnalyzer)->analyze($fixtureProject, $routes);
+    (new RouteAnalyzer)->analyze(fixture('laravel-project'));
 
-    expect($controllers)->not->toBeEmpty();
+    expect(new ControllerMiddleware('auth'))
+        ->appliesToAction('index')->toBeTrue()
+        ->appliesToAction('destroy')->toBeTrue();
+
+    expect(new ControllerMiddleware('log', only: ['index', 'show']))
+        ->appliesToAction('index')->toBeTrue()
+        ->appliesToAction('show')->toBeTrue()
+        ->appliesToAction('store')->toBeFalse();
+
+    expect(new ControllerMiddleware('subscribed', except: ['index']))->appliesToAction('index')->toBeFalse()
+        ->appliesToAction('store')->toBeTrue();
 });
 
-it('extracts constructor dependencies', function () use ($fixtureProject) {
-    $routes = (new RouteAnalyzer)->analyze($fixtureProject);
-    $controllers = (new ControllerAnalyzer)->analyze($fixtureProject, $routes);
+it('resolves controller files from routes', function () {
+    $routes = (new RouteAnalyzer)->analyze(fixture('laravel-project'));
+    $controllers = (new ControllerAnalyzer)->analyze(fixture('laravel-project'), $routes);
+
+    expect($controllers)
+        ->ToBeArray()
+        ->each->toBeInstanceOf(ControllerDefinition::class);
+});
+
+it('extracts constructor dependencies', function () {
+    $routes = (new RouteAnalyzer)->analyze(fixture('laravel-project'));
+    $controllers = (new ControllerAnalyzer)->analyze(fixture('laravel-project'), $routes);
 
     $authController = null;
     foreach ($controllers as $c) {
@@ -25,14 +45,14 @@ it('extracts constructor dependencies', function () use ($fixtureProject) {
             break;
         }
     }
-
-    expect($authController)->not->toBeNull();
-    expect($authController->constructorDeps)->toHaveKey('authService');
+    expect($authController)
+        ->toBeInstanceOf(ControllerDefinition::class)
+        ->constructorDeps->toHaveKey('authService');
 });
 
-it('extracts HasMiddleware static middleware() declarations', function () use ($fixtureProject) {
-    $routes = (new RouteAnalyzer)->analyze($fixtureProject);
-    $controllers = (new ControllerAnalyzer)->analyze($fixtureProject, $routes);
+it('extracts HasMiddleware static middleware() declarations', function () {
+    $routes = (new RouteAnalyzer)->analyze(fixture('laravel-project'));
+    $controllers = (new ControllerAnalyzer)->analyze(fixture('laravel-project'), $routes);
 
     $userController = null;
     foreach ($controllers as $c) {
@@ -42,27 +62,36 @@ it('extracts HasMiddleware static middleware() declarations', function () use ($
         }
     }
 
-    expect($userController)->not->toBeNull();
+    expect($userController)
+        ->toBeInstanceOf(ControllerDefinition::class);
 
     $middlewareNames = array_map(fn ($m) => $m->middleware, $userController->middlewares);
-    expect($middlewareNames)->toContain('auth');
-    expect($middlewareNames)->toContain('log');
-    expect($middlewareNames)->toContain('subscribed');
+
+    expect($middlewareNames)
+        ->toBe([
+            'auth',
+            'log',
+            'subscribed',
+        ]);
 
     // 'log' applies only to index + show
     $logMw = collect($userController->middlewares)->first(fn ($m) => $m->middleware === 'log');
-    expect($logMw->only)->toBe(['index', 'show']);
-    expect($logMw->except)->toBeNull();
+
+    expect($logMw)
+        ->only->toBe(['index', 'show'])
+        ->except->toBeNull();
 
     // 'subscribed' applies to all except index
     $subscribedMw = collect($userController->middlewares)->first(fn ($m) => $m->middleware === 'subscribed');
-    expect($subscribedMw->only)->toBeNull();
-    expect($subscribedMw->except)->toBe(['index']);
+
+    expect($subscribedMw)
+        ->only->toBeNull()
+        ->except->toBe(['index']);
 });
 
-it('extracts $this->middleware() calls from constructor', function () use ($fixtureProject) {
-    $routes = (new RouteAnalyzer)->analyze($fixtureProject);
-    $controllers = (new ControllerAnalyzer)->analyze($fixtureProject, $routes);
+it('extracts $this->middleware() calls from constructor', function () {
+    $routes = (new RouteAnalyzer)->analyze(fixture('laravel-project'));
+    $controllers = (new ControllerAnalyzer)->analyze(fixture('laravel-project'), $routes);
 
     $profileController = null;
     foreach ($controllers as $c) {
@@ -72,60 +101,55 @@ it('extracts $this->middleware() calls from constructor', function () use ($fixt
         }
     }
 
-    expect($profileController)->not->toBeNull();
+    expect($profileController)->toBeInstanceOf(ControllerDefinition::class);
 
     $middlewareNames = array_map(fn ($m) => $m->middleware, $profileController->middlewares);
-    expect($middlewareNames)->toContain('auth');
-    expect($middlewareNames)->toContain('verified');
-    expect($middlewareNames)->toContain('log');
+
+    expect($middlewareNames)->toBe(['auth', 'verified', 'log']);
 
     // 'verified' only for store
     $verifiedMw = collect($profileController->middlewares)->first(fn ($m) => $m->middleware === 'verified');
-    expect($verifiedMw->only)->toBe(['store']);
+
+    expect($verifiedMw)
+        ->toBeInstanceOf(ControllerMiddleware::class)
+        ->only->toBe(['store']);
 
     // 'log' except destroy (fluent chain)
     $logMw = collect($profileController->middlewares)->first(fn ($m) => $m->middleware === 'log');
-    expect($logMw->except)->toBe(['destroy']);
+
+    expect($logMw)
+        ->toBeInstanceOf(ControllerMiddleware::class)
+        ->except->toBe(['destroy']);
 });
 
-it('HasMiddleware::appliesToAction() respects only/except', function () {
-    $auth = new ControllerMiddleware('auth');
-    $log = new ControllerMiddleware('log', only: ['index', 'show']);
-    $sub = new ControllerMiddleware('subscribed', except: ['index']);
-
-    expect($auth->appliesToAction('index'))->toBeTrue();
-    expect($auth->appliesToAction('destroy'))->toBeTrue();
-
-    expect($log->appliesToAction('index'))->toBeTrue();
-    expect($log->appliesToAction('show'))->toBeTrue();
-    expect($log->appliesToAction('store'))->toBeFalse();
-
-    expect($sub->appliesToAction('index'))->toBeFalse();
-    expect($sub->appliesToAction('store'))->toBeTrue();
-});
-
-it('resolves same-namespace extends to FQCN and merges inherited actions', function () use ($fixtureProject) {
-    $routes = (new RouteAnalyzer)->analyze($fixtureProject);
-    $controllers = (new ControllerAnalyzer)->analyze($fixtureProject, $routes);
+it('resolves same-namespace extends to FQCN and merges inherited actions', function () {
+    $routes = (new RouteAnalyzer)->analyze(fixture('laravel-project'));
+    $controllers = (new ControllerAnalyzer)->analyze(fixture('laravel-project'), $routes);
 
     $v3 = $controllers['App\\Http\\Controllers\\V3\\ThingV3Controller'] ?? null;
-    expect($v3)->not->toBeNull();
-    expect($v3->parent)->toBe('App\\Http\\Controllers\\V3\\AbstractThingController');
+
+    expect($v3)->toBeInstanceOf(ControllerDefinition::class)
+        ->parent->toBe(AbstractThingController::class)
+        ->ancestorFqcns->toBe(['App\\Http\\Controllers\\V3\\AbstractThingController'])
+        ->constructorDeps->toBe([
+            'fixtureHelper' => "App\Services\V3\FixtureV3Helper",
+            'things' => "App\Contracts\ThingRepositoryInterface",
+        ]);
 
     $names = array_map(fn ($m) => $m->name, $v3->methods);
-    expect($names)->toContain('index');
-    expect($names)->toContain('label');
-    expect($v3->ancestorFqcns)->toBe(['App\\Http\\Controllers\\V3\\AbstractThingController']);
 
-    expect($v3->constructorDeps)->toHaveKey('fixtureHelper')
-        ->and($v3->constructorDeps['fixtureHelper'])->toBe('App\\Services\\V3\\FixtureV3Helper');
+    expect($names)->toBe([
+        'index',
+        'warmPanelCache',
+        'label',
+    ]);
 });
 
-it('resolves $this inside inherited methods against the declaring class', function () use ($fixtureProject) {
-    $routes = (new RouteAnalyzer)->analyze($fixtureProject);
+it('resolves $this inside inherited methods against the declaring class', function () {
+    $routes = (new RouteAnalyzer)->analyze(fixture('laravel-project'));
     $analyzer = new ControllerAnalyzer;
-    $controllers = $analyzer->analyze($fixtureProject, $routes);
-    $edges = (new MethodTracer)->trace($controllers, $analyzer->getPsr4Map(), $fixtureProject);
+    $controllers = $analyzer->analyze(fixture('laravel-project'), $routes);
+    $edges = (new MethodTracer)->trace($controllers, $analyzer->getPsr4Map(), fixture('laravel-project'));
 
     $ping = array_filter(
         $edges,
@@ -134,22 +158,33 @@ it('resolves $this inside inherited methods against the declaring class', functi
             && $e->calleeFqcn === 'App\\Services\\V3\\FixtureV3Helper'
             && $e->calleeMethod === 'ping'
     );
-    expect($ping)->not->toBeEmpty();
+
+    expect($ping)
+        ->toBeArray()
+        ->andArrayFirstElement()
+        ->toBeInstanceOf(CallChainEdge::class)
+        ->calleeFqcn->toBe('App\Services\V3\FixtureV3Helper');
 
     $wrong = array_filter($edges, fn ($e) => $e->calleeMethod === 'warmPanelCache'
         && $e->calleeFqcn === 'App\\Http\\Controllers\\V3\\ThingV3Controller');
-    expect($wrong)->toBeEmpty();
+
+    expect($wrong)->toBe([]);
 
     $right = array_filter($edges, fn ($e) => $e->calleeMethod === 'warmPanelCache'
         && $e->calleeFqcn === 'App\\Http\\Controllers\\V3\\AbstractThingController');
-    expect($right)->not->toBeEmpty();
+
+    expect($right)
+        ->toBeArray()
+        ->andArrayFirstElement()
+        ->toBeInstanceOf(CallChainEdge::class)
+        ->calleeFqcn->toBe('App\Http\Controllers\V3\AbstractThingController');
 });
 
-it('traces call chains for actions declared only on abstract parents', function () use ($fixtureProject) {
-    $routes = (new RouteAnalyzer)->analyze($fixtureProject);
+it('traces call chains for actions declared only on abstract parents', function () {
+    $routes = (new RouteAnalyzer)->analyze(fixture('laravel-project'));
     $analyzer = new ControllerAnalyzer;
-    $controllers = $analyzer->analyze($fixtureProject, $routes);
-    $edges = (new MethodTracer)->trace($controllers, $analyzer->getPsr4Map(), $fixtureProject);
+    $controllers = $analyzer->analyze(fixture('laravel-project'), $routes);
+    $edges = (new MethodTracer)->trace($controllers, $analyzer->getPsr4Map(), fixture('laravel-project'));
 
     $fromInherited = array_filter(
         $edges,
@@ -158,12 +193,16 @@ it('traces call chains for actions declared only on abstract parents', function 
             && $e->type === 'view'
     );
 
-    expect($fromInherited)->not->toBeEmpty();
+    expect($fromInherited)
+        ->toBeArray()
+        ->andArrayFirstElement()
+        ->toBeInstanceOf(CallChainEdge::class)
+        ->calleeFqcn->toBe('blade::things.v3.index');
 });
 
-it('finds methods on controllers', function () use ($fixtureProject) {
-    $routes = (new RouteAnalyzer)->analyze($fixtureProject);
-    $controllers = (new ControllerAnalyzer)->analyze($fixtureProject, $routes);
+it('finds methods on controllers', function () {
+    $routes = (new RouteAnalyzer)->analyze(fixture('laravel-project'));
+    $controllers = (new ControllerAnalyzer)->analyze(fixture('laravel-project'), $routes);
 
     $orderController = null;
     foreach ($controllers as $c) {
@@ -172,12 +211,14 @@ it('finds methods on controllers', function () use ($fixtureProject) {
             break;
         }
     }
-
-    expect($orderController)->not->toBeNull();
+    expect($orderController)->toBeInstanceOf(ControllerDefinition::class);
 
     $methodNames = array_map(fn ($m) => $m->name, $orderController->methods);
-    expect($methodNames)->toContain('index');
-    expect($methodNames)->toContain('store');
-    expect($methodNames)->toContain('show');
-    expect($methodNames)->toContain('destroy');
+
+    expect($methodNames)->toBe([
+        'index',
+        'store',
+        'show',
+        'destroy',
+    ]);
 });

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,5 +1,0 @@
-<?php
-
-test('example', function () {
-    expect(true)->toBeTrue();
-});

--- a/tests/Unit/FacadeAnalyzerTest.php
+++ b/tests/Unit/FacadeAnalyzerTest.php
@@ -5,38 +5,42 @@ declare(strict_types=1);
 use LaraMint\LaravelBrain\Analysis\ContainerBindingRecord;
 use LaraMint\LaravelBrain\Analysis\ContainerBindingRegistry;
 use LaraMint\LaravelBrain\Analysis\FacadeAnalyzer;
+use LaraMint\LaravelBrain\Analysis\FacadeRecord;
 
-$fixtureProject = __DIR__.'/../fixtures/laravel-project';
-
-it('discovers a facade via multi-level inheritance (class → abstract parent → Facade)', function () use ($fixtureProject) {
-    $registry = (new FacadeAnalyzer)->analyze($fixtureProject);
+it('discovers a facade via multi-level inheritance (class → abstract parent → Facade)', function () {
+    $registry = (new FacadeAnalyzer)->analyze(fixture('laravel-project'));
 
     // ShortUrlV3Facade extends AbstractVersionedShortUrlFacade extends Facade.
     // getFacadeAccessor() is defined on the abstract parent, not on the concrete class.
     $record = $registry->get('App\Services\V3\ShortUrlV3Facade');
-    expect($record)->not->toBeNull();
-    expect($record->accessor)->toBe('App\Services\V3\ShortUrlV3Service');
-    expect($record->concreteFqcn)->toBe('App\Services\V3\ShortUrlV3Service');
+
+    expect($record)
+        ->toBeInstanceOf(FacadeRecord::class)
+        ->accessor->toBe('App\Services\V3\ShortUrlV3Service')
+        ->concreteFqcn->toBe('App\Services\V3\ShortUrlV3Service');
 });
 
-it('does not register abstract intermediate facade classes', function () use ($fixtureProject) {
-    $registry = (new FacadeAnalyzer)->analyze($fixtureProject);
+it('does not register abstract intermediate facade classes', function () {
+    $registry = (new FacadeAnalyzer)->analyze(fixture('laravel-project'));
 
     // AbstractVersionedShortUrlFacade is abstract and must not appear in the registry.
-    expect($registry->get('App\Services\V3\AbstractVersionedShortUrlFacade'))->toBeNull();
+    expect($registry)
+        ->get('App\Services\V3\AbstractVersionedShortUrlFacade')
+        ->toBeNull();
 });
 
-it('discovers a facade that returns a string key accessor', function () use ($fixtureProject) {
-    $registry = (new FacadeAnalyzer)->analyze($fixtureProject);
+it('discovers a facade that returns a string key accessor', function () {
+    $registry = (new FacadeAnalyzer)->analyze(fixture('laravel-project'));
 
     $record = $registry->get('App\Services\V3\ShortUrlV3KeyFacade');
-    expect($record)->not->toBeNull();
-    expect($record->accessor)->toBe('short-url-v3');
-    expect($record->concreteFqcn)->toBeNull();
+
+    expect($record)->toBeInstanceOf(FacadeRecord::class)
+        ->accessor->toBe('short-url-v3')
+        ->concreteFqcn->toBeNull();
 });
 
-it('resolves string-key accessor via container binding registry', function () use ($fixtureProject) {
-    $facadeRegistry = (new FacadeAnalyzer)->analyze($fixtureProject);
+it('resolves string-key accessor via container binding registry', function () {
+    $facadeRegistry = (new FacadeAnalyzer)->analyze(fixture('laravel-project'));
 
     $bindings = new ContainerBindingRegistry;
     $bindings->add(new ContainerBindingRecord(
@@ -57,14 +61,14 @@ it('returns an empty registry for a project without an app/ directory', function
     expect($registry->all())->toBeEmpty();
 });
 
-it('does not register non-facade classes', function () use ($fixtureProject) {
-    $registry = (new FacadeAnalyzer)->analyze($fixtureProject);
+it('does not register non-facade classes', function () {
+    $registry = (new FacadeAnalyzer)->analyze(fixture('laravel-project'));
 
     expect($registry->get('App\Services\V3\ShortUrlV3Service'))->toBeNull();
 });
 
-it('resolveWith does not overwrite an already-resolved concreteFqcn', function () use ($fixtureProject) {
-    $facadeRegistry = (new FacadeAnalyzer)->analyze($fixtureProject);
+it('resolveWith does not overwrite an already-resolved concreteFqcn', function () {
+    $facadeRegistry = (new FacadeAnalyzer)->analyze(fixture('laravel-project'));
 
     $bindings = new ContainerBindingRegistry;
     $bindings->add(new ContainerBindingRecord(

--- a/tests/Unit/FilamentAnalyzerTest.php
+++ b/tests/Unit/FilamentAnalyzerTest.php
@@ -1,106 +1,129 @@
 <?php
 
+use App\Filament\Widgets\PostStatsWidget;
 use LaraMint\LaravelBrain\Analysis\FilamentAnalyzer;
-
-$fixture = __DIR__.'/../fixtures/filament-project';
-$discoverFixture = __DIR__.'/../fixtures/filament-discover-project';
+use LaraMint\LaravelBrain\Analysis\FilamentPageDefinition;
+use LaraMint\LaravelBrain\Analysis\FilamentPanelDefinition;
+use LaraMint\LaravelBrain\Analysis\FilamentRelationManagerDefinition;
+use LaraMint\LaravelBrain\Analysis\FilamentResourceDefinition;
+use LaraMint\LaravelBrain\Analysis\FilamentWidgetDefinition;
 
 it('returns detected=false when Filament is not installed', function () {
     $result = (new FilamentAnalyzer)->analyze(__DIR__.'/../fixtures/laravel-project');
 
-    expect($result['detected'])->toBeFalse();
-    expect($result['panels'])->toBeEmpty();
-    expect($result['resources'])->toBeEmpty();
+    expect($result)
+        ->detected->toBeFalse()
+        ->panels->toBe([])
+        ->resources->toBe([]);
 });
 
-it('detects Filament when vendor directory exists', function () use ($fixture) {
-    $result = (new FilamentAnalyzer)->analyze($fixture);
+it('detects Filament when vendor directory exists', function () {
+    $result = (new FilamentAnalyzer)->analyze(fixture('filament-project'));
 
     expect($result['detected'])->toBeTrue();
 });
 
-it('extracts the admin panel definition', function () use ($fixture) {
-    $result = (new FilamentAnalyzer)->analyze($fixture);
+it('extracts the admin panel definition', function () {
+    $result = (new FilamentAnalyzer)->analyze(fixture('filament-project'));
 
-    expect($result['panels'])->toHaveCount(1);
-
-    $panel = $result['panels'][0];
-    expect($panel->id)->toBe('admin');
-    expect($panel->path)->toBe('/admin');
-    expect($panel->fqcn)->toBe('App\\Providers\\Filament\\AdminPanelProvider');
-    expect($panel->resources)->toContain('App\\Filament\\Resources\\PostResource');
-    expect($panel->pages)->toContain('App\\Filament\\Pages\\Settings');
-    expect($panel->widgets)->toContain('App\\Filament\\Widgets\\PostStatsWidget');
+    expect($result['panels'])
+        ->toHaveCount(1)
+        ->andArrayFirstElement()
+        ->ToBeInstanceOf(FilamentPanelDefinition::class)
+        ->id->toBe('admin')
+        ->path->toBe('/admin')
+        ->fqcn->toBe('App\\Providers\\Filament\\AdminPanelProvider')
+        ->resources->toBe(['App\\Filament\\Resources\\PostResource'])
+        ->pages->toBe(['App\\Filament\\Pages\\Settings'])
+        ->widgets->toBe(['App\\Filament\\Widgets\\PostStatsWidget']);
 });
 
-it('extracts PostResource with correct model FQCN', function () use ($fixture) {
-    $result = (new FilamentAnalyzer)->analyze($fixture);
+it('extracts PostResource with correct model FQCN', function () {
+    $result = (new FilamentAnalyzer)->analyze(fixture('filament-project'));
 
-    expect($result['resources'])->toHaveCount(1);
-
-    $resource = $result['resources'][0];
-    expect($resource->fqcn)->toBe('App\\Filament\\Resources\\PostResource');
-    expect($resource->modelFqcn)->toBe('App\\Models\\Post');
-    expect($resource->panelId)->toBe('admin');
+    expect($result['resources'])
+        ->ToBeArray()
+        ->toHaveCount(1)
+        ->andArrayFirstElement()
+        ->ToBeInstanceOf(FilamentResourceDefinition::class)
+        ->fqcn->toBe('App\\Filament\\Resources\\PostResource')
+        ->modelFqcn->toBe('App\\Models\\Post')
+        ->panelId->toBe('admin');
 });
 
-it('extracts resource pages from getPages()', function () use ($fixture) {
-    $result = (new FilamentAnalyzer)->analyze($fixture);
+it('extracts resource pages from getPages()', function () {
+    $result = (new FilamentAnalyzer)->analyze(fixture('filament-project'));
 
-    $resource = $result['resources'][0];
-    expect($resource->pages)->toHaveKey('index');
-    expect($resource->pages)->toHaveKey('create');
-    expect($resource->pages)->toHaveKey('edit');
-    expect($resource->pages['index'])->toContain('ListPosts');
-    expect($resource->pages['create'])->toContain('CreatePost');
-    expect($resource->pages['edit'])->toContain('EditPost');
+    expect($result['resources'])
+        ->ToBeArray()
+        ->toHaveCount(1)
+        ->andArrayFirstElement()
+        ->ToBeInstanceOf(FilamentResourceDefinition::class)
+        ->pages->toBe([
+            'index' => "App\Filament\Resources\PostResource\Pages\ListPosts",
+            'create' => "App\Filament\Resources\PostResource\Pages\CreatePost",
+            'edit' => "App\Filament\Resources\PostResource\Pages\EditPost",
+        ]);
 });
 
-it('extracts relation managers from getRelations()', function () use ($fixture) {
-    $result = (new FilamentAnalyzer)->analyze($fixture);
+it('extracts relation managers from getRelations()', function () {
+    $result = (new FilamentAnalyzer)->analyze(fixture('filament-project'));
 
-    $resource = $result['resources'][0];
-    expect($resource->relations)->toHaveCount(1);
-    expect($resource->relations[0])->toContain('CommentsRelationManager');
+    expect($result['resources'])
+        ->ToBeArray()
+        ->toHaveCount(1)
+        ->andArrayFirstElement()
+        ->ToBeInstanceOf(FilamentResourceDefinition::class)
+        ->relations->toBe(['App\Filament\Resources\PostResource\RelationManagers\CommentsRelationManager']);
 });
 
-it('extracts relation manager definitions', function () use ($fixture) {
-    $result = (new FilamentAnalyzer)->analyze($fixture);
+it('extracts relation manager definitions', function () {
+    $result = (new FilamentAnalyzer)->analyze(fixture('filament-project'));
 
-    expect($result['relationManagers'])->toHaveCount(1);
-
-    $rm = $result['relationManagers'][0];
-    expect($rm->fqcn)->toContain('CommentsRelationManager');
-    expect($rm->relationship)->toBe('comments');
-    expect($rm->parentResourceFqcn)->toContain('PostResource');
+    expect($result['relationManagers'])
+        ->ToBeArray()
+        ->toHaveCount(1)
+        ->andArrayFirstElement()
+        ->ToBeInstanceOf(FilamentRelationManagerDefinition::class)
+        ->relationship->ToBe('comments')
+        ->fqcn->toBe('App\Filament\Resources\PostResource\RelationManagers\CommentsRelationManager')
+        ->parentResourceFqcn->ToBe('App\Filament\Resources\PostResource');
 });
 
-it('extracts widget definitions', function () use ($fixture) {
-    $result = (new FilamentAnalyzer)->analyze($fixture);
+it('extracts widget definitions', function () {
+    $result = (new FilamentAnalyzer)->analyze(fixture('filament-project'));
 
-    expect($result['widgets'])->toHaveCount(1);
-
-    $widget = $result['widgets'][0];
-    expect($widget->fqcn)->toBe('App\\Filament\\Widgets\\PostStatsWidget');
-    expect($widget->widgetType)->toBe('stats-overview');
+    expect($result['widgets'])
+        ->ToBeArray()
+        ->toHaveCount(1)
+        ->andArrayFirstElement()
+        ->ToBeInstanceOf(FilamentWidgetDefinition::class)
+        ->fqcn->toBe(PostStatsWidget::class)
+        ->widgetType->toBe('stats-overview');
 });
 
-it('extracts custom page definitions', function () use ($fixture) {
-    $result = (new FilamentAnalyzer)->analyze($fixture);
+it('extracts custom page definitions', function () {
+    $result = (new FilamentAnalyzer)->analyze(fixture('filament-project'));
 
     $customPages = array_filter(
         $result['pages'],
         fn ($p) => $p->pageType === 'custom'
     );
+
     expect(count($customPages))->toBeGreaterThanOrEqual(1);
 
     $settings = array_values(array_filter($customPages, fn ($p) => str_contains($p->fqcn, 'Settings')));
-    expect($settings)->toHaveCount(1);
-    expect($settings[0]->fqcn)->toBe('App\\Filament\\Pages\\Settings');
+
+    expect($settings)
+        ->ToBeArray()
+        ->toHaveCount(1)
+        ->andArrayFirstElement()
+        ->ToBeInstanceOf(FilamentPageDefinition::class)
+        ->fqcn->toBe('App\\Filament\\Pages\\Settings');
 });
 
-it('classifies resource pages by type', function () use ($fixture) {
-    $result = (new FilamentAnalyzer)->analyze($fixture);
+it('classifies resource pages by type', function () {
+    $result = (new FilamentAnalyzer)->analyze(fixture('filament-project'));
 
     $resourcePages = array_filter(
         $result['pages'],
@@ -108,40 +131,56 @@ it('classifies resource pages by type', function () use ($fixture) {
     );
 
     $types = array_column(array_values($resourcePages), 'pageType');
-    expect($types)->toContain('index');
-    expect($types)->toContain('create');
-    expect($types)->toContain('edit');
+    expect($types)->toHaveCount(3)->toContain('create', 'edit', 'index');
 });
 
 // ── discoverResources / discoverPages tests ───────────────────────────────────
 
-it('detects discoverResources namespace from panel provider', function () use ($discoverFixture) {
-    $result = (new FilamentAnalyzer)->analyze($discoverFixture);
+it('detects discoverResources namespace from panel provider', function () {
+    $result = (new FilamentAnalyzer)->analyze(fixture('filament-discover-project'));
 
-    expect($result['detected'])->toBeTrue();
+    expect($result)
+        ->ToBeArray()
+        ->detected->toBetrue();
 
-    $panel = $result['panels'][0];
-    expect($panel->discoverResourcesFor)->toContain('App\\Filament\\Resources');
-    expect($panel->discoverPagesFor)->toContain('App\\Filament\\Pages');
+    expect($result['panels'])
+        ->toBeArray()
+        ->andArrayFirstElement()
+        ->ToBeInstanceOf(FilamentPanelDefinition::class)
+        ->id->toBe('admin')
+        ->discoverResourcesFor->toBe(['App\\Filament\\Resources'])
+        ->discoverPagesFor->toBe(['App\\Filament\\Pages']);
 });
 
-it('links discovered resources to the panel via namespace matching', function () use ($discoverFixture) {
-    $result = (new FilamentAnalyzer)->analyze($discoverFixture);
+it('links discovered resources to the panel via namespace matching', function () {
+    $result = (new FilamentAnalyzer)->analyze(fixture('filament-discover-project'));
 
-    $panel = $result['panels'][0];
-    expect($panel->resources)->toContain('App\\Filament\\Resources\\PostResource');
+    expect($result['panels'])
+        ->toBeArray()
+        ->andArrayFirstElement()
+        ->ToBeInstanceOf(FilamentPanelDefinition::class)
+        ->resources->toBe(['App\\Filament\\Resources\\PostResource']);
 });
 
-it('links discovered custom pages to the panel via namespace matching', function () use ($discoverFixture) {
-    $result = (new FilamentAnalyzer)->analyze($discoverFixture);
+it('links discovered custom pages to the panel via namespace matching', function () {
+    $result = (new FilamentAnalyzer)->analyze(fixture('filament-discover-project'));
 
-    $panel = $result['panels'][0];
-    expect($panel->pages)->toContain('App\\Filament\\Pages\\Settings');
+    expect($result['panels'])
+        ->ToBeArray()
+        ->andArrayFirstElement()
+        ->ToBeInstanceOf(FilamentPanelDefinition::class)
+        ->pages->toBe([
+            'Pages\\Dashboard',
+            'App\\Filament\\Pages\\Settings',
+        ]);
 });
 
-it('attaches the panel ID to discovered resources', function () use ($discoverFixture) {
-    $result = (new FilamentAnalyzer)->analyze($discoverFixture);
+it('attaches the panel ID to discovered resources', function () {
+    $result = (new FilamentAnalyzer)->analyze(fixture('filament-discover-project'));
 
-    $resource = $result['resources'][0];
-    expect($resource->panelId)->toBe('admin');
+    expect($result['resources'])
+        ->ToBeArray()
+        ->andArrayFirstElement()
+        ->ToBeInstanceOf(FilamentResourceDefinition::class)
+        ->panelId->toBe('admin');
 });

--- a/tests/Unit/GraphBuilderTest.php
+++ b/tests/Unit/GraphBuilderTest.php
@@ -6,17 +6,17 @@ use LaraMint\LaravelBrain\Analysis\MethodTracer;
 use LaraMint\LaravelBrain\Analysis\MiddlewareRegistry;
 use LaraMint\LaravelBrain\Analysis\ModelAnalyzer;
 use LaraMint\LaravelBrain\Analysis\RouteAnalyzer;
+use LaraMint\LaravelBrain\Graph\Edge;
 use LaraMint\LaravelBrain\Graph\GraphBuilder;
+use LaraMint\LaravelBrain\Graph\Node;
 
-$fixtureProject = __DIR__.'/../fixtures/laravel-project';
-
-it('builds a graph with nodes and edges from fixture project', function () use ($fixtureProject) {
-    $routes = (new RouteAnalyzer)->analyze($fixtureProject);
+it('builds a graph with nodes and edges from fixture project', function () {
+    $routes = (new RouteAnalyzer)->analyze(fixture('laravel-project'));
     $middlewareRegistry = new MiddlewareRegistry([], [], []);
-    $controllers = (new ControllerAnalyzer)->analyze($fixtureProject, $routes);
+    $controllers = (new ControllerAnalyzer)->analyze(fixture('laravel-project'), $routes);
     $traces = (new MethodTracer)->trace($controllers);
     $modelFqcns = array_map(fn ($t) => $t->calleeFqcn, array_filter($traces, fn ($t) => $t->type === 'model'));
-    $models = (new ModelAnalyzer)->analyze($fixtureProject, $modelFqcns);
+    $models = (new ModelAnalyzer)->analyze(fixture('laravel-project'), $modelFqcns);
 
     $graph = (new GraphBuilder)->build('test', $routes, $middlewareRegistry, $controllers, $traces, $models);
 
@@ -24,102 +24,129 @@ it('builds a graph with nodes and edges from fixture project', function () use (
     expect($graph->edgeCount())->toBeGreaterThan(0);
 });
 
-it('produces valid JSON output', function () use ($fixtureProject) {
-    $routes = (new RouteAnalyzer)->analyze($fixtureProject);
+it('produces valid JSON output', function () {
+    $routes = (new RouteAnalyzer)->analyze(fixture('laravel-project'));
     $middlewareRegistry = new MiddlewareRegistry([], [], []);
-    $controllers = (new ControllerAnalyzer)->analyze($fixtureProject, $routes);
+    $controllers = (new ControllerAnalyzer)->analyze(fixture('laravel-project'), $routes);
     $traces = (new MethodTracer)->trace($controllers);
 
     $modelFqcns = array_map(fn ($t) => $t->calleeFqcn, array_filter($traces, fn ($t) => $t->type === 'model'));
-    $models = (new ModelAnalyzer)->analyze($fixtureProject, $modelFqcns);
+    $models = (new ModelAnalyzer)->analyze(fixture('laravel-project'), $modelFqcns);
 
     $graph = (new GraphBuilder)->build('test', $routes, $middlewareRegistry, $controllers, $traces, $models);
-    $json = $graph->toJson();
-    $decoded = json_decode($json, true);
 
-    expect($decoded)->toHaveKey('meta');
-    expect($decoded)->toHaveKey('nodes');
-    expect($decoded)->toHaveKey('edges');
-    expect($decoded['meta'])->toHaveKey('project');
-    expect($decoded['nodes'])->toBeArray();
-    expect($decoded['edges'])->toBeArray();
+    expect($graph->toJson())
+        ->json()
+        ->toHaveKeys(['meta', 'nodes', 'edges'])
+        ->meta->toBeArray()->toHaveKey('project')
+        ->nodes->toBeNonEmptyArray()
+        ->edges->toBeNonEmptyArray();
 });
 
-it('creates route nodes for each route', function () use ($fixtureProject) {
-    $routes = (new RouteAnalyzer)->analyze($fixtureProject);
+it('creates route nodes for each route', function () {
+    $routes = (new RouteAnalyzer)->analyze(fixture('laravel-project'));
     $middlewareRegistry = new MiddlewareRegistry([], [], []);
-    $controllers = (new ControllerAnalyzer)->analyze($fixtureProject, $routes);
+    $controllers = (new ControllerAnalyzer)->analyze(fixture('laravel-project'), $routes);
     $traces = (new MethodTracer)->trace($controllers);
     $models = [];
 
     $graph = (new GraphBuilder)->build('test', $routes, $middlewareRegistry, $controllers, $traces, $models);
 
     $routeNodes = array_filter($graph->nodes(), fn ($n) => $n->type === 'route');
-    expect(count($routeNodes))->toBe(count($routes));
+
+    expect($routeNodes)->toHavecount(count($routes));
 });
 
-it('exposes parent controller nodes and extends edges for inherited actions', function () use ($fixtureProject) {
-    $routes = (new RouteAnalyzer)->analyze($fixtureProject);
+it('exposes parent controller nodes and extends edges for inherited actions', function () {
+    $routes = (new RouteAnalyzer)->analyze(fixture('laravel-project'));
     $middlewareRegistry = new MiddlewareRegistry([], [], []);
-    $controllers = (new ControllerAnalyzer)->analyze($fixtureProject, $routes);
+    $controllers = (new ControllerAnalyzer)->analyze(fixture('laravel-project'), $routes);
     $traces = (new MethodTracer)->trace($controllers);
     $models = [];
 
-    $graph = (new GraphBuilder)->build('test', $routes, $middlewareRegistry, $controllers, $traces, $models, $fixtureProject);
+    $graph = (new GraphBuilder)->build('test', $routes, $middlewareRegistry, $controllers, $traces, $models, fixture('laravel-project'));
 
     $extends = array_values(array_filter($graph->edges(), fn ($e) => $e->type === 'controller-extends'));
-    expect($extends)->not->toBeEmpty();
+
+    expect($extends)
+        ->toBeArray()
+        ->toHaveCount(1)
+        ->andArrayFirstElement()
+        ->toBeInstanceOf(Edge::class);
 
     $ids = array_map(fn ($n) => $n->id, $graph->nodes());
-    expect($ids)->toContain('controller::App\\Http\\Controllers\\V3\\AbstractThingController');
+
+    expect($ids)
+        ->toBeArray()
+        ->toHaveCount(52)
+        ->toContain('controller::App\\Http\\Controllers\\V3\\AbstractThingController');
 
     $handlesFromParent = array_filter(
         $graph->edges(),
         fn ($e) => $e->type === 'controller-to-action'
             && $e->source === 'controller::App\\Http\\Controllers\\V3\\AbstractThingController'
     );
-    expect($handlesFromParent)->not->toBeEmpty();
+
+    expect($handlesFromParent)
+        ->toBeArray()
+        ->andArrayFirstElement()
+        ->toBeInstanceOf(Edge::class);
 });
 
-it('wires form request validated nodes and exposes validationRules on graph nodes', function () use ($fixtureProject) {
-    $routes = (new RouteAnalyzer)->analyze($fixtureProject);
+it('wires form request validated nodes and exposes validationRules on graph nodes', function () {
+    $routes = (new RouteAnalyzer)->analyze(fixture('laravel-project'));
     $middlewareRegistry = new MiddlewareRegistry([], [], []);
     $analyzer = new ControllerAnalyzer;
-    $controllers = $analyzer->analyze($fixtureProject, $routes);
-    $traces = (new MethodTracer)->trace($controllers, $analyzer->getPsr4Map(), $fixtureProject);
+    $controllers = $analyzer->analyze(fixture('laravel-project'), $routes);
+    $traces = (new MethodTracer)->trace($controllers, $analyzer->getPsr4Map(), fixture('laravel-project'));
     $models = [];
 
-    $graph = (new GraphBuilder)->build('test', $routes, $middlewareRegistry, $controllers, $traces, $models, $fixtureProject);
+    $graph = (new GraphBuilder)->build('test', $routes, $middlewareRegistry, $controllers, $traces, $models, fixture('laravel-project'));
 
     $frEdges = array_values(array_filter($graph->edges(), fn ($e) => $e->type === 'action-to-form-request'));
-    expect($frEdges)->not->toBeEmpty();
+
+    expect($frEdges)
+        ->toBeArray()
+        ->andArrayFirstElement()
+        ->toBeInstanceOf(Edge::class);
 
     $formRequestNodes = array_values(array_filter(
         $graph->nodes(),
         fn ($n) => ($n->data['fqcn'] ?? '') === 'App\\Http\\Requests\\ProfileStoreRequest'
             && ($n->data['method'] ?? '') === 'validated'
     ));
-    expect($formRequestNodes)->not->toBeEmpty();
-    expect($formRequestNodes[0]->type)->toBe('validation_request');
-    expect($formRequestNodes[0]->data['validationRules'] ?? [])->toBeArray()->not->toBeEmpty();
+
+    expect($formRequestNodes)
+        ->toBeArray()
+        ->andArrayFirstElement()
+        ->toBeInstanceOf(Node::class)
+        ->data->validationRules->toBeNonEmptyArray()
+        ->type->toBe('validation_request');
 });
 
-it('adds IoC binding edges from service providers to interfaces and implementations', function () use ($fixtureProject) {
-    $routes = (new RouteAnalyzer)->analyze($fixtureProject);
+it('adds IoC binding edges from service providers to interfaces and implementations', function () {
+    $routes = (new RouteAnalyzer)->analyze(fixture('laravel-project'));
     $middlewareRegistry = new MiddlewareRegistry([], [], []);
     $analyzer = new ControllerAnalyzer;
-    $controllers = $analyzer->analyze($fixtureProject, $routes);
-    $traces = (new MethodTracer)->trace($controllers, $analyzer->getPsr4Map(), $fixtureProject);
+    $controllers = $analyzer->analyze(fixture('laravel-project'), $routes);
+    $traces = (new MethodTracer)->trace($controllers, $analyzer->getPsr4Map(), fixture('laravel-project'));
     $models = [];
-    $bindings = (new ContainerBindingAnalyzer)->analyze($fixtureProject);
+    $bindings = (new ContainerBindingAnalyzer)->analyze(fixture('laravel-project'));
 
-    $graph = (new GraphBuilder)->build('test', $routes, $middlewareRegistry, $controllers, $traces, $models, $fixtureProject, [], $bindings);
+    $graph = (new GraphBuilder)->build('test', $routes, $middlewareRegistry, $controllers, $traces, $models, fixture('laravel-project'), [], $bindings);
 
     $types = array_map(fn ($e) => $e->type, $graph->edges());
-    expect($types)->toContain('binding-resolution');
-    expect($types)->toContain('binding-registered-in');
+
+    expect($types)
+        ->toBeArray()
+        ->toHaveCount(63)
+        ->toContain('binding-resolution', 'binding-registered-in');
 
     $resolution = array_values(array_filter($graph->edges(), fn ($e) => $e->type === 'binding-resolution'));
-    expect($resolution)->not->toBeEmpty();
-    expect($resolution[0]->label)->toContain('SqlThingRepository');
+
+    expect($resolution)
+        ->toBeArray()
+        ->andArrayFirstElement()
+        ->toBeInstanceOf(Edge::class)
+        ->label->toContain('SqlThingRepository');
 });

--- a/tests/Unit/ModelAnalyzerTest.php
+++ b/tests/Unit/ModelAnalyzerTest.php
@@ -2,21 +2,24 @@
 
 use LaraMint\LaravelBrain\Analysis\ModelAnalyzer;
 
-$fixtureProject = __DIR__.'/../fixtures/laravel-project';
-
-it('detects dispatchesEvents on Order model', function () use ($fixtureProject) {
+it('detects dispatchesEvents on Order model', function () {
     $analyzer = new ModelAnalyzer;
-    $models = $analyzer->analyze($fixtureProject, ['App\\Models\\Order']);
+    $models = $analyzer->analyze(fixture('laravel-project'), ['App\\Models\\Order']);
 
-    expect($models)->toHaveKey('App\\Models\\Order');
-    $order = $models['App\\Models\\Order'];
-    expect($order->firedEvents)->not->toBeEmpty();
-    expect($order->firedEvents[0])->toContain('OrderPlaced');
+    expect($models)
+        ->toBeArray()
+        ->toHaveCount(1)
+        ->toHaveKey('App\\Models\\Order');
+
+    $order = array_first($models);
+
+    expect($order)
+        ->firedEvents->toBe(["App\Events\OrderPlaced"]);
 });
 
-it('detects relationships on User model', function () use ($fixtureProject) {
+it('detects relationships on User model', function () {
     $analyzer = new ModelAnalyzer;
-    $models = $analyzer->analyze($fixtureProject, ['App\\Models\\User']);
+    $models = $analyzer->analyze(fixture('laravel-project'), ['App\\Models\\User']);
 
     expect($models)->toHaveKey('App\\Models\\User');
     $user = $models['App\\Models\\User'];
@@ -25,11 +28,12 @@ it('detects relationships on User model', function () use ($fixtureProject) {
     expect($types)->toContain('hasMany');
 });
 
-it('detects belongsTo relationship on Order model', function () use ($fixtureProject) {
+it('detects belongsTo relationship on Order model', function () {
     $analyzer = new ModelAnalyzer;
-    $models = $analyzer->analyze($fixtureProject, ['App\\Models\\Order']);
+    $models = $analyzer->analyze(fixture('laravel-project'), ['App\\Models\\Order']);
 
     $order = $models['App\\Models\\Order'];
     $types = array_column($order->relationships, 'type');
-    expect($types)->toContain('belongsTo');
+
+    expect($types)->ToBeArray()->toContain('belongsTo');
 });

--- a/tests/Unit/ResolveBladePathTest.php
+++ b/tests/Unit/ResolveBladePathTest.php
@@ -33,11 +33,18 @@ it('resolves module-style namespaced views under Modules/{studly}/resources/view
     try {
         $builder = new GraphBuilder;
         $rootProp = new ReflectionProperty(GraphBuilder::class, 'projectRoot');
-        $rootProp->setAccessible(true);
+
+        if (\PHP_VERSION_ID < 80100) {
+            $rootProp->setAccessible(true);
+        }
+
         $rootProp->setValue($builder, $tmp);
 
         $method = new ReflectionMethod(GraphBuilder::class, 'resolveBladePath');
-        $method->setAccessible(true);
+
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         expect($method->invoke($builder, 'blog::posts.index'))->toBe($expected);
     } finally {
@@ -54,11 +61,18 @@ it('resolves namespaced views under resources/views/vendor/{hint}', function () 
     try {
         $builder = new GraphBuilder;
         $rootProp = new ReflectionProperty(GraphBuilder::class, 'projectRoot');
-        $rootProp->setAccessible(true);
+
+        if (\PHP_VERSION_ID < 80100) {
+            $rootProp->setAccessible(true);
+        }
+
         $rootProp->setValue($builder, $tmp);
 
         $method = new ReflectionMethod(GraphBuilder::class, 'resolveBladePath');
-        $method->setAccessible(true);
+
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         expect($method->invoke($builder, 'acme::widget'))->toBe($expected);
     } finally {
@@ -75,11 +89,17 @@ it('falls back to scanning Modules/*/resources/views when studly folder name dif
     try {
         $builder = new GraphBuilder;
         $rootProp = new ReflectionProperty(GraphBuilder::class, 'projectRoot');
-        $rootProp->setAccessible(true);
+
+        if (\PHP_VERSION_ID < 80100) {
+            $rootProp->setAccessible(true);
+        }
+
         $rootProp->setValue($builder, $tmp);
 
         $method = new ReflectionMethod(GraphBuilder::class, 'resolveBladePath');
-        $method->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         expect($method->invoke($builder, 'blog::home'))->toBe($expected);
     } finally {

--- a/tests/Unit/RouteAnalyzerTest.php
+++ b/tests/Unit/RouteAnalyzerTest.php
@@ -1,83 +1,57 @@
 <?php
 
 use LaraMint\LaravelBrain\Analysis\RouteAnalyzer;
+use LaraMint\LaravelBrain\Analysis\RouteDefinition;
 
-$fixtureProject = __DIR__.'/../fixtures/laravel-project';
+it('extracts basic routes from api.php', function () {
+    $routes = (new RouteAnalyzer)->analyze(fixture('laravel-project'));
 
-function findRoute(array $routes, callable $predicate): mixed
-{
-    foreach ($routes as $r) {
-        if ($predicate($r)) {
-            return $r;
-        }
-    }
-
-    return null;
-}
-
-function routeAnalyzerTestDeleteTree(string $dir): void
-{
-    if (! is_dir($dir)) {
-        return;
-    }
-    $it = new RecursiveIteratorIterator(
-        new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
-        RecursiveIteratorIterator::CHILD_FIRST
-    );
-    foreach ($it as $fileinfo) {
-        $path = $fileinfo->getPathname();
-        if ($fileinfo->isDir()) {
-            @rmdir($path);
-        } else {
-            @unlink($path);
-        }
-    }
-    @rmdir($dir);
-}
-
-it('extracts basic routes from api.php', function () use ($fixtureProject) {
-    $routes = (new RouteAnalyzer)->analyze($fixtureProject);
-    expect($routes)->not->toBeEmpty();
+    expect($routes)
+        ->toBeArray()
+        ->each->toBeInstanceOf(RouteDefinition::class);
 });
 
-it('finds the POST /login route', function () use ($fixtureProject) {
-    $routes = (new RouteAnalyzer)->analyze($fixtureProject);
+it('finds the POST /login route', function () {
+    $routes = (new RouteAnalyzer)->analyze(fixture('laravel-project'));
     $login = findRoute($routes, fn ($r) => str_contains($r->uri, 'login'));
 
-    expect($login)->not->toBeNull();
-    expect($login->method)->toBe('POST');
-    expect($login->controller)->toContain('AuthController');
-    expect($login->action)->toBe('login');
+    expect($login)->toBeInstanceOf(RouteDefinition::class)
+        ->method->toBe('POST')
+        ->controller->toBe('App\Http\Controllers\AuthController')
+        ->action->toBe('login');
 });
 
-it('extracts middleware from groups', function () use ($fixtureProject) {
-    $routes = (new RouteAnalyzer)->analyze($fixtureProject);
+it('extracts middleware from groups', function () {
+    $routes = (new RouteAnalyzer)->analyze(fixture('laravel-project'));
     $ordersRoute = findRoute($routes, fn ($r) => $r->uri === '/orders' && $r->method === 'GET');
 
-    expect($ordersRoute)->not->toBeNull();
-    expect($ordersRoute->middlewares)->toContain('auth:sanctum');
+    expect($ordersRoute)->toBeInstanceOf(RouteDefinition::class)
+        ->middlewares->toBeArray()->toContain('auth:sanctum');
 });
 
-it('applies prefix from nested group', function () use ($fixtureProject) {
-    $routes = (new RouteAnalyzer)->analyze($fixtureProject);
+it('applies prefix from nested group', function () {
+    $routes = (new RouteAnalyzer)->analyze(fixture('laravel-project'));
     $adminRoute = findRoute($routes, fn ($r) => str_contains($r->uri, 'admin'));
 
-    expect($adminRoute)->not->toBeNull();
-    expect($adminRoute->uri)->toContain('/admin/');
-    expect($adminRoute->middlewares)->toContain('role:admin');
+    expect($adminRoute)->toBeInstanceOf(RouteDefinition::class)
+        ->uri->toBe('/admin/orders/{id}')
+        ->middlewares->toBeArray()->toContain('role:admin');
 });
 
-it('finds 13 routes total', function () use ($fixtureProject) {
-    $routes = (new RouteAnalyzer)->analyze($fixtureProject);
-    expect(count($routes))->toBe(13);
+it('finds 13 routes total', function () {
+    $routes = (new RouteAnalyzer)->analyze(fixture('laravel-project'));
+
+    expect($routes)
+        ->toBeArray()
+        ->toHaveCount(13);
 });
 
-it('captures middleware chained after the HTTP method call', function () use ($fixtureProject) {
-    $routes = (new RouteAnalyzer)->analyze($fixtureProject);
+it('captures middleware chained after the HTTP method call', function () {
+    $routes = (new RouteAnalyzer)->analyze(fixture('laravel-project'));
     $brandsRoute = findRoute($routes, fn ($r) => $r->uri === '/brands' && $r->method === 'GET');
 
-    expect($brandsRoute)->not->toBeNull();
-    expect($brandsRoute->middlewares)->toContain('ability:view-maintenance-requests,monitor-maintenance,create-transfer');
+    expect($brandsRoute)->toBeInstanceOf(RouteDefinition::class)
+        ->middlewares->toBeArray()->toContain('ability:view-maintenance-requests,monitor-maintenance,create-transfer');
 });
 
 it('expands Route::resource with distinct URIs and tab groups per action', function () {
@@ -132,6 +106,7 @@ it('expands Route::apiResource without create or edit routes', function () {
 <?php
 
 use Illuminate\Support\Facades\Route;
+use LaraMint\LaravelBrain\Analysis\RouteDefinition;
 
 Route::apiResource('posts', \App\Http\Controllers\PostController::class);
 
@@ -151,38 +126,35 @@ PHP
     }
 });
 
-it('parses Route::livewire() as a GET route with component as controller', function () {
-    $tmp = sys_get_temp_dir().'/lb-route-analyzer-'.uniqid('', true);
-    mkdir($tmp.'/routes/web', 0777, true);
-    file_put_contents(
-        $tmp.'/routes/web/livewire.php',
-        <<<'PHP'
-<?php
+// Helper Functions
 
-use Illuminate\Support\Facades\Route;
-use App\Http\Livewire\Dashboard;
-
-Route::livewire('/dashboard', Dashboard::class)->name('dashboard');
-Route::livewire('/profile', 'App\Http\Livewire\Profile');
-PHP
-    );
-
-    try {
-        $routes = (new RouteAnalyzer(['routes/*/*.php']))->analyze($tmp);
-
-        expect($routes)->toHaveCount(2);
-
-        $dashboard = findRoute($routes, fn ($r) => $r->uri === '/dashboard');
-        expect($dashboard)->not->toBeNull();
-        expect($dashboard->method)->toBe('GET');
-        expect($dashboard->controller)->toContain('Dashboard');
-        expect($dashboard->action)->toBe('render');
-
-        $profile = findRoute($routes, fn ($r) => $r->uri === '/profile');
-        expect($profile)->not->toBeNull();
-        expect($profile->method)->toBe('GET');
-        expect($profile->controller)->toBe('App\Http\Livewire\Profile');
-    } finally {
-        routeAnalyzerTestDeleteTree($tmp);
+function findRoute(array $routes, callable $predicate): mixed
+{
+    foreach ($routes as $r) {
+        if ($predicate($r)) {
+            return $r;
+        }
     }
-});
+
+    return null;
+}
+
+function routeAnalyzerTestDeleteTree(string $dir): void
+{
+    if (! is_dir($dir)) {
+        return;
+    }
+    $it = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+    foreach ($it as $fileinfo) {
+        $path = $fileinfo->getPathname();
+        if ($fileinfo->isDir()) {
+            @rmdir($path);
+        } else {
+            @unlink($path);
+        }
+    }
+    @rmdir($dir);
+}

--- a/tests/Unit/ValidationRulesExtractorTest.php
+++ b/tests/Unit/ValidationRulesExtractorTest.php
@@ -2,23 +2,23 @@
 
 use LaraMint\LaravelBrain\Analysis\ValidationRulesExtractor;
 
-$fixtureRequest = __DIR__.'/../fixtures/laravel-project/app/Http/Requests/ProfileStoreRequest.php';
-
-it('detects a concrete rules() method', function () use ($fixtureRequest) {
+it('detects a concrete rules() method', function () {
     $extractor = new ValidationRulesExtractor;
-    expect($extractor->hasNonAbstractRulesMethod($fixtureRequest))->toBeTrue();
+    expect($extractor->hasNonAbstractRulesMethod(fixture('/laravel-project/app/Http/Requests/ProfileStoreRequest.php')))->toBeTrue();
 });
 
-it('extracts validation rows from rules() return arrays', function () use ($fixtureRequest) {
+it('extracts validation rows from rules() return arrays', function () {
     $extractor = new ValidationRulesExtractor;
-    $rows = $extractor->extractFromFile($fixtureRequest);
+    $rows = $extractor->extractFromFile(fixture('/laravel-project/app/Http/Requests/ProfileStoreRequest.php'));
 
-    expect($rows)->not->toBeEmpty();
+    expect($rows)->toBeNonEmptyArray();
 
-    $fields = implode(' ', array_column($rows, 'field'));
-    expect($fields)->toContain('name');
-    expect($fields)->toContain('email');
+    $fields = array_column($rows, 'field');
+    expect($fields)->toBe(["'name'", "'email'"]);
 
-    $rulesText = implode(' ', array_column($rows, 'rules'));
-    expect($rulesText)->toContain('required');
+    $rulesText = array_column($rows, 'rules');
+    expect($rulesText)->toBe([
+        "'required', 'string', 'max:255'",
+        "'required|email'",
+    ]);
 });


### PR DESCRIPTION
Hello @mrmarchone,

Thanks for sharing such an interesting package!  Your interaction with the community really motivated me to contribute 🙂.

This PR includes some enhancements to the test suite, aiming at keeping it maintainable and welcoming to newer contributors. 

There are no major changes such as feature additions, relevant fixes, or changes to the codebase, so I did not open an issue as recommended.

Below I will summarize the most important changes.

# Important changes

## Composer Scripts
I've included composer scripts to standardize the way tests are run. 

- `composer:lint` runs Laravel Pint in parallel mode to lint the code.
- `composer test:lint` tests lint with Pint in parallel mode. 
- `composer test:types` runs PHPStan.
- `composer test:unit`: runs Pest, ordering the tests by *[random order](https://docs.phpunit.de/en/12.5/textui.html#test-execution-order)*. This allows identifying and fixing interdependent tests.

I have pointed the `composer test` command to run lint + types + unit tests.

## CI Changes

I have changed the CI to one PHP job that runs the 3 tests mentioned above, instead of setting 3 jobs, one for each test.

In addition, I have modified the GitHub Actions to call the composer script to keep standards. 

Perhaps the CI workflows should be run also on the v2.x branch? [*unchanged*]

```yaml
on:
  push:
    branches: [ "main",  "master", "v2.x"]

  pull_request:
    branches: [ "main", "master", "v2.x"]
```
## Architecture Testing
The test suite now counts with a simple [Arc Test](https://pestphp.com/docs/arch-testing) with the [`php`](https://pestphp.com/docs/arch-testing#preset-php) and [`security`](https://pestphp.com/docs/arch-testing#content-security) presets.

## Pest Helpers
I have added a [custom helper](https://pestphp.com/docs/custom-helpers) `fixture()` to remove code duplication across the test suite and eliminate the need to call `use ($var)` to access a variable outside the function scope.

```php
// 🅱🅴🅵🅾🆁🅴

$fixtureProject = __DIR__.'/../fixtures/laravel-project';

it('foobar', function () use ($fixtureProject) {
    $foo = (new FooBarAnalyzer)->analyze($fixtureProject);
   //...
});

// 🅰🅵🆃🅴🆁

it('foobar', function () {
    $foo = (new FooBarAnalyzer)->analyze(fixture('laravel-project'));
   //...
 });
```

## Custom Expectations
I've included two [`Custom Expectations`](https://pestphp.com/docs/custom-expectations) in the test suite:

- `toBeNonEmptyArray()`: Assert the value is an array with items (a short for `->toBeArray()->not->toBeEmpty()`);
- `andArrayFirstElement()`: Returns the first value of the expectation `(array) $value`. It is mainly for test readability.

Example:

```php

// 🅱🅴🅵🅾🆁🅴

    $resource = $result['resources'][0];
    expect($resource->fqcn)->toBe('App\\Filament\\Resources\\PostResource');
    expect($resource->modelFqcn)->toBe('App\\Models\\Post');
    expect($resource->panelId)->toBe('admin');

// 🅰🅵🆃🅴🆁

    expect($result['resources'])
        ->ToBeArray()
        ->toHaveCount(1)
        ->andArrayFirstElement()
        ->toBe([ //... ]);
```

_NOTE: I've opted to keep the redundant `ToBeArray()` just for code clarity._

## Refactoring Tests

### Higher Order Expectations

I have employed [`Higher Order Expectations`](https://pestphp.com/docs/higher-order-testing#content-higher-order-expectations) to make the code more compact, thus improving readability. 

```php
// 🅱🅴🅵🅾🆁🅴

expect($record)->not->toBeNull();
expect($record->accessor)->toBe('App\Services\V3\ShortUrlV3Service');
expect($record->concreteFqcn)->toBe('App\Services\V3\ShortUrlV3Service');

// 🅰🅵🆃🅴🆁

expect($record)
        ->toBeInstanceOf(FacadeRecord::class)
        ->accessor->toBe('App\Services\V3\ShortUrlV3Service')
        ->concreteFqcn->toBe('App\Services\V3\ShortUrlV3Service');
```

### Specific vs. Generic Assertions

The expectation [`toContain()`](https://pestphp.com/docs/expectations#expect-toContain) will find elements in strings and arrays. This could lead to a false positive as demonstrated below. 

```php
    $array =  ['auth:sanctum', 'auth:foo'];
    $string =  'I use auth:sanctum in this project';

    expect($array)->toContain('auth:sanctum'); //✅ Pass
    expect($string)->toContain('auth:sanctum'); //✅ Pass

    expect($string)->toBeArray()->toContain('auth:sanctum'); //❌ Fail
```

Therefore, I suggest also checking the $value type, ensuring that the return is what is expected.


A similar situation may happen with the expectation [`toBeEmpty()`](https://pestphp.com/docs/expectations#expect-toBeEmpty).

```php
    expect('')->toBeEmpty(); //✅ Pass with string
    expect([])->toBeEmpty(); //✅ Pass with array

    expect('')->ToBeArray()->toBeEmpty(); //❌ Fail
```

In some cases, I've adopted `toBe()` instead of `toContain()` to assert the value integrity.

```php
// 🅱🅴🅵🅾🆁🅴

$fields = ['name', 'email', 'unexpected value'];

expect($fields)->toContain('name'); //✅ Pass
expect($fields)->toContain('email'); //✅ Pass


// 🅰🅵🆃🅴🆁

expect($fields)->toBe(["name", "email"]); //❌ Fail
```

In the same way, I suggest using [`toBeInstanceOf()`](https://pestphp.com/docs/expectations#expect-toBeInstanceOf) to ensure the returned value is indeed the expected class.

```php
$record['accessor'] = 'App\Services\V3\ShortUrlV3Service';

expect($record['accessor'])->toBe('App\Services\V3\ShortUrlV3Service'); //✅ Pass

expect($record['accessor'])
->toBeInstanceOf(FacadeRecord::class)
->toBe('App\Services\V3\ShortUrlV3Service'); //❌ Fail
```

### Redundant Checks

I've removed some redundant checks. In the example below, `$record` can't be `null` and have the property `accessor` at the same time.

```php
// 🅱🅴🅵🅾🆁🅴

expect($record)->not->toBeNull();
expect($record->accessor)->toBe('short-url-v3');

// 🅰🅵🆃🅴🆁

 expect($record)->toBeInstanceOf(FacadeRecord::class)
        ->accessor->toBe('short-url-v3')
        ->concreteFqcn->toBeNull();
```

### Deprecated Methods

The method [`ReflectionMethod::setAccessible`](https://www.php.net/manual/en/reflectionmethod.setaccessible.php) has been deprecated as of PHP 8.5, so I wrapped it in a version condition to avoid future problems.

```php
if (\PHP_VERSION_ID < 80100) {
    $foo->setAccessible(true);
}
```

<img width="2030" height="260" alt="CleanShot 2026-05-10 at 10 20 51@2x" src="https://github.com/user-attachments/assets/89c657bb-1ce4-4c9c-adf1-69d5613c2739" />

---

Thanks and greetings,

Dan