### PR TITLE
Link dispatched events to their listeners

### DIFF
--- a/config/laravel-brain.php
+++ b/config/laravel-brain.php
@@ -137,6 +137,19 @@ return [
     ],
 
     // -------------------------------------------------------------------------
+    // Event Listeners
+    // -------------------------------------------------------------------------
+    // Directories (relative to project root) scanned for listener classes.
+    // A class whose handle() type-hints an event in its first parameter is
+    // linked to that event, so the graph shows what runs when it dispatches.
+    //
+    'listeners' => [
+        'paths' => [
+            'app/Listeners',
+        ],
+    ],
+
+    // -------------------------------------------------------------------------
     // Command Entry Points
     // -------------------------------------------------------------------------
     // Laravel commands are registered through three distinct entry points.

--- a/src/Analysis/ListenerAnalyzer.php
+++ b/src/Analysis/ListenerAnalyzer.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaraMint\LaravelBrain\Analysis;
+
+use LaraMint\LaravelBrain\Parser\PhpFileParser;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * Links dispatched events to the listeners that handle them.
+ *
+ * This pass discovers listeners by convention: a class under the configured
+ * listener directories whose `handle()` type-hints an event in its first
+ * parameter is treated as a listener for that event. It emits one
+ * event → listener CallChainEdge per discovered pairing, so the graph can
+ * answer "what runs when this event is dispatched".
+ *
+ * Other registration sources ($listen arrays, subscribers, attributes) are
+ * intentionally out of scope here and handled as follow-ups.
+ */
+class ListenerAnalyzer
+{
+    private PhpFileParser $parser;
+
+    /** @var string[] directories (relative to project root) to scan for listeners */
+    private array $listenerPaths;
+
+    /**
+     * @param  string[]  $listenerPaths
+     */
+    public function __construct(array $listenerPaths = ['app/Listeners'])
+    {
+        $this->parser = new PhpFileParser;
+        $this->listenerPaths = $listenerPaths !== [] ? $listenerPaths : ['app/Listeners'];
+    }
+
+    /**
+     * @return CallChainEdge[] event → listener edges
+     */
+    public function analyze(string $projectRoot): array
+    {
+        return $this->discoverByConvention($projectRoot);
+    }
+
+    /**
+     * @return CallChainEdge[]
+     */
+    private function discoverByConvention(string $projectRoot): array
+    {
+        $edges = [];
+
+        foreach ($this->listenerPaths as $relativePath) {
+            $basePath = rtrim($projectRoot, '/').'/'.ltrim($relativePath, '/');
+            if (! is_dir($basePath)) {
+                continue;
+            }
+
+            $it = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($basePath, \FilesystemIterator::SKIP_DOTS)
+            );
+            foreach ($it as $fileInfo) {
+                if (! $fileInfo->isFile() || $fileInfo->getExtension() !== 'php') {
+                    continue;
+                }
+                $pairing = $this->pairingFromFile($fileInfo->getPathname());
+                if ($pairing !== null) {
+                    [$eventFqcn, $listenerFqcn] = $pairing;
+                    $edges[] = new CallChainEdge(
+                        callerFqcn: $eventFqcn,
+                        callerMethod: '__construct',
+                        calleeFqcn: $listenerFqcn,
+                        calleeMethod: 'handle',
+                        type: 'listener',
+                    );
+                }
+            }
+        }
+
+        return $edges;
+    }
+
+    /**
+     * @return array{0: string, 1: string}|null [eventFqcn, listenerFqcn]
+     */
+    private function pairingFromFile(string $file): ?array
+    {
+        $parsed = $this->parser->parse($file);
+        if ($parsed['ast'] === null) {
+            return null;
+        }
+        $useMap = $parsed['useMap'];
+
+        $traverser = new NodeTraverser;
+        $visitor = new class($useMap) extends NodeVisitorAbstract
+        {
+            public ?string $listenerFqcn = null;
+
+            public ?string $eventFqcn = null;
+
+            private array $useMap;
+
+            private string $namespace = '';
+
+            public function __construct(array $useMap)
+            {
+                $this->useMap = $useMap;
+            }
+
+            public function enterNode(Node $node): ?int
+            {
+                if ($node instanceof Node\Stmt\Namespace_ && $node->name !== null) {
+                    $this->namespace = $node->name->toString();
+                }
+                if ($node instanceof Node\Stmt\Class_ && $node->name !== null) {
+                    $this->listenerFqcn = $this->namespace !== ''
+                        ? $this->namespace.'\\'.$node->name->toString()
+                        : $node->name->toString();
+                }
+                if ($node instanceof Node\Stmt\ClassMethod
+                    && in_array($node->name->toString(), ['handle', '__invoke'], true)) {
+                    $param = $node->params[0] ?? null;
+                    if ($param !== null && $param->type instanceof Node\Name) {
+                        $this->eventFqcn = $this->resolve($param->type->toString());
+                    }
+                }
+
+                return null;
+            }
+
+            private function resolve(string $name): string
+            {
+                if (isset($this->useMap[$name])) {
+                    return $this->useMap[$name];
+                }
+                if (str_contains($name, '\\')) {
+                    return ltrim($name, '\\');
+                }
+
+                return ($this->namespace !== '' ? $this->namespace.'\\' : '').$name;
+            }
+        };
+
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($parsed['ast']);
+
+        if ($visitor->listenerFqcn === null || $visitor->eventFqcn === null) {
+            return null;
+        }
+
+        return [$visitor->eventFqcn, $visitor->listenerFqcn];
+    }
+}

