### PR TITLE
Trace API resource references as resource edges

### DIFF
--- a/src/Analysis/MethodTracer.php
+++ b/src/Analysis/MethodTracer.php
@@ -166,7 +166,7 @@ class MethodTracer
                 visibility: $hop['visibility'],
             );
 
-            if (in_array($hop['type'], ['service', 'repository', 'action', 'mail', 'notification', 'abstract_class'], true)) {
+            if (in_array($hop['type'], ['service', 'repository', 'action', 'mail', 'notification', 'abstract_class', 'resource'], true)) {
                 $subEdges = $this->traceDeep($hop['fqcn'], $hop['method'], depth: 1);
                 foreach ($subEdges as $sub) {
                     $edges[] = $sub;
@@ -236,7 +236,7 @@ class MethodTracer
                     );
 
                     // Recurse into non-leaf hops (services, repositories)
-                    if (in_array($hop['type'], ['service', 'repository', 'action', 'mail', 'notification', 'abstract_class'], true)) {
+                    if (in_array($hop['type'], ['service', 'repository', 'action', 'mail', 'notification', 'abstract_class', 'resource'], true)) {
                         $subEdges = $this->traceDeep(
                             $hop['fqcn'],
                             $hop['method'],
@@ -327,7 +327,7 @@ class MethodTracer
                 visibility: $hop['visibility'],
             );
 
-            if (in_array($hop['type'], ['service', 'repository', 'action', 'mail', 'notification', 'abstract_class'], true)) {
+            if (in_array($hop['type'], ['service', 'repository', 'action', 'mail', 'notification', 'abstract_class', 'resource'], true)) {
                 $subEdges = $this->traceDeep($hop['fqcn'], $hop['method'], $depth + 1);
                 foreach ($subEdges as $sub) {
                     $edges[] = $sub;
@@ -536,6 +536,22 @@ class MethodTracer
                     return;
                 }
 
+                // API resources: UserResource::make($user) / UserResource::collection($users).
+                // Resources routinely compose sibling resources in the same namespace with no
+                // import, so an unqualified name is resolved against the current namespace.
+                if (in_array($method, ['make', 'collection'], true)) {
+                    $resourceFqcn = $this->qualifySibling($fqcn);
+                    // A recursive resource composing its own type (a tree of comments,
+                    // interactions, …) is a self-loop that adds no reach — skip it.
+                    if ($this->tracer->looksLikeResource($resourceFqcn)
+                        && ! $this->isFrameworkClass($resourceFqcn)
+                        && $resourceFqcn !== $this->currentFqcn) {
+                        $this->hops[] = ['fqcn' => $resourceFqcn, 'method' => 'toArray', 'type' => 'resource', 'visibility' => 'public'];
+
+                        return;
+                    }
+                }
+
                 // Eloquent static queries: User::find(), Order::create() …
                 if ($this->looksLikeModel($fqcn) && in_array($method, MethodTracer::MODEL_STATIC_METHODS, true)) {
                     $this->hops[] = ['fqcn' => $fqcn, 'method' => $method, 'type' => 'model', 'visibility' => 'public'];
@@ -716,6 +732,19 @@ class MethodTracer
                         'fqcn' => $fqcn,
                         'method' => 'via',
                         'type' => 'notification',
+                        'visibility' => 'public',
+                    ];
+
+                    return;
+                }
+                $resourceFqcn = $this->qualifySibling($fqcn);
+                if ($this->tracer->looksLikeResource($resourceFqcn)
+                    && ! $this->isFrameworkClass($resourceFqcn)
+                    && $resourceFqcn !== $this->currentFqcn) {
+                    $this->hops[] = [
+                        'fqcn' => $resourceFqcn,
+                        'method' => 'toArray',
+                        'type' => 'resource',
                         'visibility' => 'public',
                     ];
 
@@ -934,6 +963,24 @@ class MethodTracer
                 }
 
                 return $classes;
+            }
+
+            /**
+             * Qualify an unqualified class name against the namespace of the class
+             * currently being scanned. Names that are already qualified, or the
+             * self/static/parent keywords (already resolved to an FQCN upstream),
+             * are returned unchanged.
+             */
+            private function qualifySibling(string $fqcn): string
+            {
+                if (in_array(strtolower($fqcn), ['self', 'static', 'parent'], true)
+                    || str_contains($fqcn, '\\')
+                    || ! str_contains($this->currentFqcn, '\\')) {
+                    return $fqcn;
+                }
+                $pos = strrpos($this->currentFqcn, '\\');
+
+                return substr($this->currentFqcn, 0, $pos).'\\'.$fqcn;
             }
 
             private function looksLikeModel(string $class): bool
@@ -1221,6 +1268,16 @@ class MethodTracer
     public function looksLikeNotification(string $class): bool
     {
         return str_contains($class, '\\Notifications\\');
+    }
+
+    /**
+     * An Eloquent API resource / resource collection. Recognised by the
+     * conventional `App\Http\Resources\` location where `make:resource` places
+     * them — precise enough not to collide with Filament's `\Filament\Resources\`.
+     */
+    public function looksLikeResource(string $class): bool
+    {
+        return str_contains($class, '\\Http\\Resources\\');
     }
 
     public function declKindIsEnum(string $fqcn): bool

--- a/src/Graph/GraphBuilder.php
+++ b/src/Graph/GraphBuilder.php
@@ -654,6 +654,7 @@ class GraphBuilder
 
             case 'mail':
             case 'notification':
+            case 'resource':
                 $short = class_basename($fqcn);
                 $file = $this->resolveFile($fqcn);
                 $flowSteps = $method !== '' ? $this->extractMethodFlowSteps($fqcn, $method) : [];
@@ -857,6 +858,11 @@ class GraphBuilder
 
     private function classifyFqcn(string $fqcn): string
     {
+        // API resources live under \Http\Resources\ — check before the controller
+        // heuristic, which would otherwise claim any \Http\ class as an action.
+        if (str_contains($fqcn, '\\Http\\Resources\\')) {
+            return 'resource';
+        }
         if ($this->isController($fqcn)) {
             return 'action';
         }
@@ -925,6 +931,7 @@ class GraphBuilder
             'model' => 'queries',
             'job' => 'dispatches',
             'event' => 'dispatches',
+            'resource' => 'transforms',
             'listener' => 'handled by',
             'repository' => 'calls',
             'validation_request' => 'validates',

--- a/tests/Unit/ResourceEdgeTest.php
+++ b/tests/Unit/ResourceEdgeTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use LaraMint\LaravelBrain\Analysis\MethodTracer;
+use LaraMint\LaravelBrain\Analysis\MiddlewareRegistry;
+use LaraMint\LaravelBrain\Graph\GraphBuilder;
+
+function resourceEdges(string $fqcn, string $method): array
+{
+    $project = fixture('laravel-project');
+
+    return (new MethodTracer)->traceMethod($fqcn, $method, ['App\\' => [$project.'/app']], $project);
+}
+
+$UserApi = 'App\\Http\\Controllers\\Api\\UserApiController';
+$UserResource = 'App\\Http\\Resources\\UserResource';
+$OrderResource = 'App\\Http\\Resources\\OrderResource';
+
+it('emits a resource edge for Resource::make()', function () use ($UserApi, $UserResource) {
+    $edges = resourceEdges($UserApi, 'show');
+
+    $match = array_values(array_filter(
+        $edges,
+        fn ($e) => $e->type === 'resource' && $e->calleeFqcn === $UserResource
+    ));
+
+    expect($match)->not->toBeEmpty();
+    expect($match[0])->calleeMethod->toBe('toArray');
+});
+
+it('emits a resource edge for Resource::collection()', function () use ($UserApi, $UserResource) {
+    $edges = resourceEdges($UserApi, 'index');
+
+    expect(array_filter($edges, fn ($e) => $e->type === 'resource' && $e->calleeFqcn === $UserResource))
+        ->not->toBeEmpty();
+});
+
+it('emits a resource edge for new Resource()', function () use ($UserApi, $UserResource) {
+    $edges = resourceEdges($UserApi, 'latest');
+
+    expect(array_filter($edges, fn ($e) => $e->type === 'resource' && $e->calleeFqcn === $UserResource))
+        ->not->toBeEmpty();
+});
+
+it('descends into a resource to link its nested resource composition', function () use ($UserApi, $UserResource, $OrderResource) {
+    // Tracing the controller recurses into UserResource::toArray(), which
+    // composes OrderResource via both ::collection() and new.
+    $edges = resourceEdges($UserApi, 'show');
+
+    $nested = array_values(array_filter(
+        $edges,
+        fn ($e) => $e->type === 'resource' && $e->callerFqcn === $UserResource && $e->calleeFqcn === $OrderResource
+    ));
+
+    expect($nested)->not->toBeEmpty();
+});
+
+it('still traces the model queried alongside the resource', function () use ($UserApi) {
+    $edges = resourceEdges($UserApi, 'show');
+
+    // The resource recognition must not swallow the User::findOrFail() model hop.
+    expect(array_filter($edges, fn ($e) => $e->type === 'model' && $e->calleeFqcn === 'App\\Models\\User'))
+        ->not->toBeEmpty();
+});
+
+it('does not emit a self-loop edge for a recursively composed resource', function () use ($OrderResource) {
+    // OrderResource::toArray composes OrderResource::collection (a tree) — no self-edge.
+    $edges = resourceEdges($OrderResource, 'toArray');
+
+    expect(array_filter($edges, fn ($e) => $e->callerFqcn === $OrderResource && $e->calleeFqcn === $OrderResource))
+        ->toBe([]);
+});
+
+it('does not emit an edge for the framework JsonResource base class', function () use ($UserApi) {
+    foreach (['framework', 'frameworkNew'] as $method) {
+        $edges = resourceEdges($UserApi, $method);
+        expect(array_filter($edges, fn ($e) => $e->type === 'resource'))->toBe([]);
+    }
+});
+
+it('does not resolve a new self()/static() to a phantom resource', function () use ($OrderResource) {
+    // OrderResource::toArray composes itself via OrderResource::collection and new static() —
+    // both are self-references, so no edge (and certainly no \Http\Resources\static phantom).
+    $callees = array_map(fn ($e) => $e->calleeFqcn, resourceEdges($OrderResource, 'toArray'));
+
+    expect($callees)
+        ->not->toContain('App\\Http\\Resources\\static')
+        ->not->toContain('App\\Http\\Resources\\self')
+        ->not->toContain($OrderResource);
+});
+
+it('does not treat a Filament resource as an API resource', function () {
+    $tracer = new MethodTracer;
+
+    expect($tracer->looksLikeResource('App\\Http\\Resources\\UserResource'))->toBeTrue();
+    expect($tracer->looksLikeResource('App\\Filament\\Resources\\UserResource'))->toBeFalse();
+    expect($tracer->looksLikeResource('App\\Models\\User'))->toBeFalse();
+});
+
+it('wires action → resource and resource → resource edges into the graph', function () use ($UserApi, $UserResource, $OrderResource) {
+    $edges = resourceEdges($UserApi, 'show');
+
+    $graph = (new GraphBuilder)->build('test', [], new MiddlewareRegistry([], [], []), [], $edges, []);
+
+    $resourceNodes = array_filter($graph->nodes(), fn ($n) => $n->type === 'resource');
+    expect($resourceNodes)->not->toBeEmpty();
+
+    $labels = array_map(
+        fn ($e) => $e->label,
+        array_filter($graph->edges(), fn ($e) => $e->type === 'action-to-resource')
+    );
+    expect($labels)->toContain('transforms');
+
+    $fqcns = array_map(fn ($n) => $n->data['fqcn'], $resourceNodes);
+    expect($fqcns)->toContain($UserResource)->toContain($OrderResource);
+});

--- a/tests/fixtures/laravel-project/app/Http/Controllers/Api/UserApiController.php
+++ b/tests/fixtures/laravel-project/app/Http/Controllers/Api/UserApiController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Resources\UserResource;
+use App\Models\User;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class UserApiController
+{
+    public function show(int $id)
+    {
+        return UserResource::make(User::findOrFail($id));
+    }
+
+    public function index()
+    {
+        return UserResource::collection(User::all());
+    }
+
+    public function latest()
+    {
+        return new UserResource(User::first());
+    }
+
+    public function framework()
+    {
+        // The framework base resource is not an application resource — no edge.
+        return JsonResource::collection(User::all());
+    }
+
+    public function frameworkNew()
+    {
+        return new JsonResource(User::first());
+    }
+}

--- a/tests/fixtures/laravel-project/app/Http/Resources/OrderResource.php
+++ b/tests/fixtures/laravel-project/app/Http/Resources/OrderResource.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class OrderResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'status' => $this->status,
+            // recursive self-composition — must not create a self-loop edge
+            'children' => OrderResource::collection($this->children),
+            // keyword self-reference — must not resolve to a phantom \Http\Resources\static
+            'parent' => new static($this->parent),
+        ];
+    }
+}

--- a/tests/fixtures/laravel-project/app/Http/Resources/UserResource.php
+++ b/tests/fixtures/laravel-project/app/Http/Resources/UserResource.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class UserResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            // nested composition — resource -> resource
+            'orders' => OrderResource::collection($this->orders),
+            'latest' => new OrderResource($this->latestOrder),
+        ];
+    }
+}


