### PR TITLE
Resolve each model's authorization policy and link them in the graph

### DIFF
--- a/config/laravel-brain.php
+++ b/config/laravel-brain.php
@@ -212,6 +212,25 @@ return [
     ],
 
     // -------------------------------------------------------------------------
+    // Authorization Policies
+    // -------------------------------------------------------------------------
+    // Model → policy edges are resolved the way Laravel's Gate resolves a
+    // policy, in precedence order:
+    //   - explicit: an AuthServiceProvider::$policies map or a
+    //     Gate::policy(Model::class, Policy::class) call in a provider under
+    //     "provider_paths";
+    //   - attribute: a model marked #[UsePolicy(Policy::class)];
+    //   - convention: the guessed App\Policies\FooPolicy for App\Models\Foo,
+    //     used only when that policy class exists.
+    // So the graph shows which policy authorizes each model.
+    //
+    'policies' => [
+        'provider_paths' => [
+            'app/Providers',
+        ],
+    ],
+
+    // -------------------------------------------------------------------------
     // Command Entry Points
     // -------------------------------------------------------------------------
     // Laravel commands are registered through three distinct entry points.

--- a/src/Analysis/PolicyAnalyzer.php
+++ b/src/Analysis/PolicyAnalyzer.php
@@ -1,0 +1,361 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaraMint\LaravelBrain\Analysis;
+
+use LaraMint\LaravelBrain\Parser\PhpFileParser;
+use PhpParser\Node;
+use PhpParser\NodeFinder;
+
+/**
+ * Links Eloquent models to the authorization policies that guard them.
+ *
+ * Policies are resolved the same way Laravel's Gate resolves them, in
+ * precedence order:
+ *
+ *  1. explicit registration — an `AuthServiceProvider::$policies` map
+ *     (`Model::class => Policy::class`) or a `Gate::policy(Model::class,
+ *     Policy::class)` call in a service provider;
+ *  2. attribute — a model marked `#[UsePolicy(Policy::class)]`;
+ *  3. convention — the guessed `App\Policies\FooPolicy` for model `App\Models\Foo`,
+ *     used only when that policy class actually exists (mirroring Gate's
+ *     `class_exists` guard, so no edge is invented for a missing policy).
+ *
+ * Each model resolves to at most one policy — the first form that matches —
+ * and becomes one model → policy ("authorized by") edge, so a policy shows up
+ * in the reach of the model it protects. The link is class-level by design:
+ * it answers "what authorizes this model", not which ability maps to which
+ * policy method.
+ */
+class PolicyAnalyzer
+{
+    private const POLICY_ATTRIBUTE = 'UsePolicy';
+
+    private PhpFileParser $parser;
+
+    private NodeFinder $finder;
+
+    /** @var string[] provider directories (relative to project root) scanned for policy registrations */
+    private array $providerPaths;
+
+    /**
+     * @param  string[]  $providerPaths
+     */
+    public function __construct(array $providerPaths = ['app/Providers'])
+    {
+        $this->parser = new PhpFileParser;
+        $this->finder = new NodeFinder;
+        $this->providerPaths = $providerPaths !== [] ? $providerPaths : ['app/Providers'];
+    }
+
+    /**
+     * @param  string[]  $modelFqcns  the project's discovered model classes
+     * @param  array<string, string[]>  $psr4Map  namespace prefix => base paths
+     * @return array<string, string> model FQCN => policy FQCN
+     */
+    public function analyze(string $projectRoot, array $modelFqcns, array $psr4Map = []): array
+    {
+        $explicit = $this->explicitRegistrations($projectRoot);
+
+        $resolved = [];
+        foreach (array_unique($modelFqcns) as $model) {
+            $model = ltrim($model, '\\');
+            $policy = $explicit[$model]
+                ?? $this->attributePolicy($model, $projectRoot, $psr4Map)
+                ?? $this->conventionPolicy($model, $projectRoot, $psr4Map);
+
+            if ($policy !== null && $policy !== $model) {
+                $resolved[$model] = $policy;
+            }
+        }
+
+        // Explicitly registered models that were not in the discovered set still
+        // carry a real policy edge — keep them (the target may be any class).
+        foreach ($explicit as $model => $policy) {
+            if (! isset($resolved[$model]) && $policy !== $model) {
+                $resolved[$model] = $policy;
+            }
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * Model → policy pairs registered explicitly in a service provider, via
+     * either the `$policies` property map or `Gate::policy()` calls.
+     *
+     * @return array<string, string>
+     */
+    private function explicitRegistrations(string $projectRoot): array
+    {
+        $map = [];
+        foreach ($this->phpFiles($this->providerPaths, $projectRoot) as $file) {
+            $context = $this->context($file);
+            if ($context === null) {
+                continue;
+            }
+            [$ast, $useMap, $namespace] = $context;
+
+            foreach ($this->finder->findInstanceOf($ast, Node\Stmt\Property::class) as $property) {
+                foreach ($property->props as $prop) {
+                    if ($prop->name->toString() === 'policies' && $prop->default instanceof Node\Expr\Array_) {
+                        foreach ($this->pairsFromMap($prop->default, $useMap, $namespace) as [$model, $policy]) {
+                            $map[$model] = $policy;
+                        }
+                    }
+                }
+            }
+
+            foreach ($this->finder->findInstanceOf($ast, Node\Expr\StaticCall::class) as $call) {
+                if (! $call->name instanceof Node\Identifier
+                    || $call->name->toString() !== 'policy'
+                    || ! $call->class instanceof Node\Name
+                    || ! $this->isGateFacade($call->class, $useMap, $namespace)) {
+                    continue;
+                }
+                $args = $call->getArgs();
+                $model = isset($args[0]) ? $this->classRef($args[0]->value, $useMap, $namespace) : null;
+                $policy = isset($args[1]) ? $this->classRef($args[1]->value, $useMap, $namespace) : null;
+                if ($model !== null && $policy !== null) {
+                    $map[$model] = $policy;
+                }
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * Whether a `<Name>::policy()` call targets Laravel's Gate — resolved
+     * through the use-map so an aliased import (`use ... Gate as Access`) is
+     * recognised and an unrelated `App\Support\Gate` is not.
+     */
+    private function isGateFacade(Node\Name $class, array $useMap, string $namespace): bool
+    {
+        return in_array($this->qualify($class->toString(), $namespace, $useMap), [
+            'Illuminate\\Support\\Facades\\Gate',
+            'Illuminate\\Contracts\\Auth\\Access\\Gate',
+        ], true);
+    }
+
+    /**
+     * Parse a `$policies` map: Model::class => Policy::class.
+     *
+     * @return list<array{0: string, 1: string}>
+     */
+    private function pairsFromMap(Node\Expr\Array_ $map, array $useMap, string $namespace): array
+    {
+        $pairs = [];
+        foreach ($map->items as $item) {
+            if (! $item instanceof Node\Expr\ArrayItem || $item->key === null) {
+                continue;
+            }
+            $model = $this->classRef($item->key, $useMap, $namespace);
+            $policy = $this->classRef($item->value, $useMap, $namespace);
+            if ($model !== null && $policy !== null) {
+                $pairs[] = [$model, $policy];
+            }
+        }
+
+        return $pairs;
+    }
+
+    /**
+     * The policy named by a `#[UsePolicy]` attribute on the model class.
+     */
+    private function attributePolicy(string $modelFqcn, string $projectRoot, array $psr4Map): ?string
+    {
+        $file = $this->resolveClassFile($modelFqcn, $projectRoot, $psr4Map);
+        if ($file === null) {
+            return null;
+        }
+        $context = $this->context($file);
+        if ($context === null) {
+            return null;
+        }
+        [$ast, $useMap, $namespace] = $context;
+
+        $class = $this->finder->findFirstInstanceOf($ast, Node\Stmt\Class_::class);
+        if (! $class instanceof Node\Stmt\Class_) {
+            return null;
+        }
+
+        foreach ($class->attrGroups as $group) {
+            foreach ($group->attrs as $attr) {
+                if ($attr->name->getLast() !== self::POLICY_ATTRIBUTE) {
+                    continue;
+                }
+                $first = $attr->args[0]->value ?? null;
+                if ($first !== null) {
+                    return $this->classRef($first, $useMap, $namespace);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * The conventional policy for a model (`App\Models\Foo` → `App\Policies\FooPolicy`),
+     * returned only when the policy class file actually exists.
+     */
+    private function conventionPolicy(string $modelFqcn, string $projectRoot, array $psr4Map): ?string
+    {
+        foreach ($this->guessPolicyNames($modelFqcn) as $candidate) {
+            if ($this->resolveClassFile($candidate, $projectRoot, $psr4Map) !== null) {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Candidate policy FQCNs for a model, in the same priority order as
+     * Laravel's Gate::guessPolicyName: a `\Policies\` segment inserted at each
+     * boundary of the model's namespace (deepest preferred), plus the
+     * `\Models\` → `\Policies\` and `\Models\Policies\` rewrites. The first
+     * candidate whose class file exists is used, mirroring Gate's `class_exists`
+     * selection.
+     *
+     * @return list<string>
+     */
+    private function guessPolicyNames(string $modelFqcn): array
+    {
+        $base = ($pos = strrpos($modelFqcn, '\\')) !== false ? substr($modelFqcn, $pos + 1) : $modelFqcn;
+        $classDirname = $pos !== false ? substr($modelFqcn, 0, $pos) : '';
+        $segments = $classDirname === '' ? [] : explode('\\', $classDirname);
+
+        $candidates = [];
+        for ($index = 1; $index <= count($segments); $index++) {
+            $prefix = implode('\\', array_slice($segments, 0, $index));
+            $candidates[] = $prefix.'\\Policies\\'.$base.'Policy';
+        }
+        if (str_contains($classDirname, '\\Models\\')) {
+            $candidates[] = str_replace('\\Models\\', '\\Policies\\', $classDirname).'\\'.$base.'Policy';
+            $candidates[] = str_replace('\\Models\\', '\\Models\\Policies\\', $classDirname).'\\'.$base.'Policy';
+        }
+
+        $candidates = array_reverse($candidates);
+        if ($candidates === []) {
+            $candidates[] = $classDirname === '' ? $base.'Policy' : $classDirname.'\\Policies\\'.$base.'Policy';
+        }
+
+        return array_values(array_unique($candidates));
+    }
+
+    /**
+     * Resolve `Foo::class` or a string literal to an FQCN.
+     */
+    private function classRef(Node\Expr $expr, array $useMap, string $namespace): ?string
+    {
+        if ($expr instanceof Node\Expr\ClassConstFetch
+            && $expr->class instanceof Node\Name
+            && $expr->name instanceof Node\Identifier
+            && $expr->name->toString() === 'class') {
+            return $this->qualify($expr->class->toString(), $namespace, $useMap);
+        }
+
+        if ($expr instanceof Node\Scalar\String_) {
+            return ltrim($expr->value, '\\');
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve a (possibly short or aliased) class name to an FQCN.
+     *
+     * @param  array<string, string>  $useMap
+     */
+    private function qualify(string $name, string $namespace, array $useMap = []): string
+    {
+        $name = ltrim($name, '\\');
+        if (isset($useMap[$name])) {
+            return $useMap[$name];
+        }
+        $head = strtok($name, '\\');
+        if ($head !== false && $head !== $name && isset($useMap[$head])) {
+            return $useMap[$head].substr($name, strlen($head));
+        }
+        if (str_contains($name, '\\')) {
+            return $name;
+        }
+
+        return $namespace !== '' ? $namespace.'\\'.$name : $name;
+    }
+
+    /**
+     * @return array{0: Node\Stmt[], 1: array<string, string>, 2: string}|null [ast, useMap, namespace]
+     */
+    private function context(string $file): ?array
+    {
+        $parsed = $this->parser->parse($file);
+        if ($parsed['ast'] === null) {
+            return null;
+        }
+        $namespaceNode = $this->finder->findFirstInstanceOf($parsed['ast'], Node\Stmt\Namespace_::class);
+        $namespace = $namespaceNode instanceof Node\Stmt\Namespace_ && $namespaceNode->name !== null
+            ? $namespaceNode->name->toString()
+            : '';
+
+        return [$parsed['ast'], $parsed['useMap'], $namespace];
+    }
+
+    /**
+     * @param  string[]  $relativePaths
+     * @return iterable<string>
+     */
+    private function phpFiles(array $relativePaths, string $projectRoot): iterable
+    {
+        foreach ($relativePaths as $relativePath) {
+            $basePath = rtrim($projectRoot, '/').'/'.ltrim($relativePath, '/');
+            if (! is_dir($basePath)) {
+                continue;
+            }
+            $it = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($basePath, \FilesystemIterator::SKIP_DOTS)
+            );
+            foreach ($it as $fileInfo) {
+                if ($fileInfo->isFile() && $fileInfo->getExtension() === 'php') {
+                    yield $fileInfo->getPathname();
+                }
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, string[]>  $psr4Map
+     */
+    private function resolveClassFile(string $fqcn, string $projectRoot, array $psr4Map): ?string
+    {
+        foreach ($psr4Map as $prefix => $basePaths) {
+            if (str_starts_with($fqcn, rtrim($prefix, '\\').'\\')) {
+                $relative = str_replace('\\', '/', substr($fqcn, strlen(rtrim($prefix, '\\')) + 1)).'.php';
+                foreach ($basePaths as $basePath) {
+                    $path = rtrim($basePath, '/').'/'.ltrim($relative, '/');
+                    if (is_file($path)) {
+                        return $path;
+                    }
+                }
+            }
+        }
+
+        $candidates = [];
+        if (str_starts_with($fqcn, 'App\\')) {
+            $candidates[] = 'app/'.str_replace('\\', '/', substr($fqcn, 4)).'.php';
+        }
+        $candidates[] = 'app/'.str_replace('\\', '/', $fqcn).'.php';
+        $candidates[] = str_replace('\\', '/', $fqcn).'.php';
+
+        foreach ($candidates as $candidate) {
+            $path = rtrim($projectRoot, '/').'/'.$candidate;
+            if (is_file($path)) {
+                return $path;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Analysis/ProjectAnalyzer.php
+++ b/src/Analysis/ProjectAnalyzer.php
@@ -47,6 +47,8 @@ class ProjectAnalyzer
 
     private ListenerAnalyzer $listenerAnalyzer;
 
+    private PolicyAnalyzer $policyAnalyzer;
+
     private FilamentAnalyzer $filamentAnalyzer;
 
     private QueryTracer $queryTracer;
@@ -75,6 +77,11 @@ class ProjectAnalyzer
         $this->listenerAnalyzer = new ListenerAnalyzer(
             is_array($listenerPaths) ? $listenerPaths : [],
             is_array($providerPaths) ? $providerPaths : [],
+        );
+
+        $policyProviderPaths = config('laravel-brain.policies.provider_paths', ['app/Providers']);
+        $this->policyAnalyzer = new PolicyAnalyzer(
+            is_array($policyProviderPaths) ? $policyProviderPaths : [],
         );
 
         $cmdConfig = config('laravel-brain.commands', []);
@@ -175,6 +182,10 @@ class ProjectAnalyzer
         $models = $this->modelAnalyzer->analyze($projectRoot, $modelFqcns);
         $this->emit('step:done', ['step' => 'models', 'count' => count($models), 'unit' => 'model', 'message' => '    Found '.count($models).' model(s)']);
 
+        $this->emit('step:start', ['step' => 'policies', 'label' => 'Resolving authorization policies', 'message' => '  → Resolving authorization policies...']);
+        $policyMap = $this->policyAnalyzer->analyze($projectRoot, $modelFqcns, $psr4Map);
+        $this->emit('step:done', ['step' => 'policies', 'count' => count($policyMap), 'unit' => 'policy', 'message' => '    Found '.count($policyMap).' model-policy link(s)']);
+
         $this->emit('step:start', ['step' => 'commands', 'label' => 'Scanning console commands', 'message' => '  → Scanning console commands...']);
         $consoleResult = $this->consoleAnalyzer->analyze($projectRoot);
         $commands = $consoleResult['commands'];
@@ -265,6 +276,7 @@ class ProjectAnalyzer
         );
         $this->graphBuilder->addConsoleCommands($commands, $schedules, $commandEdges);
         $this->graphBuilder->addChannels($channels, $channelEdges);
+        $this->graphBuilder->addPolicies($policyMap);
         if ($filamentResult['detected']) {
             $this->graphBuilder->addFilament(
                 $filamentResult['panels'],

--- a/src/Graph/GraphBuilder.php
+++ b/src/Graph/GraphBuilder.php
@@ -1792,6 +1792,43 @@ class GraphBuilder
         ]));
     }
 
+    /**
+     * Wire model → policy edges discovered by PolicyAnalyzer. The edge shares
+     * the canonical model node (model::FQCN), so a model's authorization policy
+     * sits alongside its fired-event and relationship edges.
+     *
+     * @param  array<string, string>  $policyMap  model FQCN => policy FQCN
+     */
+    public function addPolicies(array $policyMap): void
+    {
+        foreach ($policyMap as $modelFqcn => $policyFqcn) {
+            $modelId = $this->modelId($modelFqcn);
+            if (! $this->graph->hasNode($modelId)) {
+                $this->addModelNode($modelFqcn, null, $modelId);
+            }
+            $policyId = $this->policyId($policyFqcn);
+            $this->addPolicyNode($policyFqcn, $policyId);
+            $this->addEdge($modelId, $policyId, 'authorized by', 'model-to-policy');
+        }
+    }
+
+    private function addPolicyNode(string $fqcn, string $id): void
+    {
+        if ($this->graph->hasNode($id)) {
+            return;
+        }
+        $short = class_basename($fqcn);
+        $file = $this->resolveFile($fqcn);
+        $members = ($file !== '' && is_file($file))
+            ? $this->getStructureInspector()->listClassMethods($file)
+            : [];
+        $this->graph->addNode(new Node($id, 'policy', $short, [
+            'fqcn' => $fqcn,
+            'file' => $file,
+            'members' => $members,
+        ]));
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private function resolveMiddlewares(array $middlewares, MiddlewareRegistry $registry): array
@@ -2036,6 +2073,11 @@ class GraphBuilder
     private function eventId(string $fqcn): string
     {
         return "event::{$fqcn}";
+    }
+
+    private function policyId(string $fqcn): string
+    {
+        return "policy::{$fqcn}";
     }
 
     private function filamentPanelId(string $fqcn): string

--- a/tests/Unit/PolicyAnalyzerTest.php
+++ b/tests/Unit/PolicyAnalyzerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use LaraMint\LaravelBrain\Analysis\MiddlewareRegistry;
+use LaraMint\LaravelBrain\Analysis\ModelAnalyzer;
+use LaraMint\LaravelBrain\Analysis\PolicyAnalyzer;
+use LaraMint\LaravelBrain\Graph\GraphBuilder;
+
+function policyMap(): array
+{
+    $project = fixture('laravel-project');
+    $models = (new ModelAnalyzer(['app/Models']))->discoverModels($project);
+
+    return (new PolicyAnalyzer)->analyze($project, $models);
+}
+
+it('resolves a policy by the App\\Models → App\\Policies convention', function () {
+    expect(policyMap()['App\\Models\\User'] ?? null)->toBe('App\\Policies\\UserPolicy');
+});
+
+it('resolves a policy from a #[UsePolicy] attribute', function () {
+    expect(policyMap()['App\\Models\\Article'] ?? null)->toBe('App\\Policies\\Custom\\ArticleAccessPolicy');
+});
+
+it('resolves a policy from an AuthServiceProvider::$policies map', function () {
+    expect(policyMap()['App\\Models\\Comment'] ?? null)->toBe('App\\Policies\\CommentPolicy');
+});
+
+it('lets an explicit Gate::policy() registration override the convention', function () {
+    // App\Policies\OrderPolicy exists (convention), but Gate::policy names SpecialOrderPolicy.
+    expect(policyMap()['App\\Models\\Order'] ?? null)->toBe('App\\Policies\\SpecialOrderPolicy');
+});
+
+it('does not invent a policy for a model whose conventional policy is absent', function () {
+    // No App\Policies\TagPolicy file exists, so Tag must not appear.
+    expect(policyMap())->not->toHaveKey('App\\Models\\Tag');
+});
+
+it('maps each model to at most one policy', function () {
+    foreach (policyMap() as $policy) {
+        expect($policy)->toBeString();
+    }
+});
+
+it('lets a #[UsePolicy] attribute override an existing conventional policy', function () {
+    // App\Policies\ArticlePolicy exists (convention), but the attribute names ArticleAccessPolicy.
+    expect(policyMap()['App\\Models\\Article'] ?? null)->toBe('App\\Policies\\Custom\\ArticleAccessPolicy');
+});
+
+it('recognises an aliased Gate facade import in a registration', function () {
+    // use Illuminate\Support\Facades\Gate as Access; Access::policy(Widget::class, WidgetPolicy::class)
+    expect(policyMap()['App\\Models\\Widget'] ?? null)->toBe('App\\Policies\\WidgetPolicy');
+});
+
+it('does not treat an unrelated ::policy() call as a Gate registration', function () {
+    // App\Support\Gate::policy(Gadget::class, ...) is not the facade — no edge, and Gadget has no convention policy.
+    expect(policyMap())->not->toHaveKey('App\\Models\\Gadget');
+});
+
+it('resolves string-literal model and policy references in a $policies map', function () {
+    expect(policyMap()['App\\Models\\Report'] ?? null)->toBe('App\\Policies\\ReportPolicy');
+});
+
+it('resolves a nested-namespace model to a flat App\\Policies policy by convention', function () {
+    expect(policyMap()['App\\Models\\Billing\\Invoice'] ?? null)->toBe('App\\Policies\\InvoicePolicy');
+});
+
+it('wires a model → policy edge into the graph', function () {
+    $map = policyMap();
+
+    $builder = new GraphBuilder;
+    $graph = $builder->build('test', [], new MiddlewareRegistry([], [], []), [], [], []);
+    $builder->addPolicies($map);
+
+    $policyNode = array_values(array_filter(
+        $graph->nodes(),
+        fn ($n) => $n->type === 'policy' && $n->data['fqcn'] === 'App\\Policies\\UserPolicy'
+    ));
+    expect($policyNode)->toHaveCount(1);
+    expect($policyNode[0]->id)->toBe('policy::App\\Policies\\UserPolicy');
+
+    $edge = array_values(array_filter(
+        $graph->edges(),
+        fn ($e) => $e->source === 'model::App\\Models\\User' && $e->target === $policyNode[0]->id
+    ));
+    expect($edge)->toHaveCount(1);
+    expect($edge[0])
+        ->label->toBe('authorized by')
+        ->type->toBe('model-to-policy');
+});
+
+it('hangs the policy edge off the same model node as the fired-event edge', function () {
+    $project = fixture('laravel-project');
+
+    // Order both fires OrderPlaced (via $dispatchesEvents) and is authorized by a policy.
+    $models = (new ModelAnalyzer)->analyze($project, ['App\\Models\\Order']);
+    $map = policyMap();
+
+    $builder = new GraphBuilder;
+    $graph = $builder->build('test', [], new MiddlewareRegistry([], [], []), [], [], $models, $project);
+    $builder->addPolicies($map);
+
+    $modelNodes = array_filter($graph->nodes(), fn ($n) => $n->id === 'model::App\\Models\\Order');
+    expect($modelNodes)->toHaveCount(1);
+
+    $types = array_map(
+        fn ($e) => $e->type,
+        array_values(array_filter($graph->edges(), fn ($e) => $e->source === 'model::App\\Models\\Order'))
+    );
+    expect($types)
+        ->toContain('model-to-event')
+        ->toContain('model-to-policy');
+});

--- a/tests/fixtures/laravel-project/app/Models/Article.php
+++ b/tests/fixtures/laravel-project/app/Models/Article.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use App\Policies\Custom\ArticleAccessPolicy;
+use Illuminate\Database\Eloquent\Attributes\UsePolicy;
+use Illuminate\Database\Eloquent\Model;
+
+#[UsePolicy(ArticleAccessPolicy::class)]
+class Article extends Model
+{
+    protected $fillable = ['title'];
+}

--- a/tests/fixtures/laravel-project/app/Models/Billing/Invoice.php
+++ b/tests/fixtures/laravel-project/app/Models/Billing/Invoice.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models\Billing;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Invoice extends Model
+{
+    protected $fillable = ['amount'];
+}

--- a/tests/fixtures/laravel-project/app/Models/Comment.php
+++ b/tests/fixtures/laravel-project/app/Models/Comment.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Comment extends Model
+{
+    protected $fillable = ['body'];
+}

--- a/tests/fixtures/laravel-project/app/Models/Gadget.php
+++ b/tests/fixtures/laravel-project/app/Models/Gadget.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Gadget extends Model
+{
+    protected $fillable = ['name'];
+}

--- a/tests/fixtures/laravel-project/app/Models/Report.php
+++ b/tests/fixtures/laravel-project/app/Models/Report.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Report extends Model
+{
+    protected $fillable = ['title'];
+}

--- a/tests/fixtures/laravel-project/app/Models/Tag.php
+++ b/tests/fixtures/laravel-project/app/Models/Tag.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+    protected $fillable = ['name'];
+}

--- a/tests/fixtures/laravel-project/app/Models/Widget.php
+++ b/tests/fixtures/laravel-project/app/Models/Widget.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Widget extends Model
+{
+    protected $fillable = ['name'];
+}

--- a/tests/fixtures/laravel-project/app/Policies/ArticlePolicy.php
+++ b/tests/fixtures/laravel-project/app/Policies/ArticlePolicy.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Policies;
+
+class ArticlePolicy
+{
+    public function view($authUser, $article): bool
+    {
+        return true;
+    }
+}

--- a/tests/fixtures/laravel-project/app/Policies/CommentPolicy.php
+++ b/tests/fixtures/laravel-project/app/Policies/CommentPolicy.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Policies;
+
+class CommentPolicy
+{
+    public function update($authUser, $comment): bool
+    {
+        return true;
+    }
+}

--- a/tests/fixtures/laravel-project/app/Policies/Custom/ArticleAccessPolicy.php
+++ b/tests/fixtures/laravel-project/app/Policies/Custom/ArticleAccessPolicy.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Policies\Custom;
+
+class ArticleAccessPolicy
+{
+    public function view($authUser, $article): bool
+    {
+        return true;
+    }
+}

--- a/tests/fixtures/laravel-project/app/Policies/InvoicePolicy.php
+++ b/tests/fixtures/laravel-project/app/Policies/InvoicePolicy.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Policies;
+
+class InvoicePolicy
+{
+    public function view($authUser, $invoice): bool
+    {
+        return true;
+    }
+}

--- a/tests/fixtures/laravel-project/app/Policies/OrderPolicy.php
+++ b/tests/fixtures/laravel-project/app/Policies/OrderPolicy.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Policies;
+
+class OrderPolicy
+{
+    public function view($authUser, $order): bool
+    {
+        return true;
+    }
+}

--- a/tests/fixtures/laravel-project/app/Policies/ReportPolicy.php
+++ b/tests/fixtures/laravel-project/app/Policies/ReportPolicy.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Policies;
+
+class ReportPolicy
+{
+    public function view($authUser, $report): bool
+    {
+        return true;
+    }
+}

--- a/tests/fixtures/laravel-project/app/Policies/SpecialOrderPolicy.php
+++ b/tests/fixtures/laravel-project/app/Policies/SpecialOrderPolicy.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Policies;
+
+class SpecialOrderPolicy
+{
+    public function view($authUser, $order): bool
+    {
+        return true;
+    }
+
+    public function delete($authUser, $order): bool
+    {
+        return true;
+    }
+}

--- a/tests/fixtures/laravel-project/app/Policies/UserPolicy.php
+++ b/tests/fixtures/laravel-project/app/Policies/UserPolicy.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+
+class UserPolicy
+{
+    public function view($authUser, User $user): bool
+    {
+        return true;
+    }
+
+    public function update($authUser, User $user): bool
+    {
+        return true;
+    }
+}

--- a/tests/fixtures/laravel-project/app/Policies/WidgetPolicy.php
+++ b/tests/fixtures/laravel-project/app/Policies/WidgetPolicy.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Policies;
+
+class WidgetPolicy
+{
+    public function view($authUser, $widget): bool
+    {
+        return true;
+    }
+}

--- a/tests/fixtures/laravel-project/app/Providers/AuthServiceProvider.php
+++ b/tests/fixtures/laravel-project/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Providers;
+
+use App\Models\Comment;
+use App\Models\Gadget;
+use App\Models\Order;
+use App\Models\Widget;
+use App\Policies\CommentPolicy;
+use App\Policies\GadgetPolicy;
+use App\Policies\SpecialOrderPolicy;
+use App\Policies\WidgetPolicy;
+use App\Support\Gate as HomeGrownGate;
+use Illuminate\Support\Facades\Gate as Access;
+
+class AuthServiceProvider
+{
+    protected $policies = [
+        Comment::class => CommentPolicy::class,
+        // String-literal registration (both key and value).
+        'App\\Models\\Report' => 'App\\Policies\\ReportPolicy',
+    ];
+
+    public function boot(): void
+    {
+        // Explicit registration overrides the App\Policies\OrderPolicy convention.
+        Access::policy(Order::class, SpecialOrderPolicy::class);
+
+        // Aliased Gate facade import must still be recognised.
+        Access::policy(Widget::class, WidgetPolicy::class);
+
+        // An unrelated, home-grown ::policy() must NOT be treated as Gate.
+        HomeGrownGate::policy(Gadget::class, GadgetPolicy::class);
+    }
+}

--- a/tests/fixtures/laravel-project/app/Support/Gate.php
+++ b/tests/fixtures/laravel-project/app/Support/Gate.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Support;
+
+class Gate
+{
+    public static function policy(string $model, string $policy): void {}
+}


### PR DESCRIPTION
## What

Adds a `PolicyAnalyzer` that maps each Eloquent **model → authorization policy** and wires `model-to-policy` ("authorized by") edges into the graph, parallel to the existing `model-to-event` edges. Today Brain has no notion of policies (authorization only surfaces as route-exposure classification), so a change to a policy shows no reach to the model it guards.

## How policies are resolved

The same precedence Laravel's `Gate` uses:

1. **Explicit** — an `AuthServiceProvider::$policies` map (`Model::class => Policy::class`) or a `Gate::policy(Model::class, Policy::class)` call in a provider. The Gate facade is matched **through the file's use-map**, so `use ... Gate as Access; Access::policy(...)` is recognised and an unrelated `App\Support\Gate::policy(...)` is not.
2. **Attribute** — a model marked `#[UsePolicy(Policy::class)]`.
3. **Convention** — the guessed policy, following Laravel's real `Gate::guessPolicyName` (a `\Policies\` segment inserted at each namespace boundary, deepest preferred, plus the `\Models\`→`\Policies\` and `\Models\Policies\` rewrites), used **only when the policy class file exists** — mirroring Gate's `class_exists` guard, so no edge is invented for a missing policy.

Both `::class` and string-literal references are resolved. Each model resolves to at most one policy — the first matching form.

## Graph wiring

`GraphBuilder::addPolicies()` attaches each edge to the canonical `model::{FQCN}` node — the *same* node used by `model-to-event` and `model-relationship` — so a model's policy sits with the rest of its edges instead of on a mangled hop node. A new `policy` node type carries the policy's ability methods (`view`/`update`/…).

## Scope

- Mirrors `ListenerAnalyzer` / the observer analyzer (AST helpers, PSR-4 resolution, configurable paths).
- Class-level by design: answers "what authorizes this model", not which ability maps to which policy method.
- Scan paths configurable via `laravel-brain.policies.provider_paths`.

```php
'policies' => [
    'provider_paths' => ['app/Providers'],
],
```

## Tests

13 Pest tests in `PolicyAnalyzerTest`: each resolution form (convention, `#[UsePolicy]`, `$policies` map, `Gate::policy()`), every precedence edge (explicit-over-convention, attribute-over-convention), the **aliased-Gate** and **unrelated-`Gate`** cases, string-literal refs, nested-namespace convention (`App\Models\Billing\Invoice` → `App\Policies\InvoicePolicy`), the missing-policy negative, the graph edge, and — the headline guarantee — a model that **both** fires an event and has a policy carrying both edges off one `model::FQCN` node.

Verified: `pint` clean · `phpstan` (level 5 + larastan) **No errors** · full suite **124 passed**. Dogfooded against a real ~large Laravel app: 90 models → 18 model-policy links (nested namespaces + explicit registrations resolved correctly), graph build produces 18 policy nodes + 18 edges.

## Note

Independent of #58 (observers); both branch from `main` and touch adjacent spots in `GraphBuilder`/`ProjectAnalyzer`/config, so whichever merges second may need a trivial rebase. Happy to do that.

