### PR TITLE
Add Laravel Boost skill

### DIFF
--- a/resources/boost/skills/laravel-brain/SKILL.md
+++ b/resources/boost/skills/laravel-brain/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: laravel-brain
+description: "Analyze a Laravel application for complexity hotspots, security surface, and database access patterns using laravel-brain. Activate when: the user asks what needs work, what should be improved, what to work on next, where to focus, what is the most complex code, what are the security issues, audit the codebase, analyze code quality, find technical debt, find refactoring targets, what are the worst parts of the codebase, or when user mentions: brain, hotspots, cyclomatic, complexity audit, security audit, codebase health, codebase review."
+---
+
+# Laravel Brain Analysis
+
+`laravel-brain` scans the application graph and surfaces cyclomatic complexity hotspots, security surface area, and database access patterns across every controller, command, and Livewire component. Use it to answer "what needs work" before writing code, not after.
+
+EXECUTE steps 0–5 IMMEDIATELY without asking the user. Scans are read-only and safe. Only pause at step 6 to present findings.
+
+---
+
+## 0. Pre-flight
+
+Ensure the package is installed before scanning:
+
+```bash
+php artisan brain:scan --help > /dev/null 2>&1 \
+  || composer require laramint/laravel-brain --dev --no-interaction 2>&1
+```
+
+If composer ran, commit `composer.json` and `composer.lock` afterwards — otherwise the package disappears on the next branch switch.
+
+---
+
+## 1. Scan
+
+Build a fresh application graph. This takes 20–40 seconds on larger projects:
+
+```bash
+php artisan brain:scan --memory-limit=1024M --no-interaction 2>&1
+```
+
+Read the summary output carefully. Note three things:
+
+- **Security surface** — the total count of flagged patterns. It is NOT broken down by type in the scan output; use step 2.5 to break it down.
+- **Nodes / Edges** — graph size; use this to calibrate the export budget in step 2.
+- **Viewer URL** — the scan prints `Open the viewer: https://[project].test/_laravel-brain`. Capture this URL for step 2.5.
+
+---
+
+## 2. Export Context
+
+Export the full analysis. The default budget (6000 tokens) silently truncates the hotspot table on any project with more than ~50 controllers — always override it:
+
+```bash
+php artisan brain:export-context \
+  --budget=20000 \
+  --format=markdown \
+  --output=/tmp/brain-analysis.md \
+  --force \
+  --no-interaction 2>&1
+```
+
+Budget calibration based on node count from step 1:
+
+| Nodes | Budget |
+|-------|--------|
+| < 300 | 8000 |
+| 300–800 | 15000 |
+| 800+ | 20000 |
+
+> **Critical limitation:** The `--node` and `--route` filters do NOT restrict the Complexity Hotspots table. They only change the focal node for the Call Chain section at the top. The full project hotspot list always appears regardless of which filter you use. There is no way to get a node-scoped hotspot export via the CLI.
+
+---
+
+## 2.5. Security Category Breakdown
+
+The scan surface count is a single number. Before reading any source, fetch the per-category breakdown from the viewer's JSON API — this determines which categories dominate and whether the count is real signal or noise:
+
+```bash
+VIEWER_URL="https://[project].test"   # replace with actual URL from step 1
+curl -sk "${VIEWER_URL}/_laravel-brain/api/context?format=json" \
+  | python3 -c "
+import sys, json
+from collections import Counter
+data = json.load(sys.stdin)
+types = Counter()
+for n in data['nodes']:
+    for i in n.get('data', {}).get('security', {}).get('issues', []):
+        types[i['type']] += 1
+for t, c in types.most_common():
+    print(f'{c:4d}  {t}')
+"
+```
+
+**Interpreting the output — known issue types:**
+
+| Type | Meaning | False-positive rate |
+|---|---|---|
+| `XSS_BLADE_UNESCAPED` | `{!! !!}` output in Blade | **High** — form builder packages (`kris/laravel-form-builder`, `rdx/laravelcollective-html`) render HTML intentionally; check whether the call is a form builder helper before flagging |
+| `PUBLIC_WRITE` | POST/PUT/PATCH/DELETE route without detected auth middleware | **Medium** — the scanner reads middleware from the route definition; middleware applied in controllers or via route groups it cannot see will produce false positives. Cross-check with `php artisan route:list --method=POST --path=<prefix>` |
+| `MISSING_THROTTLE` | Auth or write route without a rate-limit middleware | **Low** — nearly always a real gap |
+| `UNVALIDATED_INPUT` | Controller accepting user input directly without validation | **Low** — nearly always a real gap |
+
+**Decision rule:** if `XSS_BLADE_UNESCAPED` dominates, discount it and focus on `PUBLIC_WRITE` and `UNVALIDATED_INPUT`. If `PUBLIC_WRITE` is large (≥ 20), start with routes on **non-admin/non-superadmin prefixes** — admin routes often have middleware applied in controller constructors or route groups that the scanner cannot see, producing false positives. Use `php artisan route:list --path=<prefix> --columns=method,uri,middleware` to cross-check specific suspicious routes before flagging them.
+
+---
+
+## 3. Parse the Export
+
+Read `/tmp/brain-analysis.md`. Focus on three sections in order of signal quality:
+
+### 3a. Complexity Hotspots
+
+The most important section. A table of all callables sorted by cyclomatic complexity descending, with line count alongside.
+
+**Scoring thresholds:**
+
+| Cyclomatic | Meaning | Default action |
+|---|---|---|
+| ≥ 16 | Critical — many independent paths, high bug surface | Must refactor |
+| 10–15 | High — deep nesting or long if/elseif chains | Schedule refactor |
+| 7–9 | Moderate | Inspect before touching |
+| ≤ 6 | Normal | No action needed |
+
+**Use both columns together.** Cyclomatic alone does not tell the full story:
+
+- High cyclomatic + high lines (≥ 80) → almost always a real problem
+- High cyclomatic + low lines → often a `match`/`switch` on an enum; verify before flagging
+- Low cyclomatic + very high lines (≥ 150) → structural smell even without branching
+
+**Scanner line numbers may drift.** The export shows line numbers from the last scan. If files were edited after `brain:scan` ran, those numbers will be off. Use `grep -n` to find exact positions rather than jumping to the reported line directly.
+
+**Identify false positives before flagging.** These score high legitimately and should be excluded from your candidate list:
+
+- Filament schema methods (`columns()`, `filters()`, `form()`, `table()`) — cyclomatic comes from chained `->when()` calls on field configuration, not from decision logic
+- Custom query builder methods with many `->when()` clauses — same pattern
+- Artisan command argument parsing — can legitimately branch; weight controller actions higher than commands
+
+**Build your candidate list:** extract the top 5 entries that are NOT false positives, sorted by `cyclomatic × lines` as a combined risk score.
+
+### 3b. Database Operations
+
+Scan every line for these two high-signal patterns:
+
+1. **`raw query` entries** — any `DB::` call bypassing Eloquent. Raw queries skip model events, observers, and the auditing package. Every raw query entry must be investigated in source.
+2. **Same table appearing in ≥ 5 unrelated controllers** — missing encapsulation; candidate for a repository or service class.
+
+Secondary signal: controllers using `save()` vs `saveOrFail()` — bare `save()` silently swallows failures in some contexts.
+
+### 3c. Security Surface Count (from step 1)
+
+The count is a smoke signal, not a finding list. Correlate it with the hotspot and database operation sections: a controller that ranks high on complexity AND touches many tables AND has a raw query is the highest-risk intersection to investigate first.
+
+See [references/security-patterns.md](references/security-patterns.md) for the specific anti-patterns to look for in source code.
+
+---
+
+## 4. Verify via Source
+
+For each of the top 5 complexity candidates, **read the actual source file**. The score tells you where to look; the code tells you why it matters.
+
+Locate files with:
+
+```bash
+find app -name "ControllerName.php" 2>/dev/null | head -3
+```
+
+When reading, check for these anti-patterns (full descriptions and fixes in [references/security-patterns.md](references/security-patterns.md)):
+
+| Anti-pattern | Risk |
+|---|---|
+| `if/elseif` chain on `$request->input('form_type')` or similar | God controller — split into one invokable per action |
+| `$model->fill($requestData)->save()` without a FormRequest | Unvalidated mass assignment |
+| `$model->setAttribute($request->input('field'), ...)` | Arbitrary attribute name from user input |
+| `$request->ajax()` as the sole authorization check | AJAX header is trivially forgeable |
+| `$e->getTraceAsString()` rendered in a response | Stack trace exposure |
+| `DB::table(...)->insert(...)` inside a controller | Bypasses model events and auditing |
+| Large private method only called from `__invoke` | Hidden complexity — hard to test in isolation |
+| `foreach ($request->input('ids') as $id => $value)` without ownership check | Unvalidated pivot/relation update |
+
+---
+
+## 4.5. Drill Down with `--node`
+
+Before fixing any finding, run a focused call chain export for that specific controller. This shows what the target calls downstream and — critically — what routes and middleware lead into it:
+
+```bash
+php artisan brain:export-context \
+  --node=ControllerName@method \
+  --budget=8000 \
+  --format=markdown \
+  --output=/tmp/brain-node.md \
+  --force --no-interaction 2>&1
+```
+
+Read the **Call Chain** section at the top of `/tmp/brain-node.md`. It shows the lifecycle from route → middleware → controller → downstream calls, up to 3 levels deep. Use this to confirm what authorization middleware is actually applied before writing the fix.
+
+> **Reminder:** `--node` only affects the Call Chain section. The Complexity Hotspots table in this output still covers the full project — ignore it here.
+
+---
+
+## 6. Report
+
+Present findings using this structure. Only include entries you have verified by reading source — do not copy the full hotspot table.
+
+```
+## Codebase Analysis
+
+Security surface: [N] issues flagged by scanner.
+Interactive breakdown: [viewer URL from step 1]
+
+### Priority 1 — Security Concerns
+
+- `ControllerName@method` (`path/to/File.php:line`) — [one-sentence description of the specific issue]
+
+### Priority 2 — Complexity Hotspots
+
+| Controller | Cyclomatic | Lines | Issue |
+|---|---|---|---|
+| ControllerName@method | N | N | one-line description |
+
+### Priority 3 — Database Operation Concerns
+
+- Raw query in `ControllerName@method` — [why it matters]
+- Table `name` touched by N unrelated controllers — [candidate for extraction]
+
+### Recommended Focus
+
+1. [Highest-priority item with file reference]
+2. [Second]
+3. [Third]
+```
+
+Cap each section at 5 items. Group additional findings as "and N more" with a brief characterization.
+
+---
+
+## STOP
+
+Do NOT start writing code, creating specs, or making changes. Present the report and wait for the user to direct next steps.
+
+If the user wants to create a spec for a finding, activate the `write-spec` skill.
+If the user wants detail on any security anti-pattern, read [references/security-patterns.md](references/security-patterns.md).
+If the output sections are unclear, read [references/interpreting-output.md](references/interpreting-output.md).
+
+---
+
+## Permissions and Installation Errors
+
+If `brain:scan` exits with a permissions error about writing to `storage/`, the web server user and CLI user may differ. Fix with:
+
+```bash
+chmod -R 775 storage bootstrap/cache
+```
+
+If the package installs but `brain:scan` still fails to find the command, check that `laravel-brain` is in the `autoload-dev` section of `composer.json` and run `composer dump-autoload`.
+
+---
+
+## Notes on the Package
+
+- `brain:generate-rules` generates static context files for specific agents (Cursor, Windsurf, JetBrains Junie, OpenAI Codex). This skill is different — it provides structured workflow guidance distributed via the Laravel Boost skill system (`boost:update`) to whichever AI tools the developer has configured.
+- Re-scan whenever PHP files have changed since the last scan. Within a single session, one scan is sufficient — you can re-export from the cached graph as many times as needed without re-scanning.
+- The browser viewer (URL printed by `brain:scan`) is the only place the security count is broken down by category. It also provides interactive call chain exploration that is not available via the CLI export.