### PR DESCRIPTION
## What

Teaches `MethodTracer` to recognise Eloquent **API resources**, which were previously invisible to the graph. `UserResource::make($user)`, `::collection($users)`, and `new UserResource(...)` now emit a `resource` ("transforms") edge, and **nested composition** inside a resource's `toArray()` is followed transitively. So a changed resource lights up the controllers that return it and the resources that embed it — the blast-radius that was silently missing before.

## How

Recognition mirrors Brain's existing `looksLike*` heuristics (models, jobs, mails):

- `looksLikeResource()` — true when the FQCN is under `App\Http\Resources\`, the conventional `make:resource` location. Precise enough **not** to collide with Filament's `\Filament\Resources\`.
- `handleStaticCall` / `handleNew` emit a resource hop (method `toArray`) for `::make` / `::collection` / `new`.
- `'resource'` is added to the deep-recursion sets, so a resource's `toArray()` is scanned and its nested resources linked (`resource → resource`).
- Sibling resources composed in the same namespace **without an import** are resolved against the current namespace (`qualifySibling`).
- New `resource` graph node type + `transforms` edge label.

## Deliberately excluded (each verified with a test)

- **Framework base classes** under `Illuminate\Http\Resources\` (`JsonResource::collection()`, `new JsonResource(...)`) — guarded by `isFrameworkClass`, so no edges to unopenable vendor nodes.
- **`self` / `static` / `parent`** keyword references — never mis-resolved to a phantom `\Http\Resources\static`.
- **A resource composing its own type** (a recursive tree of comments/interactions) — a self-loop that adds no reach.

## Tests

10 Pest tests in `ResourceEdgeTest`: `make` / `collection` / `new`, sibling-namespace resolution, transitive nested descent, model-hop preservation alongside the resource, the framework-class exclusion, the `self`/`static` phantom exclusion, the recursive self-loop exclusion, and the Filament non-collision, plus the graph-wiring (`action-to-resource` / `resource-to-resource` edges labelled `transforms`).

Verified: `pint` clean · `phpstan` (level 5 + larastan) **No errors** · full suite **121 passed**. Dogfooded against a real ~large Laravel app (99 resources): **51 resource→resource composition edges**, correct action→resource links, and — after the guards above — **0** framework, phantom, or self-loop edges.

## Note

Independent of #58 (observers), #60 (policies), #61 (Blade view composition). All branch from `main`; this one touches `MethodTracer`, so a trivial rebase may be needed depending on merge order. Happy to do that.

