### PR TITLE
Detect $this->dispatch() and dispatch_sync() job dispatches

### DIFF
--- a/src/Analysis/FlowExtractor.php
+++ b/src/Analysis/FlowExtractor.php
@@ -318,16 +318,22 @@ class FlowExtractor
 
         // $this->service->method(...)  /  $var->method(...)
         if ($expr instanceof Node\Expr\MethodCall) {
+            $m = $expr->name instanceof Node\Identifier ? $expr->name->toString() : null;
+            if (in_array($m, ['dispatch', 'dispatchSync'], true)
+                && $expr->var instanceof Node\Expr\Variable && $expr->var->name === 'this') {
+                return ['type' => 'dispatch', 'label' => $this->shortExpr($expr)];
+            }
+
             return ['type' => 'call', 'label' => $this->shortExpr($expr)];
         }
 
-        // event(new SomeEvent)  /  dispatch(new SomeJob)
+        // event(new SomeEvent)  /  dispatch(new SomeJob)  /  dispatch_sync(new SomeJob)
         if ($expr instanceof Node\Expr\FuncCall && $expr->name instanceof Node\Name) {
             $fn = $expr->name->toString();
             if ($fn === 'event') {
                 return ['type' => 'event', 'label' => $this->shortExpr($expr)];
             }
-            if ($fn === 'dispatch') {
+            if (in_array($fn, ['dispatch', 'dispatch_sync'], true)) {
                 return ['type' => 'dispatch', 'label' => $this->shortExpr($expr)];
             }
 

--- a/src/Analysis/MethodTracer.php
+++ b/src/Analysis/MethodTracer.php
@@ -314,7 +314,7 @@ class MethodTracer
 
             private const EVENT_FUNCTIONS = ['event'];
 
-            private const DISPATCH_FUNCTIONS = ['dispatch'];
+            private const DISPATCH_FUNCTIONS = ['dispatch', 'dispatch_sync'];
 
             public function __construct(
                 array $varTypeMap,
@@ -449,6 +449,22 @@ class MethodTracer
                     && $node->var->name === 'this'
                 ) {
                     $this->handleAuthorize($node);
+
+                    return;
+                }
+
+                // $this->dispatch(new Job) / $this->dispatchSync(new Job) — DispatchesJobs trait.
+                if (in_array($method, ['dispatch', 'dispatchSync'], true)
+                    && $node->var instanceof Node\Expr\Variable
+                    && $node->var->name === 'this'
+                ) {
+                    $jobClass = $this->extractNewClass($node->args[0] ?? null);
+                    if ($jobClass !== null) {
+                        $jobFqcn = $this->useMap[$jobClass] ?? $jobClass;
+                        if ($this->looksLikeJob($jobFqcn)) {
+                            $this->hops[] = ['fqcn' => $jobFqcn, 'method' => 'handle', 'type' => 'job', 'visibility' => 'public'];
+                        }
+                    }
 
                     return;
                 }

--- a/tests/Unit/MethodTracerDispatchHelpersTest.php
+++ b/tests/Unit/MethodTracerDispatchHelpersTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use LaraMint\LaravelBrain\Analysis\MethodTracer;
+
+it('traces $this->dispatch(), $this->dispatchSync() and dispatch_sync() job dispatches', function () {
+    $root = fixture('laravel-project');
+    $psr4 = ['App\\' => [$root.'/app']];
+
+    $edges = (new MethodTracer)->traceMethod('App\Services\QueueDispatcher', 'run', $psr4, $root);
+
+    $jobTargets = array_map(
+        fn ($edge) => $edge->calleeFqcn,
+        array_filter($edges, fn ($edge) => $edge->type === 'job'),
+    );
+
+    // QueueDispatcher::run() dispatches these via the DispatchesJobs trait and the dispatch_sync() helper.
+    expect($jobTargets)
+        ->toContain('App\Jobs\ProcessReport')    // $this->dispatch(new ProcessReport)
+        ->toContain('App\Jobs\SyncInventory')     // $this->dispatchSync(new SyncInventory)
+        ->toContain('App\Jobs\RebuildCache');     // dispatch_sync(new RebuildCache)
+});

--- a/tests/fixtures/laravel-project/app/Services/QueueDispatcher.php
+++ b/tests/fixtures/laravel-project/app/Services/QueueDispatcher.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Services;
+
+use App\Jobs\ProcessReport;
+use App\Jobs\RebuildCache;
+use App\Jobs\SyncInventory;
+
+class QueueDispatcher
+{
+    public function run(): void
+    {
+        $this->dispatch(new ProcessReport);
+        $this->dispatchSync(new SyncInventory);
+        dispatch_sync(new RebuildCache);
+    }
+}


### PR DESCRIPTION
`MethodTracer` already maps the `dispatch()` helper and `Job::dispatch()`, but two common dispatch shapes aren't recognised, so the jobs they send don't appear in the graph:

- **`$this->dispatch(new Job)` / `$this->dispatchSync(new Job)`** — the `DispatchesJobs` trait form (controllers, etc.)
- **`dispatch_sync(new Job)`** — the synchronous global helper (sibling of `dispatch()`)

This adds both, plus the matching labels in `FlowExtractor` so the flow diagram stays in sync with the graph.

It stays consistent with the existing dispatch detection:

- Same hop shape (`'type' => 'job'`, `'method' => 'handle'`), so it flows straight into the current job-node / `dispatches`-edge handling — no downstream changes.
- Same `looksLikeJob` gate the existing `dispatch()` helper and `Job::dispatch()` already use, so a class is treated as a job by the same rule everywhere.
- The instance form is restricted to `$this->` (not an arbitrary `$obj->dispatch(...)`) to avoid false positives on unrelated `dispatch()` methods.

As with the existing detectors, only literal `new Job()` arguments are resolved — a job held in a variable isn't.

Tests and a fixture are included; the full suite (Pint, Pest, PHPStan) is green.
