### PR TITLE
Feat: allow custom auth middleware patterns via config

### DIFF
--- a/config/laravel-brain.php
+++ b/config/laravel-brain.php
@@ -88,6 +88,27 @@ return [
     'auto_discover_exclude_vendor' => env('LARAVEL_BRAIN_AUTO_DISCOVER_EXCLUDE_VENDOR', true),
 
     // -------------------------------------------------------------------------
+    // Security Analysis
+    // -------------------------------------------------------------------------
+    // Extra middleware aliases or FQCN prefixes that Brain should treat as
+    // authentication middleware. Entries are matched as case-insensitive
+    // prefixes, so 'auth.custom' matches 'auth.custom:api'.
+    //
+    // Add your application's custom auth middleware here to prevent
+    // false "Public Route" warnings.
+    //
+    // Example:
+    //   'auth_middleware' => [
+    //       'App\\Http\\Middleware\\CustomAuth',
+    //   ],
+    //
+    'security' => [
+        'auth_middleware' => [
+            'App\\Http\\Middleware\\CustomAuth',
+        ],
+    ],
+
+    // -------------------------------------------------------------------------
     // Route File Paths
     // -------------------------------------------------------------------------
     // Glob patterns (relative to project root) used to discover route files.

--- a/config/laravel-brain.php
+++ b/config/laravel-brain.php
@@ -103,9 +103,7 @@ return [
     //   ],
     //
     'security' => [
-        'auth_middleware' => [
-            'App\\Http\\Middleware\\CustomAuth',
-        ],
+        'auth_middleware' => [],
     ],
 
     // -------------------------------------------------------------------------

--- a/src/Analysis/ProjectAnalyzer.php
+++ b/src/Analysis/ProjectAnalyzer.php
@@ -80,7 +80,10 @@ class ProjectAnalyzer
         $this->modelAnalyzer = new ModelAnalyzer(is_array($modelPaths) ? $modelPaths : []);
         $this->filamentAnalyzer = new FilamentAnalyzer;
         $this->queryTracer = new QueryTracer;
-        $this->securityAnalyzer = new SecurityAnalyzer;
+        $authMiddleware = config('laravel-brain.security.auth_middleware', []);
+        $this->securityAnalyzer = new SecurityAnalyzer(
+            extraAuthPatterns: is_array($authMiddleware) ? $authMiddleware : [],
+        );
         $this->graphBuilder = new GraphBuilder;
         $livewirePaths = config('laravel-brain.livewire.component_paths', []);
         if (is_array($livewirePaths) && $livewirePaths !== []) {

--- a/src/Analysis/SecurityAnalyzer.php
+++ b/src/Analysis/SecurityAnalyzer.php
@@ -100,7 +100,7 @@ class SecurityAnalyzer
     /** @var array<string, list<array<string, mixed>>>|null */
     private ?array $externalByFile = null;
 
-    public function __construct()
+    public function __construct(private array $extraAuthPatterns = [])
     {
         $this->parser = new PhpFileParser;
     }
@@ -229,8 +229,9 @@ class SecurityAnalyzer
             }
         }
         // Auth check
+        $authPatterns = array_merge(self::AUTH_PATTERNS, $this->extraAuthPatterns);
         foreach ($middlewares as $mw) {
-            if ($this->middlewareMatches($mw, self::AUTH_PATTERNS)) {
+            if ($this->middlewareMatches($mw, $authPatterns)) {
                 return 'authed';
             }
         }

--- a/tests/Unit/SecurityAnalyzerTest.php
+++ b/tests/Unit/SecurityAnalyzerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use LaraMint\LaravelBrain\Analysis\MiddlewareRegistry;
+use LaraMint\LaravelBrain\Analysis\RouteDefinition;
+use LaraMint\LaravelBrain\Analysis\SecurityAnalyzer;
+
+function makeSecurityRoute(string $method, string $uri, array $middlewares): RouteDefinition
+{
+    return new RouteDefinition(
+        method: $method,
+        uri: $uri,
+        controller: '',
+        action: 'index',
+        middlewares: $middlewares,
+        name: '',
+        file: '',
+        line: 1,
+    );
+}
+
+function exposure(RouteDefinition $route, MiddlewareRegistry $registry, array $extraAuthPatterns = []): string
+{
+    $analyzer = new SecurityAnalyzer(extraAuthPatterns: $extraAuthPatterns);
+    $results = $analyzer->analyze([$route], $registry, [], '');
+    $routeId = "route::{$route->method}::{$route->uri}";
+
+    return $results[$routeId]['exposure'];
+}
+
+it('classifies a route with no auth middleware as public', function () {
+    $route = makeSecurityRoute('GET', '/open', ['web']);
+    $registry = new MiddlewareRegistry([], [], []);
+
+    expect(exposure($route, $registry))->toBe('public');
+});
+
+it('classifies a route with auth:sanctum as authed', function () {
+    $route = makeSecurityRoute('GET', '/dashboard', ['auth:sanctum']);
+    $registry = new MiddlewareRegistry([], [], []);
+
+    expect(exposure($route, $registry))->toBe('authed');
+});
+
+it('classifies a route with the Illuminate Authenticate FQCN as authed', function () {
+    $route = makeSecurityRoute('GET', '/dashboard', ['auth:api']);
+    $registry = new MiddlewareRegistry([], [], [
+        'auth' => 'Illuminate\Auth\Middleware\Authenticate',
+    ]);
+
+    expect(exposure($route, $registry))->toBe('authed');
+});
+
+it('classifies a custom auth alias as public when no extra patterns are configured', function () {
+    $route = makeSecurityRoute('GET', '/dashboard', ['auth.custom:api']);
+    $registry = new MiddlewareRegistry([], [], [
+        'auth.custom' => 'App\Http\Middleware\CustomAuth',
+    ]);
+
+    expect(exposure($route, $registry))->toBe('public');
+});
+
+it('classifies a custom auth alias as authed when the alias is in extra patterns', function () {
+    $route = makeSecurityRoute('GET', '/dashboard', ['auth.custom:api']);
+    $registry = new MiddlewareRegistry([], [], []);
+
+    expect(exposure($route, $registry, ['auth.custom']))->toBe('authed');
+});
+
+it('classifies a custom auth alias as authed when its resolved FQCN is in extra patterns', function () {
+    $route = makeSecurityRoute('GET', '/dashboard', ['auth.custom:api']);
+    $registry = new MiddlewareRegistry([], [], [
+        'auth.custom' => 'App\Http\Middleware\CustomAuth',
+    ]);
+
+    expect(exposure($route, $registry, ['App\Http\Middleware\CustomAuth']))->toBe('authed');
+});


### PR DESCRIPTION
## Summary
This PR adds an option to allow custom auth middleware patterns via config.

## Problem
Brain hardcodes its list of authentication middleware in SecurityAnalyzer::AUTH_PATTERNS. Any application using a custom auth middleware (e.g. a BFF token layer, a custom JWT guard, or any alias that doesn't start with auth, sanctum, jwt, passport, or verified) gets a false "Public Route" warning on every protected route, because Brain resolves the alias to its FQCN and that FQCN doesn't match any known pattern.

There is currently no way to tell Brain about custom auth middleware without modifying vendor code.

## Solution
Add a security.auth_middleware config key that accepts additional middleware aliases or FQCN prefixes. These are merged with the built-in patterns at analysis time using the same case-insensitive prefix matching already in place. 

Both forms work:

```
// config/laravel-brain.php
  'security' => [
      'auth_middleware' => [
          'auth.custom', // matched as alias prefix
          'App\\Http\\Middleware\\CustomAuth', // matched as FQCN prefix
      ],
  ],
```

## Changes
- `config/laravel-brain.php` — new security.auth_middleware key (defaults to [], no behaviour change for existing users)                                       
- SecurityAnalyzer — accepts extraAuthPatterns as a constructor parameter; merges with `AUTH_PATTERNS` in `ClassifyExposure()`
- ProjectAnalyzer — reads the config key and passes it to SecurityAnalyzer
- `tests/Unit/SecurityAnalyzerTest.php` — new test file covering baseline built-in patterns, the false-positive case (custom alias with no config), and both matching strategies (alias prefix and resolved FQCN)

## Behavior Impact
- Default is [] — no change in behaviour for existing users
- Extra patterns follow the same prefix matching as built-in ones, so 'auth.custom' matches auth.custom:api, and a FQCN matches with or without a guard suffix