### PR TITLE
Detect unresolved job dispatches and support custom dispatch helpers

### DIFF
--- a/config/laravel-brain.php
+++ b/config/laravel-brain.php
@@ -180,6 +180,18 @@ return [
     ],
 
     // -------------------------------------------------------------------------
+    // Job Dispatch
+    // -------------------------------------------------------------------------
+    // Brain resolves the built-in dispatch verbs (dispatch(), dispatch_sync(),
+    // Job::dispatch(), Bus::dispatch/chain/batch, $this->dispatch). List any
+    // custom global helper that wraps a queued job here so its dispatches are
+    // followed too, e.g. a project's own dispatch_with_retries().
+    //
+    'dispatch' => [
+        'helpers' => [],
+    ],
+
+    // -------------------------------------------------------------------------
     // Event Listeners
     // -------------------------------------------------------------------------
     // Directories (relative to project root) scanned for listener classes.

--- a/src/Analysis/MethodTracer.php
+++ b/src/Analysis/MethodTracer.php
@@ -68,10 +68,46 @@ class MethodTracer
     /** @var array<string, 'enum'|'interface'|'trait'|'abstract_class'|null> */
     private array $declKindCache = [];
 
-    public function __construct()
+    /** Marker hop type for a dispatch verb whose job argument can't be resolved statically. */
+    public const UNRESOLVED_DISPATCH = 'unresolved-dispatch';
+
+    /** @var string[] extra global dispatch helper names beyond dispatch()/dispatch_sync() */
+    private array $extraDispatchHelpers;
+
+    /** @var array<string, true> "FQCN::method" of methods with an unresolvable dispatch */
+    private array $unresolvedDispatchers = [];
+
+    /**
+     * @param  string[]  $extraDispatchHelpers  custom dispatch helpers (e.g. dispatch_with_retries)
+     *                                          that wrap a queued job, treated like dispatch().
+     */
+    public function __construct(array $extraDispatchHelpers = [])
     {
         $this->parser = new PhpFileParser;
         $this->structureInspector = new PhpStructureInspector($this->parser);
+        $this->extraDispatchHelpers = array_values(array_filter(
+            $extraDispatchHelpers,
+            static fn ($name): bool => is_string($name) && $name !== '',
+        ));
+    }
+
+    /**
+     * Methods that dispatch a job Brain couldn't resolve statically (the job is a
+     * variable, factory result, or other non-literal). Lets a consumer mark such a
+     * dispatcher as "may reach unknown jobs" rather than "reaches none".
+     *
+     * @return string[] "FQCN::method"
+     */
+    public function unresolvedDispatchers(): array
+    {
+        return array_keys($this->unresolvedDispatchers);
+    }
+
+    private function recordUnresolvedDispatch(string $callerFqcn, string $callerMethod): void
+    {
+        if ($callerFqcn !== '' && $callerMethod !== '') {
+            $this->unresolvedDispatchers[$callerFqcn.'::'.$callerMethod] = true;
+        }
     }
 
     /**
@@ -116,6 +152,11 @@ class MethodTracer
 
         $edges = [];
         foreach ($discovered as $hop) {
+            if ($hop['type'] === self::UNRESOLVED_DISPATCH) {
+                $this->recordUnresolvedDispatch($callerFqcn, '__invoke');
+
+                continue;
+            }
             $edges[] = new CallChainEdge(
                 callerFqcn: $callerFqcn,
                 callerMethod: '__invoke',
@@ -148,6 +189,9 @@ class MethodTracer
         $this->projectRoot = $projectRoot;
         $this->visited = [];
         $this->classCache = [];
+        // NB: unresolvedDispatchers is NOT reset here. trace() runs more than once per analysis
+        // (controllers, then Filament pages), and like the returned edges the signal must
+        // accumulate across every call for the tracer's lifetime, not be wiped by the second run.
 
         $edges = [];
 
@@ -177,6 +221,11 @@ class MethodTracer
                 );
 
                 foreach ($discovered as $hop) {
+                    if ($hop['type'] === self::UNRESOLVED_DISPATCH) {
+                        $this->recordUnresolvedDispatch($controller->fqcn, $methodDef->name);
+
+                        continue;
+                    }
                     $edges[] = new CallChainEdge(
                         callerFqcn: $controller->fqcn,
                         callerMethod: $methodDef->name,
@@ -264,6 +313,11 @@ class MethodTracer
 
         $edges = [];
         foreach ($discovered as $hop) {
+            if ($hop['type'] === self::UNRESOLVED_DISPATCH) {
+                $this->recordUnresolvedDispatch($fqcn, $method);
+
+                continue;
+            }
             $edges[] = new CallChainEdge(
                 callerFqcn: $fqcn,
                 callerMethod: $method,
@@ -297,7 +351,9 @@ class MethodTracer
     ): array {
         $traverser = new NodeTraverser;
 
-        $visitor = new class($varTypeMap, $useMap, $currentFqcn, $parentFqcn, $this) extends NodeVisitorAbstract
+        $dispatchFunctions = array_values(array_unique(['dispatch', 'dispatch_sync', ...$this->extraDispatchHelpers]));
+
+        $visitor = new class($varTypeMap, $useMap, $currentFqcn, $parentFqcn, $this, $dispatchFunctions) extends NodeVisitorAbstract
         {
             /** @var list<array{fqcn:string,method:string,type:string,visibility:string}> */
             public array $hops = [];
