### PR TITLE
Fix false "public route" warnings for routes behind app auth middleware (#59)

### DIFF
--- a/src/Analysis/SecurityAnalyzer.php
+++ b/src/Analysis/SecurityAnalyzer.php
@@ -558,6 +558,7 @@ class SecurityAnalyzer
     private function middlewareMatches(string $middleware, array $patterns): bool
     {
         $lower = strtolower($middleware);
+        $base = $this->middlewareBasename($middleware);
         foreach ($patterns as $pattern) {
             $p = strtolower($pattern);
             if (str_ends_with($p, ':')) {
@@ -570,10 +571,28 @@ class SecurityAnalyzer
                 if ($lower === $p || str_starts_with($lower, $p.':') || str_starts_with($lower, $p.'\\')) {
                     return true;
                 }
+                // Match a framework middleware by class name alone, so the app's
+                // own same-named subclass (App\Http\Middleware\Authenticate) is
+                // recognised. A name match, not a verified subclass check.
+                if (str_contains($p, '\\') && $base !== '' && $base === $this->middlewareBasename($pattern)) {
+                    return true;
+                }
             }
         }
 
         return false;
+    }
+
+    /**
+     * The lowercased class name of a middleware, ignoring any `:params` suffix —
+     * e.g. `App\Http\Middleware\Authenticate:web` → `authenticate`.
+     */
+    private function middlewareBasename(string $middleware): string
+    {
+        $name = explode(':', $middleware, 2)[0];
+        $pos = strrpos($name, '\\');
+
+        return strtolower($pos === false ? $name : substr($name, $pos + 1));
     }
 
     /**

--- a/tests/Unit/SecurityAnalyzerTest.php
+++ b/tests/Unit/SecurityAnalyzerTest.php
@@ -77,6 +77,57 @@ it('classifies a custom auth alias as authed when its resolved FQCN is in extra 
     expect(exposure($route, $registry, ['App\Http\Middleware\CustomAuth']))->toBe('authed');
 });
 
+it('classifies the app Authenticate subclass as authed (nested-group false positive)', function () {
+    // The app applies its own middleware, which subclasses the framework one.
+    $route = makeSecurityRoute('GET', '/dashboard', ['web', 'App\Http\Middleware\Authenticate']);
+    $registry = new MiddlewareRegistry([], [], []);
+
+    expect(exposure($route, $registry))->toBe('authed');
+});
+
+it('classifies a route guarded by an inherited group auth stack as admin, not public', function () {
+    // The full nested-group stack from laramint/laravel-brain#59.
+    $route = makeSecurityRoute('DELETE', '/admin/categories/{category}', [
+        'web',
+        'App\Http\Middleware\Authenticate',
+        'App\Http\Middleware\ForcePasswordReset',
+        'role:admin',
+    ]);
+    $registry = new MiddlewareRegistry([], [], []);
+
+    expect(exposure($route, $registry))->toBe('admin');
+});
+
+it('does not raise PUBLIC_WRITE on a mutating route behind the app auth stack', function () {
+    // The reporter's concrete symptom: a DELETE inside an authenticated group.
+    $route = makeSecurityRoute('DELETE', '/admin/categories/{category}', [
+        'web',
+        'App\Http\Middleware\Authenticate',
+        'role:admin',
+    ]);
+    $analyzer = new SecurityAnalyzer;
+    $results = $analyzer->analyze([$route], new MiddlewareRegistry([], [], []), [], '');
+    $types = array_map(fn ($i) => $i->type, $results['route::DELETE::/admin/categories/{category}']['issues']);
+
+    expect($types)->not->toContain('PUBLIC_WRITE');
+});
+
+it('treats an app RedirectIfAuthenticated subclass as guest', function () {
+    $route = makeSecurityRoute('GET', '/login', ['web', 'App\Http\Middleware\RedirectIfAuthenticated']);
+    $registry = new MiddlewareRegistry([], [], []);
+
+    expect(exposure($route, $registry))->toBe('guest');
+});
+
+it('does not treat a same-prefixed non-auth middleware as authentication', function () {
+    // AuthenticateSession binds the session; it is not the auth gate, and its
+    // class name differs from Authenticate, so it must not flip the exposure.
+    $route = makeSecurityRoute('GET', '/open', ['web', 'App\Http\Middleware\AuthenticateSession']);
+    $registry = new MiddlewareRegistry([], [], []);
+
+    expect(exposure($route, $registry))->toBe('public');
+});
+
 // =============================================================================
 // False-positive fixes for UNVALIDATED_INPUT, PUBLIC_WRITE and MISSING_THROTTLE
 // =============================================================================


### PR DESCRIPTION
Fixes #59.

## Problem

`SecurityAnalyzer` flags routes as **"Public Route — no authentication middleware detected"** (HIGH risk) even when they're guarded by auth middleware inherited from a parent `Route::group()`, and correspondingly raises false **PUBLIC_WRITE** alerts on mutating routes inside those groups. On a real app this produced **80+ false HIGH-risk alerts**, drowning out genuine findings.

## Root cause

Apps generate and apply their **own** auth middleware — `App\Http\Middleware\Authenticate`, a subclass of the framework class, applied as `Authenticate::class`. So a route carries the app FQCN, not the `auth` alias or `Illuminate\Auth\Middleware\Authenticate`. `middlewareMatches()` only matched the alias and the *exact* framework FQCN (prefix match), so the app's own auth middleware registered as no auth at all — even though Brain's own lifecycle graph renders `Authenticate` in the chain for the same route (the contradiction the issue notes).

## Fix

`middlewareMatches()` now also matches a framework-middleware FQCN pattern **by class name**, so `App\Http\Middleware\Authenticate` is recognised as `Illuminate\Auth\Middleware\Authenticate`. This applies uniformly to the five reserved framework middleware names:

| name | exposure |
|---|---|
| `Authenticate` | auth |
| `ValidateSignature` | auth (signed URL) |
| `RedirectIfAuthenticated` | guest |
| `Authorize` | admin |
| `ThrottleRequests` | throttle |

It is a **name match, not a verified subclass check** (documented in-code) — consistent with the analyzer's existing `*_PATTERNS` heuristic style — and is **guarded to FQCN patterns only** (`str_contains($pattern, '\\')`), so the `auth`/`guest`/`throttle`/`admin` alias semantics are unchanged. A middleware whose name differs, e.g. `AuthenticateSession`, is deliberately not matched (covered by a negative test).

## Tests

5 new cases in `SecurityAnalyzerTest`: the app `Authenticate` subclass → authed; the full nested-group stack (`web`, app `Authenticate`, `role:admin`) → admin; a **direct assertion that PUBLIC_WRITE is not raised** on the reporter's DELETE symptom; the app `RedirectIfAuthenticated` → guest; and the negative `AuthenticateSession` → still public. Existing `CustomAuth`-name-and-config tests still pass (the fix doesn't over-match).

Verified: `pint` clean · `phpstan` (level 5 + larastan) **No errors** · full suite **116 passed**. Reproduced and confirmed fixed against a real large app: routes carrying an app `Authenticate` subclass dropped from **292 mis-classified "public" to 118** — the remainder being genuinely public (login/error pages) or custom-named auth middleware, which the existing `security.auth_middleware` config already covers.

## Note

For stricter precision a future change could resolve the middleware's `extends` chain rather than match by name; the name heuristic was chosen to match the repo's existing style and to keep the fix minimal. Branches from `main`.