--- a/resources/boost/skills/laravel-brain/references/interpreting-output.md
+++ b/resources/boost/skills/laravel-brain/references/interpreting-output.md
@@ -1,0 +1,103 @@
+# Interpreting brain:export-context Output
+
+The exported markdown has five sections. This reference explains what each contains, what is worth reading versus skimming, and where the limitations are.
+
+---
+
+## Section: Call Chain (depth ≤ 3)
+
+Shows the call graph for the **focal node** — the entry point brain chose or that you specified via `--node`. Appears at the very top of the export.
+
+**Read this when:** You are investigating a specific controller and want to understand what it calls downstream, or what calls into it.
+
+**Skip this when:** You are doing a broad audit. The default focal node (often something like `UserController@getStoreUser`) is rarely the most important thing in a general health scan.
+
+> **The `--node` filter only affects this section.** Using `--node=ControllerName@method` shifts the focal node for the Call Chain, but the Complexity Hotspots and Database Operations sections still cover the full project. There is no way to export a node-scoped hotspot list.
+
+---
+
+## Section: Complexity Hotspots
+
+The most important section for identifying work targets. Columns:
+
+| Column | Meaning |
+|---|---|
+| Label | `ClassName@method`, an Artisan command signature, or a Filament schema method name |
+| Cyclomatic | Number of independent code paths (decision branches). Higher = harder to test and reason about. |
+| Lines | Physical line count of the method body. |
+
+**How to read the table:**
+
+The table is sorted by cyclomatic descending. Scan the top — but treat the two columns as a combined signal, not cyclomatic alone.
+
+The practical risk ranking is:
+
+1. High cyclomatic + high lines → almost certainly a real problem
+2. High cyclomatic + low lines → may be a match/switch on an enum; verify before flagging
+3. Low cyclomatic + very high lines → structural smell; logic may be dense even without many branches
+
+**What looks alarming but is not:**
+
+- **Filament table/filter/form methods** (e.g. `ListUsers@columns`, `SomeResource@filters`, `SomeResource@form`) — these score high because Filament's fluent builder API uses heavy `->when()` chaining for conditional column/filter configuration. The cyclomatic count reflects the number of `->when()` calls, not branching decision logic. These methods are intentionally long; they are not candidates for refactoring unless the underlying conditions themselves are wrong.
+- **Query builder scope methods** — same pattern; `->when()` on every optional filter adds to the cyclomatic count without representing logic complexity.
+- **Artisan commands with argument parsing** — commands that handle multiple `{--option}` flags can legitimately branch per flag. Weight controller actions higher than commands when prioritizing.
+
+**What is almost always a real problem:**
+
+- Controller actions (especially `__invoke`, `store`, `update`) with cyclomatic ≥ 10 and lines ≥ 80 that are NOT Filament schema methods
+- Private helper methods called only from `__invoke` with high cyclomatic — hidden complexity that belongs in a service class
+- `if/elseif` chains keyed on `$request->input('form_type')` or similar — the god controller anti-pattern
+
+---
+
+## Section: Database Operations
+
+Lists every Eloquent and raw DB call grouped by the controller method that triggers it. Format:
+
+```
+- eloquent [method] [table] (via ControllerClass@action)
+- raw query  (via ControllerClass@action)
+```
+
+**High-signal patterns:**
+
+| Pattern | What to do |
+|---|---|
+| `raw query` | Read the source immediately — bypasses model events, observers, and the auditing package |
+| Same table in ≥ 5 unrelated controllers | Candidate for a repository or service class |
+| Controller with ≥ 8 different tables | May be doing too much; check whether it is a coordinator (acceptable) or a god class (not) |
+| `eloquent delete` without a soft-delete model | Check whether cascades are handled |
+
+**Secondary signals:**
+
+- `saveOrFail` is better than `save()` — bare `save()` silently swallows failures in some contexts
+- `firstOrCreate` appearing in a controller action (rather than in a factory or seeder) can be a sign of missing session management
+
+---
+
+## Section: Backend Packages
+
+The full `composer.json` dependency list. Useful for cross-referencing installed packages against what you find in source.
+
+Most relevant during a security review — for example: if `owen-it/laravel-auditing` is installed and you find a `raw query` entry in the database operations section, that controller is bypassing the audit log. Check the Backend Packages section to see whether an auditing package is present before treating raw queries as audit gaps.
+
+---
+
+## Section: Frontend Packages
+
+The full `package.json` list. Rarely relevant for backend complexity or security analysis. Scan only when doing a frontend-specific audit.
+
+---
+
+## What the Export Does NOT Contain
+
+These things are absent from the export and must be investigated separately:
+
+| Missing information | How to get it |
+|---|---|
+| Route middleware (auth, can:admin, etc.) | `php artisan route:list --path=your-path --columns=method,uri,action,middleware` |
+| Blade view content (XSS, unescaped output) | Grep for `{!! !!}` in `resources/views/` |
+| Model `$fillable` / `$guarded` settings | Read the model files directly |
+| Policy and Gate registrations | Read `app/Policies/` and `AuthServiceProvider` |
+| Specific security findings breakdown | Browser viewer at `https://[project].test/_laravel-brain` |
+| JavaScript/TypeScript analysis | Not scanned; use ESLint for JS security patterns |

