### PR TITLE
fix(security): recognise custom auth guards by their extends chain

### DIFF
--- a/src/Analysis/SecurityAnalyzer.php
+++ b/src/Analysis/SecurityAnalyzer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LaraMint\LaravelBrain\Analysis;
 
+use LaraMint\LaravelBrain\Parser\PhpExtendsFqcnResolver;
 use LaraMint\LaravelBrain\Parser\PhpFileParser;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
@@ -105,6 +106,14 @@ class SecurityAnalyzer
 
     /** @var array<string, list<array<string, mixed>>>|null */
     private ?array $externalByFile = null;
+
+    /**
+     * Memoised result of {@see self::isAuthClass()} keyed by FQCN, so each
+     * middleware class's `extends` chain is walked at most once per scan.
+     *
+     * @var array<string, bool>
+     */
+    private array $authClassCache = [];
 
     /**
      * Effective auth-middleware patterns (defaults + $extraAuthPatterns),
@@ -281,9 +290,16 @@ class SecurityAnalyzer
                 return 'admin';
             }
         }
-        // Auth check
+        // Auth check — pattern/basename match OR a verified `extends
+        // Authenticate` chain. The chain walk catches a custom guard whose
+        // class name doesn't contain "auth" (e.g. `auth.customer` mapped to
+        // App\Http\Middleware\AuthenticateCustomer), which basename matching
+        // against the framework `Authenticate` alone would miss.
         foreach ($middlewares as $mw) {
             if ($this->middlewareMatches($mw, $this->authPatterns)) {
+                return 'authed';
+            }
+            if ($this->isAuthClass($this->middlewareClass($mw))) {
                 return 'authed';
             }
         }
@@ -593,6 +609,94 @@ class SecurityAnalyzer
         $pos = strrpos($name, '\\');
 
         return strtolower($pos === false ? $name : substr($name, $pos + 1));
+    }
+
+    /**
+     * The class/alias part of a resolved middleware string, stripped of any
+     * `:params` suffix. The registry has already resolved aliases to FQCNs,
+     * so this is usually a class name.
+     */
+    private function middlewareClass(string $middleware): string
+    {
+        return explode(':', $middleware, 2)[0];
+    }
+
+    /**
+     * True when $fqcn is the framework's Authenticate middleware or any class
+     * whose `extends` chain reaches it. Results are memoised per scan so each
+     * FQCN is walked at most once.
+     */
+    private function isAuthClass(string $fqcn): bool
+    {
+        $fqcn = ltrim($fqcn, '\\');
+        if ($fqcn === '') {
+            return false;
+        }
+        if (isset($this->authClassCache[$fqcn])) {
+            return $this->authClassCache[$fqcn];
+        }
+        if ($fqcn === 'Illuminate\\Auth\\Middleware\\Authenticate') {
+            return $this->authClassCache[$fqcn] = true;
+        }
+
+        // Seed the memo *before* recursing so a cyclic `extends` chain (two
+        // classes that extend each other — only possible with a broken class
+        // Brain can't execute) terminates instead of exhausting memory and
+        // taking the whole scan down. The real result overwrites this below.
+        $this->authClassCache[$fqcn] = false;
+
+        $parent = $this->resolveParentClass($fqcn);
+        if ($parent === null) {
+            return false;
+        }
+
+        return $this->authClassCache[$fqcn] = $this->isAuthClass($parent);
+    }
+
+    /**
+     * Best-effort: parse the file declaring $fqcn (PSR-4 convention) and
+     * return the FQCN of its `extends` clause, or null when the file can't be
+     * found or the class doesn't extend anything we can resolve.
+     */
+    private function resolveParentClass(string $fqcn): ?string
+    {
+        $file = $this->locateClassFile($fqcn);
+        if ($file === null) {
+            return null;
+        }
+
+        $parsed = $this->cachedParse($file);
+        if (($parsed['ast'] ?? null) === null) {
+            return null;
+        }
+
+        $namespace = PhpExtendsFqcnResolver::namespaceFromAst($parsed['ast']);
+        $useMap = $parsed['useMap'] ?? [];
+
+        $parent = null;
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor(new class($parent, $namespace, $useMap) extends NodeVisitorAbstract
+        {
+            public function __construct(public ?string &$parent, private string $namespace, private array $useMap) {}
+
+            public function enterNode(Node $node): ?int
+            {
+                if ($node instanceof Node\Stmt\Class_ && $node->extends !== null) {
+                    $this->parent = PhpExtendsFqcnResolver::resolveExtends(
+                        $node->extends,
+                        $this->namespace,
+                        $this->useMap,
+                    );
+
+                    return NodeTraverser::STOP_TRAVERSAL;
+                }
+
+                return null;
+            }
+        });
+        $traverser->traverse($parsed['ast']);
+
+        return $parent;
     }
 
     /**

--- a/tests/Unit/SecurityAnalyzerTest.php
+++ b/tests/Unit/SecurityAnalyzerTest.php
@@ -487,3 +487,49 @@ it('still flags MISSING_THROTTLE on sensitive routes with no rate-limiting', fun
     expect(issueTypes($analysis, 'route::POST::/login-noop'))
         ->toContain('MISSING_THROTTLE');
 });
+
+// =============================================================================
+// Custom auth guard detection via a verified `extends Authenticate` chain.
+// Catches guards whose class name does not contain "auth" (e.g. an
+// `auth.customer` alias mapped to App\Http\Middleware\AuthenticateCustomer),
+// which basename matching against the framework `Authenticate` alone misses.
+// =============================================================================
+
+function customAuthFixtureRoot(): string
+{
+    return fixture('custom-auth-project');
+}
+
+it('classifies a differently-named Authenticate subclass (resolved via alias) as authed', function () {
+    $route = makeSecurityRoute('DELETE', '/account/claims/{claim}', ['auth.customer']);
+    $registry = new MiddlewareRegistry([], [], [
+        'auth.customer' => 'App\\Http\\Middleware\\AuthenticateCustomer',
+    ]);
+
+    $analysis = (new SecurityAnalyzer)->analyze([$route], $registry, [], customAuthFixtureRoot());
+
+    $routeId = 'route::DELETE::/account/claims/{claim}';
+    expect($analysis[$routeId]['exposure'])->toBe('authed')
+        ->and(issueTypes($analysis, $routeId))->not->toContain('PUBLIC_WRITE');
+});
+
+it('classifies a differently-named Authenticate subclass given by bare FQCN as authed', function () {
+    $route = makeSecurityRoute('POST', '/account/profile', ['App\\Http\\Middleware\\AuthenticateCustomer']);
+    $registry = new MiddlewareRegistry([], [], []);
+
+    $analysis = (new SecurityAnalyzer)->analyze([$route], $registry, [], customAuthFixtureRoot());
+
+    expect($analysis['route::POST::/account/profile']['exposure'])->toBe('authed');
+});
+
+it('terminates on a cyclic middleware extends chain instead of exhausting memory', function () {
+    // CyclicA extends CyclicB extends CyclicA. Neither reaches Authenticate, so
+    // the route stays public; the point is that the walk returns at all.
+    $route = makeSecurityRoute('POST', '/cyclic', ['App\\Http\\Middleware\\CyclicA']);
+    $registry = new MiddlewareRegistry([], [], []);
+
+    $analysis = (new SecurityAnalyzer)->analyze([$route], $registry, [], customAuthFixtureRoot());
+
+    expect($analysis['route::POST::/cyclic']['exposure'])->toBe('public')
+        ->and(issueTypes($analysis, 'route::POST::/cyclic'))->toContain('PUBLIC_WRITE');
+});

--- a/tests/fixtures/custom-auth-project/app/Http/Middleware/AuthenticateCustomer.php
+++ b/tests/fixtures/custom-auth-project/app/Http/Middleware/AuthenticateCustomer.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Auth\Middleware\Authenticate;
+
+/**
+ * Custom auth middleware backing a second guard (e.g. the `auth.customer`
+ * alias). Extending the framework's Authenticate is the standard Laravel
+ * idiom for adding a guard alongside `auth` — but the class name does not
+ * contain "auth", so basename matching against `Authenticate` alone misses
+ * it and the extends-chain walk is what recognises it.
+ */
+class AuthenticateCustomer extends Authenticate {}