--- a/src/Analysis/ProjectAnalyzer.php
+++ b/src/Analysis/ProjectAnalyzer.php
@@ -43,6 +43,8 @@ class ProjectAnalyzer
 
     private ChannelAnalyzer $channelAnalyzer;
 
+    private ListenerAnalyzer $listenerAnalyzer;
+
     private FilamentAnalyzer $filamentAnalyzer;
 
     private QueryTracer $queryTracer;
@@ -65,6 +67,9 @@ class ProjectAnalyzer
 
         $channelPaths = config('laravel-brain.channel_paths', ['routes/*/*.php']);
         $this->channelAnalyzer = new ChannelAnalyzer($channelPaths);
+
+        $listenerPaths = config('laravel-brain.listeners.paths', ['app/Listeners']);
+        $this->listenerAnalyzer = new ListenerAnalyzer(is_array($listenerPaths) ? $listenerPaths : []);
 
         $cmdConfig = config('laravel-brain.commands', []);
         $this->consoleAnalyzer = new ConsoleAnalyzer(
@@ -141,6 +146,11 @@ class ProjectAnalyzer
             foreach ($closureEdges as $edge) {
                 $callChain[] = $edge;
             }
+        }
+
+        // Link dispatched events to the listeners that handle them (discovered by convention).
+        foreach ($this->listenerAnalyzer->analyze($projectRoot) as $edge) {
+            $callChain[] = $edge;
         }
 
         $this->emit('step:done', ['step' => 'lifecycle', 'count' => count($callChain), 'unit' => 'call edge', 'message' => '    Discovered '.count($callChain).' call chain edge(s)']);

--- a/src/Graph/GraphBuilder.php
+++ b/src/Graph/GraphBuilder.php
@@ -716,6 +716,20 @@ class GraphBuilder
                 ]));
                 break;
 
+            case 'listener':
+                $short = class_basename($fqcn);
+                $file = $this->resolveFile($fqcn);
+                $flowSteps = $method ? $this->extractMethodFlowSteps($fqcn, $method) : [];
+                $this->graph->addNode(new Node($id, 'listener', $method ? "{$short}@{$method}" : $short, [
+                    'fqcn' => $fqcn,
+                    'method' => $method,
+                    'file' => $file,
+                    'flowSteps' => $flowSteps,
+                    'visibility' => 'public',
+                    ...($this->hasN1InSteps($flowSteps) ? ['hasN1' => true] : []),
+                ]));
+                break;
+
             case 'repository':
                 $short = class_basename($fqcn);
                 $file = $this->resolveFile($fqcn);
@@ -865,6 +879,9 @@ class GraphBuilder
         if ($this->looksLikeNotificationFqcn($fqcn)) {
             return 'notification';
         }
+        if (str_contains($fqcn, '\\Listeners\\')) {
+            return 'listener';
+        }
         if (str_contains($fqcn, 'Repository') || str_contains($fqcn, '\\Repositories\\')) {
             return 'repository';
         }
@@ -908,6 +925,7 @@ class GraphBuilder
             'model' => 'queries',
             'job' => 'dispatches',
             'event' => 'dispatches',
+            'listener' => 'handled by',
             'repository' => 'calls',
             'validation_request' => 'validates',
             'view' => 'renders',

