### PR TITLE
Detect jobs dispatched via the Bus facade

### DIFF
--- a/src/Analysis/FlowExtractor.php
+++ b/src/Analysis/FlowExtractor.php
@@ -312,6 +312,9 @@ class FlowExtractor
             if (in_array($class, ['Event', 'Illuminate\\Support\\Facades\\Event']) && $method === 'dispatch') {
                 return ['type' => 'event', 'label' => 'Event::dispatch(...)'];
             }
+            if (in_array($class, ['Bus', 'Illuminate\\Support\\Facades\\Bus']) && in_array($method, ['dispatch', 'dispatchSync', 'chain', 'batch'])) {
+                return ['type' => 'dispatch', 'label' => "Bus::{$method}(...)"];
+            }
 
             return ['type' => 'call', 'label' => "{$short}::{$method}(...)"];
         }

--- a/src/Analysis/MethodTracer.php
+++ b/src/Analysis/MethodTracer.php
@@ -395,6 +395,26 @@ class MethodTracer
                     return;
                 }
 
+                // Bus facade: Bus::dispatch(new Job) / Bus::dispatchSync(new Job)
+                // and the array forms Bus::chain([new A, new B]) / Bus::batch([new A, new B]).
+                if (in_array($class, ['Bus', 'Illuminate\\Support\\Facades\\Bus'], true)
+                    && in_array($method, ['dispatch', 'dispatchSync', 'chain', 'batch'], true)) {
+                    $jobClasses = in_array($method, ['chain', 'batch'], true)
+                        ? $this->extractNewClassesFromArray($node->args[0] ?? null)
+                        : array_filter([$this->extractNewClass($node->args[0] ?? null)]);
+
+                    foreach ($jobClasses as $jobClass) {
+                        $this->hops[] = [
+                            'fqcn' => $this->useMap[$jobClass] ?? $jobClass,
+                            'method' => 'handle',
+                            'type' => 'job',
+                            'visibility' => 'public',
+                        ];
+                    }
+
+                    return;
+                }
+
                 // View::make('name')
                 if (in_array($class, ['View', 'Illuminate\\Support\\Facades\\View'], true) && $method === 'make') {
                     $vn = $this->extractViewName($node->args[0] ?? null);
@@ -757,6 +777,29 @@ class MethodTracer
                 }
 
                 return null;
+            }
+
+            /**
+             * The `new X()` items in an array-literal argument, e.g. Bus::chain([new A, new B]).
+             *
+             * @return string[]
+             */
+            private function extractNewClassesFromArray(?Node $node): array
+            {
+                $value = $node instanceof Node\Arg ? $node->value : $node;
+                if (! $value instanceof Node\Expr\Array_) {
+                    return [];
+                }
+
+                $classes = [];
+                foreach ($value->items as $item) {
+                    $class = $item !== null ? $this->extractNewClass($item->value) : null;
+                    if ($class !== null) {
+                        $classes[] = $class;
+                    }
+                }
+
+                return $classes;
             }
 
             private function looksLikeModel(string $class): bool

--- a/tests/Unit/MethodTracerBusDispatchTest.php
+++ b/tests/Unit/MethodTracerBusDispatchTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use LaraMint\LaravelBrain\Analysis\MethodTracer;
+
+it('traces jobs dispatched through the Bus facade (dispatch, chain, batch)', function () {
+    $root = fixture('laravel-project');
+    $psr4 = ['App\\' => [$root.'/app']];
+
+    $edges = (new MethodTracer)->traceMethod('App\Services\BusDispatcher', 'dispatchAll', $psr4, $root);
+
+    $jobTargets = array_map(
+        fn ($edge) => $edge->calleeFqcn,
+        array_filter($edges, fn ($edge) => $edge->type === 'job'),
+    );
+
+    // BusDispatcher::dispatchAll() dispatches these via Bus::dispatch / Bus::chain / Bus::batch.
+    expect($jobTargets)
+        ->toContain('App\Jobs\ShipOrder')        // Bus::dispatch(new ShipOrder())
+        ->toContain('App\Jobs\ChargeOrder')       // Bus::chain([new ChargeOrder(), ...])
+        ->toContain('App\Jobs\NotifyWarehouse')   // Bus::chain([..., new NotifyWarehouse()])
+        ->toContain('App\Jobs\ReindexOrder');     // Bus::batch([new ReindexOrder()])
+});

--- a/tests/fixtures/laravel-project/app/Services/BusDispatcher.php
+++ b/tests/fixtures/laravel-project/app/Services/BusDispatcher.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Services;
+
+use App\Jobs\ChargeOrder;
+use App\Jobs\NotifyWarehouse;
+use App\Jobs\ReindexOrder;
+use App\Jobs\ShipOrder;
+use Illuminate\Support\Facades\Bus;
+
+class BusDispatcher
+{
+    public function dispatchAll(): void
+    {
+        Bus::dispatch(new ShipOrder);
+        Bus::chain([new ChargeOrder, new NotifyWarehouse]);
+        Bus::batch([new ReindexOrder]);
+    }
+}


### PR DESCRIPTION
`MethodTracer` already maps `Job::dispatch()` and `Event::dispatch()`, but the `Bus` facade isn't recognised — so jobs sent through `Bus::dispatch()`, `Bus::chain([...])`, or `Bus::batch([...])` don't appear in the graph.

This adds the `Bus` facade alongside the existing `Event` one, plus the matching label in `FlowExtractor`:

- `Bus::dispatch(new Job)` / `Bus::dispatchSync(new Job)` → one job edge
- `Bus::chain([new A, new B])` / `Bus::batch([new A, new B])` → a job edge per job in the array

It emits the same hop shape as the existing job detection (`'type' => 'job'`, `'method' => 'handle'`), so it flows straight into the current job-node / `dispatches`-edge handling with no downstream changes.

Like the existing dispatch detectors, only literal `new Job()` arguments are resolved — a job held in a variable isn't.

Tests and a small fixture are included; the full suite (Pint, Pest, PHPStan) is green.
