### PR TITLE
Stop skipping files that open with declare(strict_types=1) in the binding, facade and inheritance scans

### DIFF
--- a/src/Analysis/ContainerBindingAnalyzer.php
+++ b/src/Analysis/ContainerBindingAnalyzer.php
@@ -66,9 +66,15 @@ final class ContainerBindingAnalyzer
         $useMap = $parsed['useMap'];
         $ns = PhpExtendsFqcnResolver::namespaceFromAst($ast);
 
+        // Find the namespace wherever it sits: a leading `declare(strict_types=1);` shifts it off
+        // index 0, which used to make the scan silently skip the whole provider. Same iteration
+        // PhpExtendsFqcnResolver::namespaceFromAst() uses to resolve $ns above.
         $stmts = $ast;
-        if (isset($stmts[0]) && $stmts[0] instanceof Namespace_) {
-            $stmts = $stmts[0]->stmts;
+        foreach ($ast as $stmt) {
+            if ($stmt instanceof Namespace_) {
+                $stmts = $stmt->stmts;
+                break;
+            }
         }
 
         foreach ($stmts as $stmt) {

--- a/src/Analysis/FacadeAnalyzer.php
+++ b/src/Analysis/FacadeAnalyzer.php
@@ -322,8 +322,13 @@ final class FacadeAnalyzer
         if (! is_array($ast)) {
             return [];
         }
-        if (isset($ast[0]) && $ast[0] instanceof Namespace_) {
-            return $ast[0]->stmts;
+
+        // Find the namespace wherever it sits: a leading `declare(strict_types=1);` shifts it off
+        // index 0, which used to make every scan through here silently skip the whole file.
+        foreach ($ast as $stmt) {
+            if ($stmt instanceof Namespace_) {
+                return $stmt->stmts;
+            }
         }
 
         return $ast;

--- a/src/Graph/GraphBuilder.php
+++ b/src/Graph/GraphBuilder.php
@@ -359,9 +359,14 @@ class GraphBuilder
      */
     private function extractExtendsFromAst(array $ast, string $ns, array $useMap): ?string
     {
+        // Find the namespace wherever it sits: a leading `declare(strict_types=1);` shifts it off
+        // index 0, which used to break the inheritance walk for strict-typed child classes.
         $stmts = $ast;
-        if (isset($stmts[0]) && $stmts[0] instanceof PhpNode\Stmt\Namespace_) {
-            $stmts = $stmts[0]->stmts;
+        foreach ($ast as $stmt) {
+            if ($stmt instanceof PhpNode\Stmt\Namespace_) {
+                $stmts = $stmt->stmts;
+                break;
+            }
         }
         foreach ($stmts as $stmt) {
             if ($stmt instanceof PhpNode\Stmt\Class_ && $stmt->extends !== null) {

--- a/tests/Unit/ContainerBindingAnalyzerTest.php
+++ b/tests/Unit/ContainerBindingAnalyzerTest.php
@@ -13,3 +13,13 @@ it('extracts singleton bindings from fixture AppServiceProvider', function () {
         ->providerFqcn->toBe('App\Providers\AppServiceProvider')
         ->kind->toBe('singleton');
 });
+
+it('extracts bindings from a provider that opens with declare(strict_types=1)', function () {
+    $registry = (new ContainerBindingAnalyzer)->analyze(fixture('strict-types-project'));
+    $rec = $registry->get('App\Contracts\ClockInterface');
+
+    expect($rec)
+        ->concreteFqcn->toBe('App\Support\SystemClock')
+        ->providerFqcn->toBe('App\Providers\StrictTypesServiceProvider')
+        ->kind->toBe('singleton');
+});

--- a/tests/Unit/FacadeAnalyzerTest.php
+++ b/tests/Unit/FacadeAnalyzerTest.php
@@ -84,3 +84,17 @@ it('resolveWith does not overwrite an already-resolved concreteFqcn', function (
     $record = $facadeRegistry->get('App\Services\V3\ShortUrlV3Facade');
     expect($record?->concreteFqcn)->toBe('App\Services\V3\ShortUrlV3Service');
 });
+
+it('discovers a facade whose files open with declare(strict_types=1)', function () {
+    $registry = (new FacadeAnalyzer)->analyze(fixture('strict-types-project'));
+
+    // Both the concrete facade and the abstract parent carrying getFacadeAccessor() open with
+    // declare(strict_types=1), so the Namespace_ node is never at index 0 — this exercises the
+    // unwrap in scanFile(), isInFacadeChain() and findAccessorInChain() in one chain.
+    $record = $registry->get('App\Support\Facades\StrictClockFacade');
+
+    expect($record)
+        ->toBeInstanceOf(FacadeRecord::class)
+        ->accessor->toBe('App\Support\SystemClock')
+        ->concreteFqcn->toBe('App\Support\SystemClock');
+});

--- a/tests/Unit/FindMethodNodeInChainTest.php
+++ b/tests/Unit/FindMethodNodeInChainTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use LaraMint\LaravelBrain\Graph\GraphBuilder;
+
+it('walks the inheritance chain of a class that opens with declare(strict_types=1)', function () {
+    $builder = new GraphBuilder;
+
+    $psr4 = new ReflectionProperty(GraphBuilder::class, 'psr4Map');
+
+    if (\PHP_VERSION_ID < 80100) {
+        $psr4->setAccessible(true);
+    }
+
+    $psr4->setValue($builder, ['App' => fixture('strict-types-project').'/app']);
+
+    $method = new ReflectionMethod(GraphBuilder::class, 'findMethodNodeInChain');
+
+    if (\PHP_VERSION_ID < 80100) {
+        $method->setAccessible(true);
+    }
+
+    // show() lives on the parent only, so resolving it from the child forces the extends walk
+    // through extractExtendsFromAst() — on an AST whose Namespace_ node sits behind the declare.
+    $found = $method->invoke($builder, 'App\Http\Controllers\StrictTypesChildController', 'show');
+
+    expect($found)->not->toBeNull()
+        ->and($found['declaringFqcn'])->toBe('App\Http\Controllers\StrictTypesBaseController');
+});

--- a/tests/fixtures/strict-types-project/app/Http/Controllers/StrictTypesBaseController.php
+++ b/tests/fixtures/strict-types-project/app/Http/Controllers/StrictTypesBaseController.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+class StrictTypesBaseController
+{
+    public function show(): string
+    {
+        return 'ok';
+    }
+}

--- a/tests/fixtures/strict-types-project/app/Http/Controllers/StrictTypesChildController.php
+++ b/tests/fixtures/strict-types-project/app/Http/Controllers/StrictTypesChildController.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+final class StrictTypesChildController extends StrictTypesBaseController
+{
+    public function index(): string
+    {
+        return 'index';
+    }
+}

--- a/tests/fixtures/strict-types-project/app/Providers/StrictTypesServiceProvider.php
+++ b/tests/fixtures/strict-types-project/app/Providers/StrictTypesServiceProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use App\Contracts\ClockInterface;
+use App\Support\SystemClock;
+use Illuminate\Support\ServiceProvider;
+
+class StrictTypesServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->singleton(ClockInterface::class, SystemClock::class);
+    }
+}

--- a/tests/fixtures/strict-types-project/app/Support/Facades/AbstractStrictClockFacade.php
+++ b/tests/fixtures/strict-types-project/app/Support/Facades/AbstractStrictClockFacade.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Facades;
+
+use App\Support\SystemClock;
+use Illuminate\Support\Facades\Facade;
+
+abstract class AbstractStrictClockFacade extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return SystemClock::class;
+    }
+}

--- a/tests/fixtures/strict-types-project/app/Support/Facades/StrictClockFacade.php
+++ b/tests/fixtures/strict-types-project/app/Support/Facades/StrictClockFacade.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Facades;
+
+final class StrictClockFacade extends AbstractStrictClockFacade {}


### PR DESCRIPTION
## What

Three scans unwrap a file's namespace only when it is the *first* statement in the AST. A file that opens with `declare(strict_types=1);` shifts the `Namespace_` node to index 1, so the unwrap never fires, no top-level `Class_` is found, and the file is silently skipped — one bug class, three surfaces:

- `ContainerBindingAnalyzer::scanFile()` — **strict-typed apps get zero container-binding records**, across both registration surfaces (`bind()`/`singleton()`/`scoped()` calls and the `$bindings`/`$singletons` properties).
- `FacadeAnalyzer::topLevelStmts()` — feeds all three facade scans (`scanFile()`, `isInFacadeChain()`, `findAccessorInChain()`), so a strict-typed facade never reaches the registry, and a strict-typed intermediate parent silently breaks chain and accessor resolution for its children.
- `GraphBuilder::extractExtendsFromAst()` — the method inheritance walk (`findMethodNodeInChain()`, which feeds flow steps and complexity metrics) cannot resolve the parent of a strict-typed child class, so inherited methods read as missing.

## How

Each unwrap now iterates the top-level statements to the first `Namespace_` — the same iteration `PhpExtendsFqcnResolver::namespaceFromAst()` already performs to resolve the namespace string, so the namespace string and the statement list can no longer disagree about where the namespace lives. Files without a namespace fall through unchanged.

## Scope

- Behavioral surface is the three statement unwraps only — extraction, name resolution, and registry semantics are untouched.
- Files without a leading `declare` scan exactly as before (every pre-existing fixture test passes unchanged).
- Found while building [sandermuller/richter](https://github.com/SanderMuller/richter) on top of Brain: its fixture app enforces `declare(strict_types=1)` via Pint, which made every container binding vanish from the graph — the silent-empty failure shape that made this worth fixing at the root. The facade and inheritance-walk instances are the same pattern found by sweeping `src/` for the remaining `$stmts[0] instanceof Namespace_` sites; after this PR that sweep comes back empty.
- Adjacent observation, deliberately **not** touched here: `ContainerBindingAnalyzer::scanFile()` still scans only the first class per file (`break` after the first `Class_`). Fine for real-world providers — noting it only so the scope of this fix is unambiguous.

## Tests

- Fixture project `tests/fixtures/strict-types-project/` (the `security-project` pattern, so `GraphBuilderTest`'s exact edge-count assertion on the shared `laravel-project` fixture stays untouched) grows a strict-typed facade pair — concrete `StrictClockFacade` plus abstract parent carrying `getFacadeAccessor()`, exercising all three facade call sites in one chain — and a strict-typed controller pair whose method lives on the parent only.
- `ContainerBindingAnalyzerTest`: *it extracts bindings from a provider that opens with declare(strict_types=1)* — fails on `main` (the registry comes back empty), passes with the fix.
- `FacadeAnalyzerTest`: *it discovers a facade whose files open with declare(strict_types=1)* — fails on `main` (the facade never reaches the registry), passes with the fix.
- `FindMethodNodeInChainTest`: *it walks the inheritance chain of a class that opens with declare(strict_types=1)* — follows the `ResolveBladePathTest` reflection pattern for private-method coverage; fails on `main` (the walk returns null), passes with the fix.

Verified: full Pest suite **114 passed (450 assertions)** · Pint clean · PHPStan **No errors**. The 3 deprecation notices in the suite are pre-existing vendor tooling on PHP 8.5 (`pest-plugin-arch` calling `ReflectionProperty::setAccessible()`), unrelated to this change.