--- a/tests/Unit/ListenerAnalyzerTest.php
+++ b/tests/Unit/ListenerAnalyzerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use LaraMint\LaravelBrain\Analysis\ControllerAnalyzer;
+use LaraMint\LaravelBrain\Analysis\ListenerAnalyzer;
+use LaraMint\LaravelBrain\Analysis\MethodTracer;
+use LaraMint\LaravelBrain\Analysis\MiddlewareRegistry;
+use LaraMint\LaravelBrain\Analysis\RouteAnalyzer;
+use LaraMint\LaravelBrain\Graph\GraphBuilder;
+
+it('discovers an event → listener edge by convention', function () {
+    $edges = (new ListenerAnalyzer)->analyze(fixture('laravel-project'));
+
+    $match = array_values(array_filter(
+        $edges,
+        fn ($e) => $e->calleeFqcn === 'App\\Listeners\\HandleUserLoggedIn'
+    ));
+
+    expect($match)->toHaveCount(1);
+    expect($match[0])
+        ->callerFqcn->toBe('App\\Events\\UserLoggedIn')
+        ->callerMethod->toBe('__construct')
+        ->calleeMethod->toBe('handle')
+        ->type->toBe('listener');
+});
+
+it('discovers an invokable listener', function () {
+    $edges = (new ListenerAnalyzer)->analyze(fixture('laravel-project'));
+
+    $match = array_values(array_filter(
+        $edges,
+        fn ($e) => $e->calleeFqcn === 'App\\Listeners\\LogUserLoggedIn'
+    ));
+
+    expect($match)->toHaveCount(1);
+    expect($match[0])
+        ->callerFqcn->toBe('App\\Events\\UserLoggedIn')
+        ->type->toBe('listener');
+});
+
+it('connects a dispatched event to its listener in the graph', function () {
+    $project = fixture('laravel-project');
+    $routes = (new RouteAnalyzer)->analyze($project);
+    $controllers = (new ControllerAnalyzer)->analyze($project, $routes);
+    $traces = (new MethodTracer)->trace($controllers);
+    $traces = array_merge($traces, (new ListenerAnalyzer)->analyze($project));
+
+    $graph = (new GraphBuilder)->build('test', $routes, new MiddlewareRegistry([], [], []), $controllers, $traces, []);
+
+    $listenerNodes = array_filter($graph->nodes(), fn ($n) => $n->type === 'listener');
+    expect($listenerNodes)->not->toBeEmpty();
+
+    $listenerNode = array_values($listenerNodes)[0];
+    $edge = array_values(array_filter(
+        $graph->edges(),
+        fn ($e) => $e->target === $listenerNode->id
+    ));
+
+    expect($edge)->not->toBeEmpty();
+    expect($edge[0]->label)->toBe('handled by');
+});

--- a/tests/fixtures/laravel-project/app/Listeners/HandleUserLoggedIn.php
+++ b/tests/fixtures/laravel-project/app/Listeners/HandleUserLoggedIn.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\UserLoggedIn;
+
+class HandleUserLoggedIn
+{
+    public function handle(UserLoggedIn $event): void
+    {
+    }
+}

--- a/tests/fixtures/laravel-project/app/Listeners/HandleUserLoggedIn.php
+++ b/tests/fixtures/laravel-project/app/Listeners/HandleUserLoggedIn.php
@@ -6,7 +6,5 @@ use App\Events\UserLoggedIn;
 
 class HandleUserLoggedIn
 {
-    public function handle(UserLoggedIn $event): void
-    {
-    }
+    public function handle(UserLoggedIn $event): void {}
 }

--- a/tests/fixtures/laravel-project/app/Listeners/LogUserLoggedIn.php
+++ b/tests/fixtures/laravel-project/app/Listeners/LogUserLoggedIn.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\UserLoggedIn;
+
+class LogUserLoggedIn
+{
+    public function __invoke(UserLoggedIn $event): void
+    {
+    }
+}

--- a/tests/fixtures/laravel-project/app/Listeners/LogUserLoggedIn.php
+++ b/tests/fixtures/laravel-project/app/Listeners/LogUserLoggedIn.php
@@ -6,7 +6,5 @@ use App\Events\UserLoggedIn;
 
 class LogUserLoggedIn
 {
-    public function __invoke(UserLoggedIn $event): void
-    {
-    }
+    public function __invoke(UserLoggedIn $event): void {}
 }


### PR DESCRIPTION
## What

Brain links event *dispatches* (`event(new X)`, `Event::dispatch`) to event nodes, but never to the listeners that handle them — so the graph can't answer "what actually runs when this event fires". This adds that link.

A new `ListenerAnalyzer` discovers listeners **by convention**: a class under the configured listener directories (default `app/Listeners`) whose `handle()` or `__invoke()` type-hints an event in its first parameter is treated as a listener for that event. Each pairing emits one `event → listener` edge.

## How

- The edge rides the **existing** `$callChain` (`CallChainEdge[]`) channel into `GraphBuilder::build()` — no signature change. The edge's caller is the event FQCN (method `__construct`), which maps onto the same event node a dispatch creates, so the listener connects to the existing event rather than spawning a duplicate.
- Adds a `listener` node type and a `handled by` edge label, mirroring the existing `event`/`job` cases.
- Adds a `listeners.paths` config block, consistent with `channel_paths` / `commands` / `models`.

## Scope (deliberately narrow)

- **Auto-discovery only.** `$listen` arrays, subscribers, and `#[AsEventListener]` attributes are out of scope here — a natural follow-up that plugs into the same analyzer.
- The edge connects where the event is dispatched in traced code (the impact-analysis case). A listener for an event that's never dispatched stays an isolated node.

## Tests

`tests/Unit/ListenerAnalyzerTest.php`:
- discovers the `event → listener` edge by convention (correct caller/callee/method/type)
- discovers an invokable (`__invoke`) listener
- end-to-end: the fixture's `event(new UserLoggedIn)` dispatch connects to its listener in the built graph with a `handled by` edge

Full suite green, PHPStan clean, Pint clean.