--- a/tests/fixtures/custom-auth-project/app/Http/Middleware/CyclicA.php
+++ b/tests/fixtures/custom-auth-project/app/Http/Middleware/CyclicA.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Middleware;
+
+/**
+ * Deliberately broken: CyclicA and CyclicB extend each other. This can only
+ * happen with a class PHP could never load, but Brain parses source without
+ * executing it, so the extends walk in SecurityAnalyzer::isAuthClass() must
+ * terminate on the cycle instead of recursing until memory is exhausted.
+ */
+class CyclicA extends CyclicB {}

--- a/tests/fixtures/custom-auth-project/app/Http/Middleware/CyclicB.php
+++ b/tests/fixtures/custom-auth-project/app/Http/Middleware/CyclicB.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace App\Http\Middleware;
+
+/** Counterpart to CyclicA — see that class for why this cycle exists. */
+class CyclicB extends CyclicA {}


### PR DESCRIPTION
Rebased onto current `main` and narrowed to the classifier change. The array-form `$middleware->alias([...])` fix is split out to #86 (per @SanderMuller's suggestion), and the review items that only applied to the old base — the `SAFE_INFRA_PATTERNS` suppression, the duplicated locate helper, the `signed`/`ValidateSignature` contradiction — are gone with the rebase (current `main` never had them).

## Problem

`classifyExposure()` already recognises the framework `Authenticate` and an app subclass that happens to **share its name** (`App\Http\Middleware\Authenticate`), via basename matching. It still misses a custom guard whose class name doesn't contain "auth" — the textbook second-guard case:

```php
$middleware->alias(['auth.customer' => AuthenticateCustomer::class]);
```

`AuthenticateCustomer extends Authenticate`, but its basename isn't `authenticate`, so the route is classified `public` and every mutating route behind it gets a false `PUBLIC_WRITE`.

## Change

`classifyExposure()` now also does a **verified `extends Authenticate` walk** (reusing the existing `PhpExtendsFqcnResolver`) for any middleware that pattern matching didn't already resolve. A guard that reaches `Illuminate\Auth\Middleware\Authenticate` through its parent chain is classified `authed`, which in turn suppresses the false `PUBLIC_WRITE`.

The walk is memoised per scan. Addressing your review: the memo is **seeded before recursing**, so a cyclic `extends` chain (a broken class that Brain can't execute) terminates instead of exhausting memory and taking the whole scan down.

No public API change; no new constructor parameters.

## Tests

Appended to `tests/Unit/SecurityAnalyzerTest.php` (+ `custom-auth-project` middleware fixtures):

- a differently-named `Authenticate` subclass resolved via an alias → `authed`, no `PUBLIC_WRITE`
- the same subclass given by bare FQCN → `authed`
- a cyclic `A extends B extends A` chain terminates (route stays `public`, `PUBLIC_WRITE` still fires)

Full suite green (213 passed), phpstan 0 errors, pint clean.

## Relationship to #86

Independent and self-contained (its tests build the alias map directly), but they compose: #86 makes the array-form alias reach the registry, and this PR classifies the resolved guard correctly. Either order merges cleanly.