--- a/resources/boost/skills/laravel-brain/references/security-patterns.md
+++ b/resources/boost/skills/laravel-brain/references/security-patterns.md
@@ -1,0 +1,239 @@
+# Security Patterns to Investigate
+
+After identifying high-complexity controllers from the hotspot table, look for these specific anti-patterns in the source. Each entry describes what it looks like, why it is dangerous, and the correct fix.
+
+---
+
+## 1. Arbitrary Attribute Setting
+
+**What it looks like:**
+
+```php
+if ($request->filled('attributeName') && $request->filled('attributeValue')) {
+    $model->setAttribute($request->attributeName, $request->attributeValue);
+}
+```
+
+**Why it is dangerous:** The user controls both the column name and the value. Even when the parent session is authorized via a policy, this allows setting sensitive attributes the caller was never meant to touch — `user_id`, `company_id`, `is_admin`, or any other column on the model.
+
+**Fix:** Maintain an explicit allowlist of settable attribute names and validate against it:
+
+```php
+$validated = $request->validate([
+    'attributeName' => ['required', 'string', 'in:coverage_id,manually_chosen'],
+    'attributeValue' => ['nullable'],
+]);
+$model->setAttribute($validated['attributeName'], $validated['attributeValue']);
+```
+
+---
+
+## 2. Unvalidated Mass Fill from Request
+
+**What it looks like:**
+
+```php
+foreach ($riskDataCollection as $riskResultData) {
+    $result->fill($riskResultData)->save();
+}
+```
+
+**Why it is dangerous:** Every field in the request payload is written to the model. Even behind admin middleware, this allows callers to corrupt model state by injecting attributes the endpoint was not designed to accept. It also makes the contract of the endpoint implicit rather than explicit.
+
+**Fix:** Either use a FormRequest to define the exact shape of each item, or be explicit about which fields are accepted:
+
+```php
+$result->fill(Arr::only($riskResultData, [
+    'overview_text',
+    'conditions_text',
+    'effective_from',
+    'points',
+]))->save();
+```
+
+---
+
+## 3. AJAX-Only Authorization
+
+**What it looks like:**
+
+```php
+if (! $request->ajax()) {
+    abort(Response::HTTP_FORBIDDEN, 'Access denied');
+}
+```
+
+**Why it is dangerous:** The `ajax()` check only reads the `X-Requested-With` request header, which any HTTP client can set. This is not authentication or authorization — it is header inspection. Any user who can reach the route can forge this header.
+
+**Fix:** Add a real policy or gate check in addition to, or instead of, the AJAX check:
+
+```php
+Gate::authorize('update', $model);
+// or with a policy constant:
+// Gate::authorize(ModelPolicy::UPDATE, $model);
+```
+
+---
+
+## 4. Unvalidated IDs in a Pivot Loop
+
+**What it looks like:**
+
+```php
+foreach ($request->input('related_ids') as $relatedId => $value) {
+    $model->relatedItems()->updateExistingPivot((int) $relatedId, [
+        'some_field' => $value,
+    ]);
+}
+```
+
+**Why it is dangerous:** The user supplies the pivot key directly. Without checking that each ID belongs to this model, a caller can update pivot records for models they are not authorized to modify.
+
+**Fix:** Validate submitted IDs against the model's actual related set before iterating:
+
+```php
+$allowedIds = $model->relatedItems()->pluck('related_items.id');
+
+foreach ($request->input('related_ids') as $relatedId => $value) {
+    if (! $allowedIds->contains((int) $relatedId)) {
+        abort(Response::HTTP_FORBIDDEN);
+    }
+
+    $model->relatedItems()->updateExistingPivot((int) $relatedId, [
+        'some_field' => $value,
+    ]);
+}
+```
+
+---
+
+## 5. Exception Stack Trace in Response
+
+**What it looks like:**
+
+```php
+catch (Throwable $e) {
+    return view('app.plain', [
+        'content' => $e->getMessage() . $e->getTraceAsString(),
+    ]);
+}
+```
+
+**Why it is dangerous:** Stack traces reveal file paths, class names, method names, line numbers, and sometimes argument values — all useful for an attacker mapping the system. Even behind admin or superadmin middleware, this is unnecessary information exposure.
+
+**Fix:** Log the full trace server-side; return only a sanitized message to the client:
+
+```php
+catch (Throwable $e) {
+    Log::error('Operation failed', ['exception' => $e]);
+
+    return view('app.plain', [
+        'content' => 'An error occurred. Check the application logs.',
+    ]);
+}
+```
+
+---
+
+## 6. Raw DB Query Bypassing Eloquent Events and Auditing
+
+**Brain export signal:** `raw query (via ControllerName@action)`
+
+**What it looks like:**
+
+```php
+DB::table($relation->getTable())->insert(
+    $coveragesData->map(fn (array $row): array => [...$row])->all()
+);
+```
+
+**Why it is dangerous:** Raw `DB::table()` calls bypass:
+- Eloquent model events (`creating`, `created`, `updating`, etc.)
+- Observer classes
+- Audit logging packages (e.g. `owen-it/laravel-auditing`) — if auditing is installed, raw inserts do not produce audit log entries
+
+**Before flagging as a problem:** Check whether the raw query is an intentional workaround. Common legitimate uses:
+- Bulk pivot inserts inside a `DB::transaction()` where `attach()` / `sync()` would not produce the right rows (e.g. duplicate company IDs per pivot)
+- Backfill migrations where firing model events would have unintended side effects
+
+If intentional, verify there is a comment explaining why and that audit gaps are acceptable for this data.
+
+**Fix:** Use Eloquent model `create()` / `save()` so the full lifecycle fires. If a bulk insert is genuinely needed for performance, consider whether you can manually fire the audit event, or at minimum add a comment explaining why Eloquent was bypassed and what the consequences are.
+
+---
+
+## 7. Unvalidated Foreign Key
+
+**What it looks like:**
+
+```php
+$company->insurance_company_id = $request->filled('insurance_company_id')
+    ? (int) $request->input('insurance_company_id')
+    : null;
+```
+
+**Why it is dangerous:** An arbitrary integer is cast and written directly to a foreign key column without verifying that the referenced record exists or is accessible to the current user. If there is no database-level FK constraint, this can silently write dangling references.
+
+**Fix:** Validate the FK value before assigning it:
+
+```php
+$validated = $request->validate([
+    'related_model_id' => ['nullable', 'integer', 'exists:related_models,id'],
+]);
+
+$model->related_model_id = $validated['related_model_id'];
+```
+
+---
+
+## Quick Grep Commands
+
+Use these to scan hotspot files for the patterns above without reading every line:
+
+```bash
+# Arbitrary attribute setting
+grep -n 'setAttribute\s*(\s*\$request' app/Http/Controllers/**/*.php
+
+# Mass fill from request
+grep -n '->fill(\$' app/Http/Controllers/**/*.php
+
+# AJAX-only auth
+grep -n 'ajax()' app/Http/Controllers/**/*.php
+
+# getTraceAsString in response
+grep -rn 'getTraceAsString' app/
+
+# Raw DB queries in controllers
+grep -rn 'DB::table' app/Http/Controllers/
+
+# Unvalidated FK assignment
+grep -n "input\('.*_id'\)" app/Http/Controllers/**/*.php
+```
+
+---
+
+## Scanner Line-Number Drift
+
+The brain export lists line numbers from when the graph was last built. If the file has been edited since the last `brain:scan`, those line numbers will be off. Before navigating to a reported line:
+
+```bash
+# Find the actual line of a pattern rather than trusting the export
+grep -n 'setAttribute\s*(\$request' app/Http/Controllers/Path/To/Controller.php
+```
+
+Always verify the line number by grepping for the specific pattern rather than jumping directly to the reported line. The anti-pattern search commands in the Quick Grep Commands section above are the reliable way to find exact positions.
+
+---
+
+## Checking Authorization Coverage
+
+To quickly assess which routes lack middleware protection:
+
+```bash
+php artisan route:list \
+  --except-vendor \
+  --columns=method,uri,action,middleware \
+  2>/dev/null | grep -v 'auth\|can:' | head -40
+```
+
+Routes in `superadmin` or `admin` prefixes that appear without `auth` or `can:` in the middleware column warrant individual inspection.