@@ -314,19 +370,45 @@ class MethodTracer
 
             private const EVENT_FUNCTIONS = ['event'];
 
-            private const DISPATCH_FUNCTIONS = ['dispatch', 'dispatch_sync'];
+            /** @var string[] global dispatch helpers: built-in plus any configured extras */
+            private array $dispatchFunctions;
 
+            /**
+             * @param  string[]  $dispatchFunctions
+             */
             public function __construct(
                 array $varTypeMap,
                 array $useMap,
                 string $currentFqcn,
                 ?string $parentFqcn,
                 private MethodTracer $tracer,
+                array $dispatchFunctions = ['dispatch', 'dispatch_sync'],
             ) {
                 $this->varTypeMap = $varTypeMap;
                 $this->useMap = $useMap;
                 $this->currentFqcn = $currentFqcn;
                 $this->parentFqcn = $parentFqcn;
+                $this->dispatchFunctions = $dispatchFunctions;
+            }
+
+            private function markUnresolvedDispatch(): void
+            {
+                $this->hops[] = ['fqcn' => '', 'method' => '', 'type' => MethodTracer::UNRESOLVED_DISPATCH, 'visibility' => 'public'];
+            }
+
+            /**
+             * True when a dispatch argument is a job we couldn't read statically (a variable, property,
+             * or factory call) rather than nothing, or a string/array literal. A string/array first
+             * argument means an event dispatch ($this->dispatch('saved', ...) in Livewire/Filament),
+             * not a queued job, so it must not be reported as an unresolved job dispatch.
+             */
+            private function isOpaqueJobArg(?Node $arg): bool
+            {
+                $value = $arg instanceof Node\Arg ? $arg->value : $arg;
+
+                return $value !== null
+                    && ! $value instanceof Node\Scalar\String_
+                    && ! $value instanceof Node\Expr\Array_;
             }
 
             public function enterNode(Node $node): ?int
