### PR TITLE
Discover model observers and link them to their models

### DIFF
--- a/config/laravel-brain.php
+++ b/config/laravel-brain.php
@@ -212,6 +212,26 @@ return [
     ],
 
     // -------------------------------------------------------------------------
+    // Model Observers
+    // -------------------------------------------------------------------------
+    // Model → observer edges are discovered from every registration form:
+    //   - attribute: a model under "model_paths" marked #[ObservedBy(...)];
+    //   - observe(): a Model::observe(Observer::class) call, whether made from a
+    //     provider under "provider_paths" or from the model's own booted()
+    //     via self::observe() / static::observe().
+    // So the graph shows which observer runs on a model's lifecycle events,
+    // however it is wired.
+    //
+    'observers' => [
+        'model_paths' => [
+            'app/Models',
+        ],
+        'provider_paths' => [
+            'app/Providers',
+        ],
+    ],
+
+    // -------------------------------------------------------------------------
     // Command Entry Points
     // -------------------------------------------------------------------------
     // Laravel commands are registered through three distinct entry points.

--- a/src/Analysis/ObserverAnalyzer.php
+++ b/src/Analysis/ObserverAnalyzer.php
@@ -1,0 +1,315 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaraMint\LaravelBrain\Analysis;
+
+use LaraMint\LaravelBrain\Parser\PhpFileParser;
+use PhpParser\Node;
+use PhpParser\NodeFinder;
+
+/**
+ * Links Eloquent models to the observers that watch their lifecycle events.
+ *
+ * Observers are discovered from every way Laravel registers one:
+ *
+ *  - by attribute — a model class marked `#[ObservedBy(Observer::class)]`
+ *                   (or `#[ObservedBy([A::class, B::class])]`);
+ *  - by `observe()` — a `Model::observe(Observer::class)` call, whether made
+ *                     from a service provider's `boot()` (the common form) or
+ *                     from the model's own `booted()` via `self`/`static`.
+ *
+ * Each pairing becomes one model → observer link, so the graph can answer
+ * "what runs when this model is created/updated/deleted", regardless of how
+ * the observer was registered. Tracing the observer's own method bodies
+ * (created/updated/…) is a separate concern handled by the call-chain tracer.
+ *
+ * The `observe()` scan is a static heuristic: any `<Name>::observe(Class::class)`
+ * call is recorded, without confirming the left side is an Eloquent model — the
+ * same pragmatic approach ListenerAnalyzer takes with `$listen`/`$subscribe`.
+ * Only the statically resolvable forms are followed: a `::class` or string
+ * argument; an instance argument (`observe(new Foo)`) or a variable target is
+ * not resolved (and is not statically resolvable in the general case).
+ */
+class ObserverAnalyzer
+{
+    private PhpFileParser $parser;
+
+    private NodeFinder $finder;
+
+    /** @var string[] model directories (relative to project root) scanned for #[ObservedBy] + self::observe() */
+    private array $modelPaths;
+
+    /** @var string[] provider directories (relative to project root) scanned for Model::observe() */
+    private array $providerPaths;
+
+    /**
+     * @param  string[]  $modelPaths
+     * @param  string[]  $providerPaths
+     */
+    public function __construct(array $modelPaths = ['app/Models'], array $providerPaths = ['app/Providers'])
+    {
+        $this->parser = new PhpFileParser;
+        $this->finder = new NodeFinder;
+        $this->modelPaths = $modelPaths !== [] ? $modelPaths : ['app/Models'];
+        $this->providerPaths = $providerPaths !== [] ? $providerPaths : ['app/Providers'];
+    }
+
+    /**
+     * @return array<string, list<string>> model FQCN => observer FQCNs
+     */
+    public function analyze(string $projectRoot): array
+    {
+        $pairs = [];
+        foreach ($this->phpFiles($this->modelPaths, $projectRoot) as $file) {
+            array_push($pairs, ...$this->pairsFromModelFile($file));
+        }
+        foreach ($this->phpFiles($this->providerPaths, $projectRoot) as $file) {
+            array_push($pairs, ...$this->pairsFromProviderFile($file));
+        }
+
+        return $this->group($pairs);
+    }
+
+    /**
+     * `#[ObservedBy]` on the model class, plus any `self`/`static::observe()`
+     * registered inside the model itself (e.g. from `booted()`).
+     *
+     * @return list<array{0: string, 1: string}> [modelFqcn, observerFqcn]
+     */
+    private function pairsFromModelFile(string $file): array
+    {
+        $context = $this->context($file);
+        if ($context === null) {
+            return [];
+        }
+        [$ast, $useMap, $namespace] = $context;
+
+        $class = $this->finder->findFirstInstanceOf($ast, Node\Stmt\Class_::class);
+        if (! $class instanceof Node\Stmt\Class_ || $class->name === null) {
+            return [];
+        }
+        $modelFqcn = $this->qualify($class->name->toString(), $namespace);
+
+        $pairs = [];
+        foreach ($this->observedByObservers($class->attrGroups, $useMap, $namespace) as $observer) {
+            $pairs[] = [$modelFqcn, $observer];
+        }
+        array_push($pairs, ...$this->observeCallPairs($ast, $useMap, $namespace, $modelFqcn));
+
+        return $pairs;
+    }
+
+    /**
+     * `Model::observe(Observer::class)` calls in a service provider.
+     *
+     * @return list<array{0: string, 1: string}> [modelFqcn, observerFqcn]
+     */
+    private function pairsFromProviderFile(string $file): array
+    {
+        $context = $this->context($file);
+        if ($context === null) {
+            return [];
+        }
+        [$ast, $useMap, $namespace] = $context;
+
+        return $this->observeCallPairs($ast, $useMap, $namespace, null);
+    }
+
+    /**
+     * Find every `<Model>::observe(...)` static call in an AST and resolve it to
+     * [modelFqcn, observerFqcn] pairs. When the call target is `self`/`static`
+     * the model is $selfFqcn (set when scanning a model file, null otherwise).
+     *
+     * @return list<array{0: string, 1: string}>
+     */
+    private function observeCallPairs(array $ast, array $useMap, string $namespace, ?string $selfFqcn): array
+    {
+        $pairs = [];
+        foreach ($this->finder->findInstanceOf($ast, Node\Expr\StaticCall::class) as $call) {
+            if (! $call->name instanceof Node\Identifier || $call->name->toString() !== 'observe') {
+                continue;
+            }
+            if (! $call->class instanceof Node\Name) {
+                continue;
+            }
+            $model = $this->resolveModelTarget($call->class, $useMap, $namespace, $selfFqcn);
+            if ($model === null) {
+                continue;
+            }
+            $args = $call->getArgs();
+            if (! isset($args[0])) {
+                continue;
+            }
+            foreach ($this->observerRefs($args[0]->value, $useMap, $namespace) as $observer) {
+                $pairs[] = [$model, $observer];
+            }
+        }
+
+        return $pairs;
+    }
+
+    /**
+     * Resolve the class side of a `<Model>::observe()` call to a model FQCN.
+     */
+    private function resolveModelTarget(Node\Name $class, array $useMap, string $namespace, ?string $selfFqcn): ?string
+    {
+        $name = $class->toString();
+        if ($name === 'self' || $name === 'static') {
+            return $selfFqcn;
+        }
+
+        return $this->qualify($name, $namespace, $useMap);
+    }
+
+    /**
+     * Read the observer FQCNs named by `#[ObservedBy]` attributes on a class.
+     *
+     * @param  Node\AttributeGroup[]  $groups
+     * @return list<string>
+     */
+    private function observedByObservers(array $groups, array $useMap, string $namespace): array
+    {
+        $observers = [];
+        foreach ($groups as $group) {
+            foreach ($group->attrs as $attr) {
+                if ($attr->name->getLast() !== 'ObservedBy') {
+                    continue;
+                }
+                $first = $attr->args[0]->value ?? null;
+                if ($first !== null) {
+                    array_push($observers, ...$this->observerRefs($first, $useMap, $namespace));
+                }
+            }
+        }
+
+        return $observers;
+    }
+
+    /**
+     * Resolve an observer argument — a single `Observer::class` or an array of
+     * them — to a list of FQCNs.
+     *
+     * @return list<string>
+     */
+    private function observerRefs(Node\Expr $value, array $useMap, string $namespace): array
+    {
+        if ($value instanceof Node\Expr\Array_) {
+            $refs = [];
+            foreach ($value->items as $item) {
+                if ($item instanceof Node\Expr\ArrayItem) {
+                    $ref = $this->classRef($item->value, $useMap, $namespace);
+                    if ($ref !== null) {
+                        $refs[] = $ref;
+                    }
+                }
+            }
+
+            return $refs;
+        }
+
+        $ref = $this->classRef($value, $useMap, $namespace);
+
+        return $ref === null ? [] : [$ref];
+    }
+
+    /**
+     * Resolve `Observer::class` or a string literal to an FQCN.
+     */
+    private function classRef(Node\Expr $expr, array $useMap, string $namespace): ?string
+    {
+        if ($expr instanceof Node\Expr\ClassConstFetch
+            && $expr->class instanceof Node\Name
+            && $expr->name instanceof Node\Identifier
+            && $expr->name->toString() === 'class') {
+            return $this->qualify($expr->class->toString(), $namespace, $useMap);
+        }
+
+        if ($expr instanceof Node\Scalar\String_) {
+            return ltrim($expr->value, '\\');
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve a (possibly short or aliased) class name to an FQCN.
+     *
+     * @param  array<string, string>  $useMap
+     */
+    private function qualify(string $name, string $namespace, array $useMap = []): string
+    {
+        $name = ltrim($name, '\\');
+        if (isset($useMap[$name])) {
+            return $useMap[$name];
+        }
+        $head = strtok($name, '\\');
+        if ($head !== false && $head !== $name && isset($useMap[$head])) {
+            return $useMap[$head].substr($name, strlen($head));
+        }
+        if (str_contains($name, '\\')) {
+            return $name;
+        }
+
+        return $namespace !== '' ? $namespace.'\\'.$name : $name;
+    }
+
+    /**
+     * @return array{0: Node\Stmt[], 1: array<string, string>, 2: string}|null [ast, useMap, namespace]
+     */
+    private function context(string $file): ?array
+    {
+        $parsed = $this->parser->parse($file);
+        if ($parsed['ast'] === null) {
+            return null;
+        }
+        $namespaceNode = $this->finder->findFirstInstanceOf($parsed['ast'], Node\Stmt\Namespace_::class);
+        $namespace = $namespaceNode instanceof Node\Stmt\Namespace_ && $namespaceNode->name !== null
+            ? $namespaceNode->name->toString()
+            : '';
+
+        return [$parsed['ast'], $parsed['useMap'], $namespace];
+    }
+
+    /**
+     * Group [model, observer] pairs into model => observers, de-duplicating an
+     * observer wired by more than one mechanism.
+     *
+     * @param  list<array{0: string, 1: string}>  $pairs
+     * @return array<string, list<string>>
+     */
+    private function group(array $pairs): array
+    {
+        $map = [];
+        foreach ($pairs as [$model, $observer]) {
+            $map[$model] ??= [];
+            if (! in_array($observer, $map[$model], true)) {
+                $map[$model][] = $observer;
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param  string[]  $relativePaths
+     * @return iterable<string>
+     */
+    private function phpFiles(array $relativePaths, string $projectRoot): iterable
+    {
+        foreach ($relativePaths as $relativePath) {
+            $basePath = rtrim($projectRoot, '/').'/'.ltrim($relativePath, '/');
+            if (! is_dir($basePath)) {
+                continue;
+            }
+            $it = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($basePath, \FilesystemIterator::SKIP_DOTS)
+            );
+            foreach ($it as $fileInfo) {
+                if ($fileInfo->isFile() && $fileInfo->getExtension() === 'php') {
+                    yield $fileInfo->getPathname();
+                }
+            }
+        }
+    }
+}

--- a/src/Analysis/ProjectAnalyzer.php
+++ b/src/Analysis/ProjectAnalyzer.php
@@ -47,6 +47,8 @@ class ProjectAnalyzer
 
     private ListenerAnalyzer $listenerAnalyzer;
 
+    private ObserverAnalyzer $observerAnalyzer;
+
     private FilamentAnalyzer $filamentAnalyzer;
 
     private QueryTracer $queryTracer;
@@ -75,6 +77,13 @@ class ProjectAnalyzer
         $this->listenerAnalyzer = new ListenerAnalyzer(
             is_array($listenerPaths) ? $listenerPaths : [],
             is_array($providerPaths) ? $providerPaths : [],
+        );
+
+        $observerModelPaths = config('laravel-brain.observers.model_paths', ['app/Models']);
+        $observerProviderPaths = config('laravel-brain.observers.provider_paths', ['app/Providers']);
+        $this->observerAnalyzer = new ObserverAnalyzer(
+            is_array($observerModelPaths) ? $observerModelPaths : [],
+            is_array($observerProviderPaths) ? $observerProviderPaths : [],
         );
 
         $cmdConfig = config('laravel-brain.commands', []);
@@ -175,6 +184,11 @@ class ProjectAnalyzer
         $models = $this->modelAnalyzer->analyze($projectRoot, $modelFqcns);
         $this->emit('step:done', ['step' => 'models', 'count' => count($models), 'unit' => 'model', 'message' => '    Found '.count($models).' model(s)']);
 
+        $this->emit('step:start', ['step' => 'observers', 'label' => 'Scanning model observers', 'message' => '  → Scanning model observers...']);
+        $observerMap = $this->observerAnalyzer->analyze($projectRoot);
+        $observerCount = array_sum(array_map('count', $observerMap));
+        $this->emit('step:done', ['step' => 'observers', 'count' => $observerCount, 'unit' => 'observer', 'message' => '    Found '.$observerCount.' model-observer link(s)']);
+
         $this->emit('step:start', ['step' => 'commands', 'label' => 'Scanning console commands', 'message' => '  → Scanning console commands...']);
         $consoleResult = $this->consoleAnalyzer->analyze($projectRoot);
         $commands = $consoleResult['commands'];
@@ -265,6 +279,7 @@ class ProjectAnalyzer
         );
         $this->graphBuilder->addConsoleCommands($commands, $schedules, $commandEdges);
         $this->graphBuilder->addChannels($channels, $channelEdges);
+        $this->graphBuilder->addObservers($observerMap);
         if ($filamentResult['detected']) {
             $this->graphBuilder->addFilament(
                 $filamentResult['panels'],

--- a/src/Graph/GraphBuilder.php
+++ b/src/Graph/GraphBuilder.php
@@ -1792,6 +1792,58 @@ class GraphBuilder
         ]));
     }
 
+    /**
+     * Wire model → observer edges discovered by ObserverAnalyzer. The edge
+     * shares the canonical model node (model::FQCN), so observers sit alongside
+     * the model's fired-event and relationship edges rather than on the mangled
+     * hop node a call chain would create.
+     *
+     * @param  array<string, list<string>>  $observerMap  model FQCN => observer FQCNs
+     */
+    public function addObservers(array $observerMap): void
+    {
+        foreach ($observerMap as $modelFqcn => $observerFqcns) {
+            $modelId = $this->modelId($modelFqcn);
+            if (! $this->graph->hasNode($modelId)) {
+                $this->addModelNode($modelFqcn, null, $modelId);
+            }
+            foreach ($observerFqcns as $observerFqcn) {
+                $observerId = $this->observerId($observerFqcn);
+                $this->addObserverNode($observerFqcn, $observerId);
+                $this->addEdge($modelId, $observerId, 'observed by', 'model-to-observer');
+            }
+        }
+    }
+
+    private function addObserverNode(string $fqcn, string $id): void
+    {
+        if ($this->graph->hasNode($id)) {
+            return;
+        }
+        $short = class_basename($fqcn);
+        $this->graph->addNode(new Node($id, 'observer', $short, [
+            'fqcn' => $fqcn,
+            'file' => $this->resolveFile($fqcn),
+            'members' => $this->observerMembers($fqcn),
+        ]));
+    }
+
+    /**
+     * The Eloquent lifecycle hooks an observer actually implements (created,
+     * updated, deleted, …), so the node can show which events it handles.
+     *
+     * @return list<array{name: string, static: bool, visibility: string}>
+     */
+    private function observerMembers(string $fqcn): array
+    {
+        $file = $this->resolveFile($fqcn);
+        if ($file === '' || ! is_file($file)) {
+            return [];
+        }
+
+        return $this->getStructureInspector()->listClassMethods($file);
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private function resolveMiddlewares(array $middlewares, MiddlewareRegistry $registry): array
@@ -2036,6 +2088,11 @@ class GraphBuilder
     private function eventId(string $fqcn): string
     {
         return "event::{$fqcn}";
+    }
+
+    private function observerId(string $fqcn): string
+    {
+        return "observer::{$fqcn}";
     }
 
     private function filamentPanelId(string $fqcn): string

--- a/tests/Unit/ObserverAnalyzerTest.php
+++ b/tests/Unit/ObserverAnalyzerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+use LaraMint\LaravelBrain\Analysis\MiddlewareRegistry;
+use LaraMint\LaravelBrain\Analysis\ModelAnalyzer;
+use LaraMint\LaravelBrain\Analysis\ObserverAnalyzer;
+use LaraMint\LaravelBrain\Graph\GraphBuilder;
+
+it('discovers an observer registered via a single #[ObservedBy] attribute', function () {
+    $map = (new ObserverAnalyzer)->analyze(fixture('laravel-project'));
+
+    expect($map)->toHaveKey('App\\Models\\Comment');
+    expect($map['App\\Models\\Comment'])->toBe(['App\\Observers\\CommentObserver']);
+});
+
+it('discovers every observer in an #[ObservedBy([...])] array attribute', function () {
+    $map = (new ObserverAnalyzer)->analyze(fixture('laravel-project'));
+
+    expect($map)->toHaveKey('App\\Models\\Product');
+    expect($map['App\\Models\\Product'])
+        ->toContain('App\\Observers\\ProductObserver')
+        ->toContain('App\\Observers\\ProductAuditObserver');
+});
+
+it('discovers an observer registered via Model::observe() in a provider', function () {
+    $map = (new ObserverAnalyzer)->analyze(fixture('laravel-project'));
+
+    expect($map['App\\Models\\Order'] ?? [])->toBe(['App\\Observers\\OrderObserver']);
+});
+
+it('discovers an observer from the array form of Model::observe()', function () {
+    $map = (new ObserverAnalyzer)->analyze(fixture('laravel-project'));
+
+    expect($map['App\\Models\\User'] ?? [])->toBe(['App\\Observers\\UserObserver']);
+});
+
+it('discovers a self/static::observe() call inside the model itself', function () {
+    $map = (new ObserverAnalyzer)->analyze(fixture('laravel-project'));
+
+    expect($map['App\\Models\\Invoice'] ?? [])->toBe(['App\\Observers\\InvoiceObserver']);
+});
+
+it('de-duplicates an observer registered by both #[ObservedBy] and observe()', function () {
+    $map = (new ObserverAnalyzer)->analyze(fixture('laravel-project'));
+
+    $occurrences = array_filter(
+        $map['App\\Models\\Product'],
+        fn ($o) => $o === 'App\\Observers\\ProductObserver'
+    );
+
+    expect($occurrences)->toHaveCount(1);
+});
+
+it('does not invent observers for a model that registers none', function () {
+    $map = (new ObserverAnalyzer)->analyze(fixture('laravel-project'));
+
+    // Order is observed only by OrderObserver — nothing leaks in from other models.
+    expect($map['App\\Models\\Order'])->toBe(['App\\Observers\\OrderObserver']);
+    expect($map)->not->toHaveKey('App\\Models\\NonExistentModel');
+});
+
+it('resolves an aliased #[ObservedBy] import to the real observer FQCN', function () {
+    $map = (new ObserverAnalyzer)->analyze(fixture('laravel-project'));
+
+    expect($map['App\\Models\\Tag'] ?? [])->toContain('App\\Observers\\TagObserver');
+});
+
+it('resolves a string-literal observer reference in observe()', function () {
+    $map = (new ObserverAnalyzer)->analyze(fixture('laravel-project'));
+
+    expect($map['App\\Models\\Tag'] ?? [])->toContain('App\\Observers\\TagAuditObserver');
+});
+
+it('wires a model → observer edge into the graph', function () {
+    $map = (new ObserverAnalyzer)->analyze(fixture('laravel-project'));
+
+    $builder = new GraphBuilder;
+    $graph = $builder->build('test', [], new MiddlewareRegistry([], [], []), [], [], []);
+    $builder->addObservers($map);
+
+    $observerNode = array_values(array_filter(
+        $graph->nodes(),
+        fn ($n) => $n->type === 'observer' && $n->data['fqcn'] === 'App\\Observers\\OrderObserver'
+    ));
+    expect($observerNode)->toHaveCount(1);
+    expect($observerNode[0]->id)->toBe('observer::App\\Observers\\OrderObserver');
+
+    $edge = array_values(array_filter(
+        $graph->edges(),
+        fn ($e) => $e->source === 'model::App\\Models\\Order' && $e->target === $observerNode[0]->id
+    ));
+    expect($edge)->toHaveCount(1);
+    expect($edge[0])
+        ->label->toBe('observed by')
+        ->type->toBe('model-to-observer');
+});
+
+it('hangs the observer edge off the same model node as the fired-event edge', function () {
+    $project = fixture('laravel-project');
+
+    // Order both fires OrderPlaced (via $dispatchesEvents) and is observed by OrderObserver.
+    $models = (new ModelAnalyzer)->analyze($project, ['App\\Models\\Order']);
+    $map = (new ObserverAnalyzer)->analyze($project);
+
+    $builder = new GraphBuilder;
+    $graph = $builder->build('test', [], new MiddlewareRegistry([], [], []), [], [], $models, $project);
+    $builder->addObservers($map);
+
+    $modelNodes = array_filter(
+        $graph->nodes(),
+        fn ($n) => $n->id === 'model::App\\Models\\Order'
+    );
+    expect($modelNodes)->toHaveCount(1);
+
+    $outgoing = array_filter(
+        $graph->edges(),
+        fn ($e) => $e->source === 'model::App\\Models\\Order'
+    );
+    $types = array_map(fn ($e) => $e->type, array_values($outgoing));
+
+    expect($types)
+        ->toContain('model-to-event')
+        ->toContain('model-to-observer');
+});

--- a/tests/fixtures/laravel-project/app/Models/Comment.php
+++ b/tests/fixtures/laravel-project/app/Models/Comment.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use App\Observers\CommentObserver;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Model;
+
+#[ObservedBy(CommentObserver::class)]
+class Comment extends Model
+{
+    protected $fillable = ['body'];
+}

--- a/tests/fixtures/laravel-project/app/Models/Invoice.php
+++ b/tests/fixtures/laravel-project/app/Models/Invoice.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use App\Observers\InvoiceObserver;
+use Illuminate\Database\Eloquent\Model;
+
+class Invoice extends Model
+{
+    protected $fillable = ['total'];
+
+    protected static function booted(): void
+    {
+        static::observe(InvoiceObserver::class);
+    }
+}

--- a/tests/fixtures/laravel-project/app/Models/Product.php
+++ b/tests/fixtures/laravel-project/app/Models/Product.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use App\Observers\ProductAuditObserver;
+use App\Observers\ProductObserver;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Model;
+
+#[ObservedBy([ProductObserver::class, ProductAuditObserver::class])]
+class Product extends Model
+{
+    protected $fillable = ['name'];
+}

--- a/tests/fixtures/laravel-project/app/Models/Tag.php
+++ b/tests/fixtures/laravel-project/app/Models/Tag.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use App\Observers\TagObserver as Watcher;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Model;
+
+#[ObservedBy(Watcher::class)]
+class Tag extends Model
+{
+    protected $fillable = ['name'];
+}

--- a/tests/fixtures/laravel-project/app/Observers/CommentObserver.php
+++ b/tests/fixtures/laravel-project/app/Observers/CommentObserver.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Observers;
+
+class CommentObserver
+{
+    public function created($comment): void {}
+}

--- a/tests/fixtures/laravel-project/app/Observers/InvoiceObserver.php
+++ b/tests/fixtures/laravel-project/app/Observers/InvoiceObserver.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Observers;
+
+class InvoiceObserver
+{
+    public function created($invoice): void {}
+}

--- a/tests/fixtures/laravel-project/app/Observers/OrderObserver.php
+++ b/tests/fixtures/laravel-project/app/Observers/OrderObserver.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Order;
+
+class OrderObserver
+{
+    public function created(Order $order): void {}
+
+    public function updated(Order $order): void {}
+
+    public function deleted(Order $order): void {}
+}

--- a/tests/fixtures/laravel-project/app/Observers/ProductAuditObserver.php
+++ b/tests/fixtures/laravel-project/app/Observers/ProductAuditObserver.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Observers;
+
+class ProductAuditObserver
+{
+    public function saved($product): void {}
+}

--- a/tests/fixtures/laravel-project/app/Observers/ProductObserver.php
+++ b/tests/fixtures/laravel-project/app/Observers/ProductObserver.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Observers;
+
+class ProductObserver
+{
+    public function created($product): void {}
+}

--- a/tests/fixtures/laravel-project/app/Observers/TagAuditObserver.php
+++ b/tests/fixtures/laravel-project/app/Observers/TagAuditObserver.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Observers;
+
+class TagAuditObserver
+{
+    public function saved($tag): void {}
+}

--- a/tests/fixtures/laravel-project/app/Observers/TagObserver.php
+++ b/tests/fixtures/laravel-project/app/Observers/TagObserver.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Observers;
+
+class TagObserver
+{
+    public function created($tag): void {}
+}

--- a/tests/fixtures/laravel-project/app/Observers/UserObserver.php
+++ b/tests/fixtures/laravel-project/app/Observers/UserObserver.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\User;
+
+class UserObserver
+{
+    public function created(User $user): void {}
+}

--- a/tests/fixtures/laravel-project/app/Providers/AppServiceProvider.php
+++ b/tests/fixtures/laravel-project/app/Providers/AppServiceProvider.php
@@ -3,6 +3,13 @@
 namespace App\Providers;
 
 use App\Contracts\ThingRepositoryInterface;
+use App\Models\Order;
+use App\Models\Product;
+use App\Models\Tag;
+use App\Models\User;
+use App\Observers\OrderObserver;
+use App\Observers\ProductObserver;
+use App\Observers\UserObserver;
 use App\Repositories\SqlThingRepository;
 
 class AppServiceProvider
@@ -10,5 +17,17 @@ class AppServiceProvider
     public function register(): void
     {
         $this->app->singleton(ThingRepositoryInterface::class, SqlThingRepository::class);
+    }
+
+    public function boot(): void
+    {
+        Order::observe(OrderObserver::class);
+        User::observe([UserObserver::class]);
+
+        // Also registered via #[ObservedBy] on the model — must de-duplicate to one edge.
+        Product::observe(ProductObserver::class);
+
+        // String-literal observer reference (Tag also has an aliased #[ObservedBy]).
+        Tag::observe('App\\Observers\\TagAuditObserver');
     }
 }


### PR DESCRIPTION
## What

Adds an `ObserverAnalyzer` that maps Eloquent **model → observer** relationships and wires them into the graph as `model-to-observer` ("observed by") edges, parallel to the existing `model-to-event` ("fires") edges. This closes the gap where a model's observers — a core part of "what runs when this model changes" — were invisible to the graph.

## How observers are discovered

Every registration form Laravel supports:

- **Attribute** — a model marked `#[ObservedBy(Observer::class)]` or `#[ObservedBy([A::class, B::class])]`.
- **`observe()` call** — `Model::observe(Observer::class)`, whether from a service provider's `boot()` (the common form) or from the model's own `booted()` via `self::observe()` / `static::observe()`.
- Both the **single-class and array** argument shapes, plus `::class` and **string-literal** observer references and **aliased imports** (resolved through the file's use-map).

An observer wired by more than one mechanism de-duplicates to a single edge.

## Graph wiring

`GraphBuilder::addObservers()` attaches each edge to the canonical `model::{FQCN}` node — the *same* node used by `model-to-event` and `model-relationship` — so observers sit with the rest of a model's edges instead of on a separate mangled hop node. A new `observer` node type carries the observer's lifecycle methods (`created`/`updated`/…) for display.

## Scope & design notes

- Mirrors `ListenerAnalyzer` throughout (AST resolution helpers, dedup, provider scan, configurable paths) — this is the event-listener feature's natural sibling.
- The `observe()` scan is a **static heuristic**: it records any `<Name>::observe(<class-ref>)` without confirming the left side extends `Model`, and only follows statically resolvable arguments (`::class` / string). Instance args (`observe(new Foo)`) and variable targets aren't resolved — the same pragmatic boundary `ListenerAnalyzer` draws for `$listen`/`$subscribe`. Documented in the class docblock.
- **Tracing the observer's own method bodies** (the services/jobs each hook calls) is intentionally left to the existing call-chain tracer — out of scope here.
- Scan paths are configurable via `laravel-brain.observers` (`model_paths` + `provider_paths`).

## Config

```php
'observers' => [
    'model_paths'    => ['app/Models'],
    'provider_paths' => ['app/Providers'],
],
```

## Tests

11 new Pest tests in `ObserverAnalyzerTest`: each registration form (attribute single/array, provider `observe()` single/array, `static::observe()` in `booted()`), aliased import, string-literal ref, dedup, a negative case, the graph-wiring edge, and — the headline guarantee — that a model which **both** fires an event and has an observer carries both edges off a **single** `model::FQCN` node.

Verified: `pint` clean · `phpstan` (level 5 + larastan) **No errors** · full suite **122 passed**. Also dogfooded against a real ~large Laravel app (11 models / 11 observer links discovered, including observers that live outside `app/Observers`, resolved correctly from the attribute FQCN).

> Note: two pre-existing PHPStan items are unrelated to this change. *(none on this branch — full run is clean.)*