### PR DESCRIPTION
### What

Adds a Laravel Boost skill, following the same pattern as `livewire/blaze` (`resources/boost/skills/blaze-optimize/`). The skill is agent-agnostic — `boost:update` distributes it to whichever AI tools the developer has configured (Claude Code, Cursor, GitHub Copilot, etc.).

```
resources/boost/skills/laravel-brain/
├── SKILL.md                        # Step-by-step analysis workflow
└── references/
    ├── security-patterns.md        # Anti-pattern catalogue with fixes
    └── interpreting-output.md      # Guide to reading brain:export-context output
```

### Why

`brain:generate-rules` generates static context files for specific agents (Cursor, Windsurf, JetBrains Junie, OpenAI Codex). A Boost skill is different — it provides structured workflow guidance that tells the agent *how* to use the tool, not just that it exists.

Without a skill, agents default to `brain:export-context` with the 6000-token budget, which silently truncates the hotspot table on any project with more than ~50 controllers. They also skip the security category breakdown, since that data is only available via the viewer's JSON API (`/_laravel-brain/api/context?format=json`), not in the CLI export.

### What it does

- Installs the package if missing, then runs `brain:scan` and calibrates the export budget to graph size
- Fetches per-category security counts from the viewer JSON API before reading any source
- Filters Filament/query-builder false positives from the hotspot table; ranks by `cyclomatic × lines`
- Reads the top candidates in source and checks for 8 specific anti-patterns
- Runs `brain:export-context --node` on confirmed findings to verify middleware before writing fixes
- Outputs a structured report (Security / Complexity / DB concerns) with only source-verified items

### Design decisions worth noting

**Budget calibration.** The skill always overrides the default budget based on graph size (8k / 15k / 20k tokens for <300 / 300–800 / 800+ nodes). Discovered when the default truncated the entire hotspot table on a real project.

**JSON API security breakdown.** The `brain:scan` surface count is a single number. The skill fetches per-category counts from the viewer API before reading any source — this was the highest-signal step in practice, revealing 125 `PUBLIC_WRITE` findings the plain export never surfaced.

**CLI limitation documentation.** The skill calls out that `--node` / `--route` filters only affect the Call Chain section, not the Complexity Hotspots table. This is non-obvious and caused confusion when trying to scope exports.

### Open question

Should `brain:generate-rules` also output the Boost skill alongside its existing per-agent outputs? Happy to add that in this PR or leave it as a follow-up — the skill works standalone either way.