@@ -399,9 +481,11 @@ class MethodTracer
                 // and the array forms Bus::chain([new A, new B]) / Bus::batch([new A, new B]).
                 if (in_array($class, ['Bus', 'Illuminate\\Support\\Facades\\Bus'], true)
                     && in_array($method, ['dispatch', 'dispatchSync', 'chain', 'batch'], true)) {
-                    $jobClasses = in_array($method, ['chain', 'batch'], true)
-                        ? $this->extractNewClassesFromArray($node->args[0] ?? null)
-                        : array_filter([$this->extractNewClass($node->args[0] ?? null)]);
+                    $arg = $node->args[0] ?? null;
+                    $isGroup = in_array($method, ['chain', 'batch'], true);
+                    $jobClasses = $isGroup
+                        ? $this->extractNewClassesFromArray($arg)
+                        : array_filter([$this->extractNewClass($arg)]);
 
                     foreach ($jobClasses as $jobClass) {
                         $this->hops[] = [
@@ -410,6 +494,10 @@ class MethodTracer
                             'type' => 'job',
                             'visibility' => 'public',
                         ];
+                    }
+
+                    if ($this->busDispatchIsUnresolved($arg, $isGroup, count($jobClasses))) {
+                        $this->markUnresolvedDispatch();
                     }
 
                     return;
@@ -478,12 +566,17 @@ class MethodTracer
                     && $node->var instanceof Node\Expr\Variable
                     && $node->var->name === 'this'
                 ) {
-                    $jobClass = $this->extractNewClass($node->args[0] ?? null);
+                    $arg = $node->args[0] ?? null;
+                    $jobClass = $this->extractNewClass($arg);
                     if ($jobClass !== null) {
                         $jobFqcn = $this->useMap[$jobClass] ?? $jobClass;
                         if ($this->looksLikeJob($jobFqcn)) {
                             $this->hops[] = ['fqcn' => $jobFqcn, 'method' => 'handle', 'type' => 'job', 'visibility' => 'public'];
                         }
+                    } elseif ($this->isOpaqueJobArg($arg)) {
+                        // $this->dispatch($job) with a non-literal job — unresolved. A string/array arg is
+                        // a Livewire/Filament event dispatch, not a job, so isOpaqueJobArg() excludes it.
+                        $this->markUnresolvedDispatch();
                     }
 
                     return;
@@ -579,13 +672,17 @@ class MethodTracer
                             'visibility' => 'public',
                         ];
                     }
-                } elseif (in_array($funcName, self::DISPATCH_FUNCTIONS, true)) {
-                    $jobClass = $this->extractNewClass($node->args[0] ?? null);
-                    if ($jobClass) {
+                } elseif (in_array($funcName, $this->dispatchFunctions, true)) {
+                    $arg = $node->args[0] ?? null;
+                    $jobClass = $this->extractNewClass($arg);
+                    if ($jobClass !== null) {
                         $jobFqcn = $this->useMap[$jobClass] ?? $jobClass;
                         if ($this->looksLikeJob($jobFqcn)) {
                             $this->hops[] = ['fqcn' => $jobFqcn, 'method' => 'handle', 'type' => 'job', 'visibility' => 'public'];
                         }
+                    } elseif ($this->isOpaqueJobArg($arg)) {
+                        // A dispatch verb whose job is a variable / factory result, not a literal new — unresolved.
+                        $this->markUnresolvedDispatch();
                     }
                 }
             }
@@ -793,6 +890,27 @@ class MethodTracer
                 }
 
                 return null;
+            }
+
+            /**
+             * A Bus dispatch is unresolved when its job argument isn't a literal Brain can read:
+             * a single dispatch whose argument isn't `new Job`, or a chain/batch whose argument
+             * isn't an array literal or contains a non-literal entry. A no-arg call isn't a dispatch.
+             */
+            private function busDispatchIsUnresolved(?Node $arg, bool $isGroup, int $resolvedCount): bool
+            {
+                $value = $arg instanceof Node\Arg ? $arg->value : $arg;
+                if ($value === null) {
+                    return false;
+                }
+                if (! $isGroup) {
+                    return ! $value instanceof Node\Expr\New_;
+                }
+                if (! $value instanceof Node\Expr\Array_) {
+                    return true;
+                }
+
+                return count(array_filter($value->items)) > $resolvedCount;
             }
 
             /**

--- a/src/Analysis/ProjectAnalyzer.php
+++ b/src/Analysis/ProjectAnalyzer.php
@@ -24,6 +24,8 @@ class AnalysisResult
         public int $totalCommands = 0,
         public int $totalChannels = 0,
         public int $totalFilamentResources = 0,
+        /** @var string[] "FQCN::method" of methods that dispatch a job Brain couldn't resolve statically */
+        public array $unresolvedDispatchers = [],
     ) {}
 }
 
@@ -80,7 +82,8 @@ class ProjectAnalyzer
 
         $this->middlewareAnalyzer = new MiddlewareAnalyzer;
         $this->controllerAnalyzer = new ControllerAnalyzer;
-        $this->methodTracer = new MethodTracer;
+        $dispatchHelpers = config('laravel-brain.dispatch.helpers', []);
+        $this->methodTracer = new MethodTracer(is_array($dispatchHelpers) ? $dispatchHelpers : []);
         $modelPaths = config('laravel-brain.models.paths', ['app/Models']);
         $this->modelAnalyzer = new ModelAnalyzer(is_array($modelPaths) ? $modelPaths : []);
         $this->filamentAnalyzer = new FilamentAnalyzer;
@@ -304,6 +307,7 @@ class ProjectAnalyzer
             totalCommands: count($commands),
             totalChannels: count($channels),
             totalFilamentResources: $filamentResourceCount,
+            unresolvedDispatchers: $this->methodTracer->unresolvedDispatchers(),
         );
 
         $this->emit('analysis:done', [

--- a/src/Commands/ScanCommand.php
+++ b/src/Commands/ScanCommand.php
@@ -210,7 +210,7 @@ class ScanCommand extends Command
         if ($verbose) {
             $elapsed = microtime(true) - $totalStart;
             $this->newLine();
-            $this->renderSummary($result->fullGraph->nodeCount(), $result->fullGraph->edgeCount(), $result->totalRoutes, $result->totalCommands, $result->totalChannels, $result->totalFilamentResources, $elapsed);
+            $this->renderSummary($result->fullGraph->nodeCount(), $result->fullGraph->edgeCount(), $result->totalRoutes, $result->totalCommands, $result->totalChannels, $result->totalFilamentResources, count($result->unresolvedDispatchers), $elapsed);
             $url = rtrim(config('app.url', 'http://localhost'), '/').'/_laravel-brain';
             $this->newLine();
             $this->line("  Open the viewer: <fg=cyan;options=bold>{$url}</>");
@@ -328,7 +328,7 @@ class ScanCommand extends Command
         file_put_contents($flagFile, date('Y-m-d H:i:s'));
     }
 
-    private function renderSummary(int $nodes, int $edges, int $routes, int $commands, int $channels, int $filamentResources, float $elapsed): void
+    private function renderSummary(int $nodes, int $edges, int $routes, int $commands, int $channels, int $filamentResources, int $unresolvedDispatchers, float $elapsed): void
     {
         $this->line('  <fg=gray>─────────────────────────────────────────</>');
         $this->line('  <options=bold>Summary</>');
@@ -344,6 +344,10 @@ class ScanCommand extends Command
 
         if ($filamentResources > 0) {
             $rows[] = ['Filament Res.', "<fg=cyan>{$filamentResources}</>"];
+        }
+
+        if ($unresolvedDispatchers > 0) {
+            $rows[] = ['Unresolved disp.', "<fg=yellow>{$unresolvedDispatchers}</>"];
         }
 
         $rows[] = ['Total time', '<fg=yellow>'.number_format($elapsed, 2).'s</>'];

--- a/tests/Unit/MethodTracerUnresolvedDispatchTest.php
+++ b/tests/Unit/MethodTracerUnresolvedDispatchTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use LaraMint\LaravelBrain\Analysis\MethodTracer;
+
+function dynamicDispatcherEdges(MethodTracer $tracer, string $method): array
+{
+    $root = fixture('laravel-project');
+
+    return $tracer->traceMethod('App\Services\DynamicDispatcher', $method, ['App\\' => [$root.'/app']], $root);
+}
+
+function jobTargets(array $edges): array
+{
+    return array_map(
+        fn ($edge) => $edge->calleeFqcn,
+        array_filter($edges, fn ($edge) => $edge->type === 'job'),
+    );
+}
+
+it('reports a method that dispatches a job it cannot resolve statically', function () {
+    $tracer = new MethodTracer;
+    $edges = dynamicDispatcherEdges($tracer, 'run');
+
+    // The literal dispatch is still resolved to a job edge.
+    expect(jobTargets($edges))->toContain('App\Jobs\ProcessReport');
+    // ...and the variable / non-literal dispatches flag the method as unresolved.
+    expect($tracer->unresolvedDispatchers())->toContain('App\Services\DynamicDispatcher::run');
+});
+
+it('resolves the literal job of a partial chain and still flags the opaque entry', function () {
+    $tracer = new MethodTracer;
+    $edges = dynamicDispatcherEdges($tracer, 'chainOnly');
+
+    expect(jobTargets($edges))->toContain('App\Jobs\ProcessReport');
+    expect($tracer->unresolvedDispatchers())->toContain('App\Services\DynamicDispatcher::chainOnly');
+});
+
+it('flags a single Bus::dispatch of an opaque job', function () {
+    $tracer = new MethodTracer;
+    dynamicDispatcherEdges($tracer, 'busSingle');
+
+    expect($tracer->unresolvedDispatchers())->toContain('App\Services\DynamicDispatcher::busSingle');
+});
+
+it('does not flag Livewire-style event dispatches or no-arg calls', function () {
+    $tracer = new MethodTracer;
+    dynamicDispatcherEdges($tracer, 'livewireEvents');
+
+    expect($tracer->unresolvedDispatchers())->not->toContain('App\Services\DynamicDispatcher::livewireEvents');
+});
+
+it('never emits the unresolved marker as a real edge', function () {
+    $tracer = new MethodTracer;
+    $edges = dynamicDispatcherEdges($tracer, 'run');
+
+    expect(array_filter($edges, fn ($e) => $e->type === MethodTracer::UNRESOLVED_DISPATCH))->toBe([]);
+    expect(array_filter($edges, fn ($e) => $e->calleeFqcn === ''))->toBe([]);
+});
+
+it('does not flag a fully-resolved dispatcher as unresolved', function () {
+    $root = fixture('laravel-project');
+    $tracer = new MethodTracer;
+    $tracer->traceMethod('App\Services\QueueDispatcher', 'run', ['App\\' => [$root.'/app']], $root);
+
+    expect($tracer->unresolvedDispatchers())->not->toContain('App\Services\QueueDispatcher::run');
+});
+
+it('accumulates unresolved dispatchers across traceMethod calls', function () {
+    $tracer = new MethodTracer;
+    dynamicDispatcherEdges($tracer, 'run');
+    dynamicDispatcherEdges($tracer, 'busSingle');
+
+    expect($tracer->unresolvedDispatchers())
+        ->toContain('App\Services\DynamicDispatcher::run')
+        ->toContain('App\Services\DynamicDispatcher::busSingle');
+});
+
+it('resolves and flags a configured custom dispatch helper', function () {
+    $configured = new MethodTracer(['dispatch_with_retries']);
+    $edges = dynamicDispatcherEdges($configured, 'withRetries');
+
+    expect(jobTargets($edges))->toContain('App\Jobs\ProcessReport');
+    expect($configured->unresolvedDispatchers())->toContain('App\Services\DynamicDispatcher::withRetries');
+});
+
+it('ignores a custom dispatch helper that is not configured', function () {
+    $default = new MethodTracer;
+    $edges = dynamicDispatcherEdges($default, 'withRetries');
+
+    expect(jobTargets($edges))->not->toContain('App\Jobs\ProcessReport');
+    expect($default->unresolvedDispatchers())->not->toContain('App\Services\DynamicDispatcher::withRetries');
+});

--- a/tests/fixtures/laravel-project/app/Services/DynamicDispatcher.php
+++ b/tests/fixtures/laravel-project/app/Services/DynamicDispatcher.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Services;
+
+use App\Jobs\ProcessReport;
+use Illuminate\Support\Facades\Bus;
+
+class DynamicDispatcher
+{
+    public function run($job): void
+    {
+        dispatch(new ProcessReport);  // resolved (control)
+        dispatch($job);               // unresolved: variable
+        $this->dispatch($job);        // unresolved: $this->dispatch variable
+        Bus::batch($this->pending()); // unresolved: non-array argument
+    }
+
+    // The only dispatch is a partially-resolvable chain: one literal job + one opaque entry.
+    public function chainOnly($job): void
+    {
+        Bus::chain([new ProcessReport, $job]);
+    }
+
+    // The only dispatch is a single Bus::dispatch of an opaque job.
+    public function busSingle($job): void
+    {
+        Bus::dispatch($job);
+    }
+
+    // Livewire/Filament event dispatches — string/array first arg, NOT queued jobs.
+    public function livewireEvents(): void
+    {
+        $this->dispatch('saved');
+        $this->dispatch('refresh', id: 1);
+        dispatch();
+    }
+
+    public function withRetries($job): void
+    {
+        dispatch_with_retries(new ProcessReport); // resolved only when helper is configured
+        dispatch_with_retries($job);              // unresolved only when helper is configured
+    }
+
+    private function pending(): array
+    {
+        return [];
+    }
+}


### PR DESCRIPTION
## What

Companion to #52 / #53 (job-dispatch detection). Two gaps remain after those PRs:

1. Brain resolves a *literal* dispatch (`dispatch(new Job)`, `Bus::dispatch(...)`) but emits nothing when the job is a variable or factory result — so a job reachable only through such a dispatch shows as "no impact" rather than "unknown".
2. Custom global dispatch helpers (e.g. a project's `dispatch_with_retries()`) aren't recognised at all.

## How

- **Unresolved-dispatch reporting.** `MethodTracer` records the dispatcher (`FQCN::method`) whenever a recognised dispatch verb's job argument can't be resolved statically — the global helpers, `$this->dispatch()`/`dispatchSync()`, and `Bus::dispatch`/`dispatchSync`/`chain`/`batch`. Exposed via `MethodTracer::unresolvedDispatchers()` and surfaced on the new additive `AnalysisResult::$unresolvedDispatchers`, so a consumer can mark such a dispatcher "may reach unknown jobs" rather than "reaches none".
- **Configurable dispatch helpers.** A `laravel-brain.dispatch.helpers` config list registers custom global helpers that wrap a queued job, so their dispatches are followed (and their unresolved cases reported) exactly like `dispatch()`.

## Scope

- **Additive only** — no method signature changes; the new `AnalysisResult` field defaults to `[]`. No `GraphBuilder` change: the signal rides on `AnalysisResult`, not as graph nodes/edges.
- The marker is per dispatcher *method*, not per call site: a method with both a resolved and an unresolved dispatch still emits the resolved job edge and is reported once.
- Consistent with #52/#53, `Job::dispatch()` (the class is the job) is always resolved; only verbs whose job *argument* is non-literal count as unresolved.

## Tests

`tests/Unit/MethodTracerUnresolvedDispatchTest.php`:

- reports a method whose `dispatch($var)` / `$this->dispatch($var)` / `Bus::batch($x)` / partial `Bus::chain([new, $x])` can't be resolved, while still emitting the literal job edge
- a fully-resolved dispatcher is not flagged
- a configured custom helper resolves its literal job and flags its unresolved case
- an unconfigured custom helper is ignored

Full Pest suite green, Pint clean. PHPStan is clean on the changed files; the 2 pre-existing `ModelAnalyzer::collectClassParents()` errors on `v2.x` are unrelated to this change.
