### PR TITLE
Stop re-parsing and re-walking the project on every lookup

### DIFF
--- a/src/Analysis/ControllerAnalyzer.php
+++ b/src/Analysis/ControllerAnalyzer.php
@@ -616,23 +616,6 @@ class ControllerAnalyzer
             $searchDirs[] = 'Modules';
         }
 
-        foreach ($searchDirs as $dir) {
-            $base = $projectRoot.'/'.$dir;
-            if (! is_dir($base)) {
-                continue;
-            }
-
-            $iterator = new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator($base, \FilesystemIterator::SKIP_DOTS)
-            );
-
-            foreach ($iterator as $file) {
-                if ($file->getFilename() === $filename) {
-                    return $file->getPathname();
-                }
-            }
-        }
-
-        return null;
+        return ProjectFileIndex::findFile($projectRoot, $searchDirs, $filename);
     }
 }

--- a/src/Analysis/FacadeAnalyzer.php
+++ b/src/Analysis/FacadeAnalyzer.php
@@ -62,10 +62,27 @@ final class FacadeAnalyzer
             if ($file->getExtension() !== 'php') {
                 continue;
             }
+            if (! $this->mightDefineFacade($file->getPathname())) {
+                continue;
+            }
             $this->scanFile($file->getPathname(), $registry);
         }
 
         return $registry;
+    }
+
+    /**
+     * A facade reaches Facade through `extends`, so a file without the keyword cannot define
+     * one. Crude in the safe direction: `extends` in a comment or a string only costs a scan
+     * that would have happened anyway.
+     */
+    private function mightDefineFacade(string $file): bool
+    {
+        $code = @file_get_contents($file);
+
+        // stripos, not str_contains: PHP keywords are case-insensitive, and `class X EXTENDS Y`
+        // is valid source.
+        return $code !== false && stripos($code, 'extends') !== false;
     }
 
     private function scanFile(string $file, FacadeRegistry $registry): void

--- a/src/Analysis/FacadeAnalyzer.php
+++ b/src/Analysis/FacadeAnalyzer.php
@@ -33,6 +33,8 @@ final class FacadeAnalyzer
 
     private string $appDir = '';
 
+    private string $projectRoot = '';
+
     /** @var array<string, array{ast: mixed, useMap: array<string,string>}|null> */
     private array $parseCache = [];
 
@@ -45,7 +47,8 @@ final class FacadeAnalyzer
     {
         $registry = new FacadeRegistry;
         $this->parseCache = [];
-        $this->appDir = rtrim($projectRoot, '/').'/app';
+        $this->projectRoot = rtrim($projectRoot, '/');
+        $this->appDir = $this->projectRoot.'/app';
 
         if (! is_dir($this->appDir)) {
             return $registry;
@@ -276,7 +279,7 @@ final class FacadeAnalyzer
      */
     private function findFileInAppDir(string $fqcn): ?string
     {
-        if ($this->appDir === '' || ! is_dir($this->appDir)) {
+        if ($this->projectRoot === '') {
             return null;
         }
 
@@ -284,17 +287,7 @@ final class FacadeAnalyzer
             ? substr($fqcn, strrpos($fqcn, '\\') + 1)
             : $fqcn;
 
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($this->appDir, \FilesystemIterator::SKIP_DOTS)
-        );
-
-        foreach ($iterator as $file) {
-            if ($file->getFilename() === $shortName.'.php') {
-                return $file->getPathname();
-            }
-        }
-
-        return null;
+        return ProjectFileIndex::findFile($this->projectRoot, ['app'], $shortName.'.php');
     }
 
     /**

--- a/src/Analysis/MethodTracer.php
+++ b/src/Analysis/MethodTracer.php
@@ -8,6 +8,7 @@ use LaraMint\LaravelBrain\Parser\PhpExtendsFqcnResolver;
 use LaraMint\LaravelBrain\Parser\PhpFileParser;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitorAbstract;
 
 /**
@@ -1122,6 +1123,10 @@ class MethodTracer
                     }
 
                     $this->methods[$name] = $node;
+
+                    // Collecting signatures does not need the body, and not descending stops a
+                    // method of an anonymous class inside it from overwriting this one.
+                    return NodeVisitor::DONT_TRAVERSE_CHILDREN;
                 }
 
                 return null;

--- a/src/Analysis/MethodTracer.php
+++ b/src/Analysis/MethodTracer.php
@@ -1208,24 +1208,7 @@ class MethodTracer
 
         $filename = $shortName.'.php';
 
-        foreach (['app', 'src'] as $dir) {
-            $base = $this->projectRoot.'/'.$dir;
-            if (! is_dir($base)) {
-                continue;
-            }
-
-            $iterator = new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator($base, \FilesystemIterator::SKIP_DOTS)
-            );
-
-            foreach ($iterator as $file) {
-                if ($file->getFilename() === $filename) {
-                    return $file->getPathname();
-                }
-            }
-        }
-
-        return null;
+        return ProjectFileIndex::findFile($this->projectRoot, ['app', 'src'], $filename);
     }
 
     private function fallbackEntryMethod(string $fqcn, string $requested, array $methods): string

--- a/src/Analysis/PhpStructureInspector.php
+++ b/src/Analysis/PhpStructureInspector.php
@@ -18,6 +18,13 @@ class PhpStructureInspector
 {
     private PhpFileParser $parser;
 
+    /**
+     * Per-file memo: GraphBuilder inspects the same file once per node it builds from it.
+     *
+     * @var array<string, array{kind: string, members: list<array<string, mixed>>}|null>
+     */
+    private array $inspectCache = [];
+
     public function __construct(?PhpFileParser $parser = null)
     {
         $this->parser = $parser ?? new PhpFileParser;
@@ -27,6 +34,18 @@ class PhpStructureInspector
      * @return array{kind: string, members: list<array<string, mixed>>}|null
      */
     public function inspectFile(string $file): ?array
+    {
+        if (array_key_exists($file, $this->inspectCache)) {
+            return $this->inspectCache[$file];
+        }
+
+        return $this->inspectCache[$file] = $this->inspectFileUncached($file);
+    }
+
+    /**
+     * @return array{kind: string, members: list<array<string, mixed>>}|null
+     */
+    private function inspectFileUncached(string $file): ?array
     {
         if (! is_file($file)) {
             return null;

--- a/src/Analysis/ProjectAnalyzer.php
+++ b/src/Analysis/ProjectAnalyzer.php
@@ -126,6 +126,10 @@ class ProjectAnalyzer
         }
 
         $projectRoot = rtrim($projectRoot, '/');
+
+        // Rebuilt per analysis, so a rescan sees files added since the previous one.
+        ProjectFileIndex::clear();
+
         $appName = function_exists('config') ? config('app.name') : null;
         $projectName = (is_string($appName) && $appName !== '') ? $appName : 'Laravel Brain';
         $analyzedAt = date('c');

--- a/src/Analysis/ProjectFileIndex.php
+++ b/src/Analysis/ProjectFileIndex.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaraMint\LaravelBrain\Analysis;
+
+/**
+ * Filename index for the by-short-name lookups Brain falls back to when PSR-4 resolution cannot
+ * place a class, replacing a recursive directory walk per class asked about.
+ *
+ * Lookup semantics are unchanged: within a searched directory the first file in
+ * RecursiveIteratorIterator order whose name matches wins — the iterator yields leaves only,
+ * exactly as the replaced loops did — and callers keep their own directory precedence.
+ *
+ * Process-static, cleared at the start of every ProjectAnalyzer::analyze(), so a rescan or any
+ * long-lived process sees files added since the previous build.
+ */
+class ProjectFileIndex
+{
+    /** @var array<string, array<string, string>> absolute dir => filename => first matching path */
+    private static array $index = [];
+
+    public static function clear(): void
+    {
+        self::$index = [];
+    }
+
+    /**
+     * @param  list<string>  $dirs  directories relative to $projectRoot, in precedence order
+     */
+    public static function findFile(string $projectRoot, array $dirs, string $filename): ?string
+    {
+        foreach ($dirs as $dir) {
+            $base = rtrim($projectRoot, '/').'/'.$dir;
+            $map = self::$index[$base] ??= self::buildDirIndex($base);
+            if (isset($map[$filename])) {
+                return $map[$filename];
+            }
+        }
+
+        return null;
+    }
+
+    /** @return array<string, string> filename => first matching path in walk order */
+    private static function buildDirIndex(string $base): array
+    {
+        if (! is_dir($base)) {
+            return [];
+        }
+
+        $map = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($base, \FilesystemIterator::SKIP_DOTS)
+        );
+        foreach ($iterator as $file) {
+            $map[$file->getFilename()] ??= $file->getPathname();
+        }
+
+        return $map;
+    }
+}

--- a/src/Graph/GraphBuilder.php
+++ b/src/Graph/GraphBuilder.php
@@ -49,13 +49,18 @@ class GraphBuilder
     private array $resolveFileMemo = [];
 
     /**
-     * Maximum number of parsed file ASTs to keep in memory at once.
-     * Oldest entries are evicted when the limit is reached to prevent OOM on large codebases.
+     * Per-file method map, use map and resolved parent — see fileClassInfo().
+     *
+     * @var array<string, array{methods: array<string, PhpNode\Stmt\ClassMethod>, useMap: array<string,string>, parent: ?string}|null>
      */
-    private const PARSE_CACHE_MAX = 200;
+    private array $fileClassInfo = [];
 
-    /** @var array<string, array> file path => parsed result cache (bounded, insertion-ordered) */
-    private array $parseCache = [];
+    /**
+     * Memoized findMethodNodeInChain() results, keyed by "fqcn\0method".
+     *
+     * @var array<string, array{methodNode: PhpNode\Stmt\ClassMethod, useMap: array<string,string>, file: string, declaringFqcn: string}|null>
+     */
+    private array $methodNodeMemo = [];
 
     /**
      * Accumulator for fat-class detection.
@@ -293,63 +298,48 @@ class GraphBuilder
             return null;
         }
 
+        // Entry calls only: a nested call has already spent part of the five-hop budget, so its
+        // result is not the answer to the same question.
+        $memoKey = $fqcn."\0".$method;
+        if ($depth === 0 && array_key_exists($memoKey, $this->methodNodeMemo)) {
+            return $this->methodNodeMemo[$memoKey];
+        }
+
+        $found = $this->findMethodNodeInChainUncached($fqcn, $method, $depth);
+
+        if ($depth === 0) {
+            $this->methodNodeMemo[$memoKey] = $found;
+        }
+
+        return $found;
+    }
+
+    /**
+     * @return array{methodNode: PhpNode\Stmt\ClassMethod, useMap: array<string,string>, file: string, declaringFqcn: string}|null
+     */
+    private function findMethodNodeInChainUncached(string $fqcn, string $method, int $depth): ?array
+    {
         $file = $this->resolveFile($fqcn);
         if ($file === '') {
             return null;
         }
 
-        if (! isset($this->parseCache[$file])) {
-            if (count($this->parseCache) >= self::PARSE_CACHE_MAX) {
-                // Evict the oldest quarter of entries to avoid repeated single evictions
-                $evictCount = (int) (self::PARSE_CACHE_MAX / 4);
-                foreach (array_keys($this->parseCache) as $k) {
-                    unset($this->parseCache[$k]);
-                    if (--$evictCount <= 0) {
-                        break;
-                    }
-                }
-            }
-            $this->parseCache[$file] = $this->parser->parse($file);
-        }
-        $parsed = $this->parseCache[$file];
-        if (! $parsed || ! $parsed['ast']) {
+        $info = $this->fileClassInfo($file);
+        if ($info === null) {
             return null;
         }
 
-        $traverser = new NodeTraverser;
-        $finder = new class($method) extends NodeVisitorAbstract
-        {
-            public ?PhpNode\Stmt\ClassMethod $found = null;
-
-            public function __construct(private string $target) {}
-
-            public function enterNode(PhpNode $node): ?int
-            {
-                if ($node instanceof PhpNode\Stmt\ClassMethod
-                    && $node->name->toString() === $this->target) {
-                    $this->found = $node;
-
-                    return NodeVisitor::STOP_TRAVERSAL;
-                }
-
-                return null;
-            }
-        };
-        $traverser->addVisitor($finder);
-        $traverser->traverse($parsed['ast']);
-
-        if ($finder->found !== null) {
+        if (isset($info['methods'][$method])) {
             return [
-                'methodNode' => $finder->found,
-                'useMap' => $parsed['useMap'] ?? [],
+                'methodNode' => $info['methods'][$method],
+                'useMap' => $info['useMap'],
                 'file' => $file,
                 'declaringFqcn' => $fqcn,
             ];
         }
 
         // Method not in this class — walk up to the parent if it is an app class.
-        $ns = PhpExtendsFqcnResolver::namespaceFromAst($parsed['ast']);
-        $parentFqcn = $this->extractExtendsFromAst($parsed['ast'], $ns, $parsed['useMap'] ?? []);
+        $parentFqcn = $info['parent'];
         if (
             $parentFqcn !== null
             && ! str_starts_with($parentFqcn, 'Illuminate\\')
@@ -359,6 +349,55 @@ class GraphBuilder
         }
 
         return null;
+    }
+
+    /**
+     * Everything the chain walk needs from one file, collected in a single traversal and kept
+     * for the build: its methods by name, its use map, and its resolved parent FQCN. The
+     * traversal does not descend into method bodies.
+     *
+     * @return array{methods: array<string, PhpNode\Stmt\ClassMethod>, useMap: array<string,string>, parent: ?string}|null
+     */
+    private function fileClassInfo(string $file): ?array
+    {
+        if (array_key_exists($file, $this->fileClassInfo)) {
+            return $this->fileClassInfo[$file];
+        }
+
+        $parsed = $this->parser->parse($file);
+        if (! $parsed['ast']) {
+            return $this->fileClassInfo[$file] = null;
+        }
+
+        $traverser = new NodeTraverser;
+        $collector = new class extends NodeVisitorAbstract
+        {
+            /** @var array<string, PhpNode\Stmt\ClassMethod> */
+            public array $methods = [];
+
+            public function enterNode(PhpNode $node): ?int
+            {
+                if ($node instanceof PhpNode\Stmt\ClassMethod) {
+                    // First declaration wins, as with the previous stop-at-first-match.
+                    $this->methods[$node->name->toString()] ??= $node;
+
+                    // The node keeps its body for later use; collecting names does not need it.
+                    return NodeVisitor::DONT_TRAVERSE_CHILDREN;
+                }
+
+                return null;
+            }
+        };
+        $traverser->addVisitor($collector);
+        $traverser->traverse($parsed['ast']);
+
+        $ns = PhpExtendsFqcnResolver::namespaceFromAst($parsed['ast']);
+
+        return $this->fileClassInfo[$file] = [
+            'methods' => $collector->methods,
+            'useMap' => $parsed['useMap'] ?? [],
+            'parent' => $this->extractExtendsFromAst($parsed['ast'], $ns, $parsed['useMap'] ?? []),
+        ];
     }
 
     /**
@@ -1684,57 +1723,22 @@ class GraphBuilder
 
     private function extractVisibility(string $fqcn, string $method): string
     {
-        $file = $this->resolveFile($fqcn);
-        if ($file === '' || ! file_exists($file)) {
+        // The declaringFqcn check keeps the original semantics: only a method declared in
+        // $fqcn's own file has a visibility here; an inherited one reports 'public'.
+        $found = $this->findMethodNodeInChain($fqcn, $method);
+        if ($found === null || $found['declaringFqcn'] !== $fqcn) {
             return 'public';
         }
 
-        if (! isset($this->parseCache[$file])) {
-            if (count($this->parseCache) >= self::PARSE_CACHE_MAX) {
-                $evictCount = (int) (self::PARSE_CACHE_MAX / 4);
-                foreach (array_keys($this->parseCache) as $k) {
-                    unset($this->parseCache[$k]);
-                    if (--$evictCount <= 0) {
-                        break;
-                    }
-                }
-            }
-            $this->parseCache[$file] = $this->parser->parse($file);
+        $node = $found['methodNode'];
+        if ($node->isPrivate()) {
+            return 'private';
         }
-        $parsed = $this->parseCache[$file];
-        if (! $parsed || ! $parsed['ast']) {
-            return 'public';
+        if ($node->isProtected()) {
+            return 'protected';
         }
 
-        $traverser = new NodeTraverser;
-        $finder = new class($method) extends NodeVisitorAbstract
-        {
-            public string $visibility = 'public';
-
-            public function __construct(private string $target) {}
-
-            public function enterNode(PhpNode $node): ?int
-            {
-                if ($node instanceof PhpNode\Stmt\ClassMethod
-                    && $node->name->toString() === $this->target) {
-                    if ($node->isPrivate()) {
-                        $this->visibility = 'private';
-                    } elseif ($node->isProtected()) {
-                        $this->visibility = 'protected';
-                    } else {
-                        $this->visibility = 'public';
-                    }
-
-                    return NodeVisitor::STOP_TRAVERSAL;
-                }
-
-                return null;
-            }
-        };
-        $traverser->addVisitor($finder);
-        $traverser->traverse($parsed['ast']);
-
-        return $finder->visibility;
+        return 'public';
     }
 
     private function hasN1InSteps(array $steps): bool

--- a/src/Graph/GraphBuilder.php
+++ b/src/Graph/GraphBuilder.php
@@ -23,6 +23,7 @@ use LaraMint\LaravelBrain\Analysis\MethodTracer;
 use LaraMint\LaravelBrain\Analysis\MiddlewareRegistry;
 use LaraMint\LaravelBrain\Analysis\ModelDefinition;
 use LaraMint\LaravelBrain\Analysis\PhpStructureInspector;
+use LaraMint\LaravelBrain\Analysis\ProjectFileIndex;
 use LaraMint\LaravelBrain\Analysis\RouteDefinition;
 use LaraMint\LaravelBrain\Analysis\ScheduleEntry;
 use LaraMint\LaravelBrain\Analysis\ValidationRulesExtractor;
@@ -212,24 +213,7 @@ class GraphBuilder
 
         $filename = $shortName.'.php';
 
-        foreach (['app', 'src'] as $dir) {
-            $base = $this->projectRoot.'/'.$dir;
-            if (! is_dir($base)) {
-                continue;
-            }
-
-            $iterator = new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator($base, \FilesystemIterator::SKIP_DOTS)
-            );
-
-            foreach ($iterator as $file) {
-                if ($file->getFilename() === $filename) {
-                    return $file->getPathname();
-                }
-            }
-        }
-
-        return '';
+        return ProjectFileIndex::findFile($this->projectRoot, ['app', 'src'], $filename) ?? '';
     }
 
     /**

--- a/src/Graph/GraphBuilder.php
+++ b/src/Graph/GraphBuilder.php
@@ -45,6 +45,9 @@ class GraphBuilder
 
     private array $psr4Map = [];
 
+    /** @var array<string, string> FQCN => resolved path ('' when unresolvable), per build */
+    private array $resolveFileMemo = [];
+
     /**
      * Maximum number of parsed file ASTs to keep in memory at once.
      * Oldest entries are evicted when the limit is reached to prevent OOM on large codebases.
@@ -149,8 +152,16 @@ class GraphBuilder
 
     /**
      * Resolve an FQCN to an absolute file path using the PSR-4 map.
+     *
+     * Memoized for the build: the answer depends only on the FQCN, the PSR-4 map and the
+     * project root, all fixed once buildGraph() starts.
      */
     private function resolveFile(string $fqcn): string
+    {
+        return $this->resolveFileMemo[$fqcn] ??= $this->resolveFileUncached($fqcn);
+    }
+
+    private function resolveFileUncached(string $fqcn): string
     {
         // Livewire v2 namespace::dot.notation (e.g. 'pages::password.create')
         if (str_contains($fqcn, '::') && ! str_contains($fqcn, '\\')) {

--- a/src/Parser/PhpFileParser.php
+++ b/src/Parser/PhpFileParser.php
@@ -17,9 +17,42 @@ class PhpFileParser
 {
     private Parser $parser;
 
+    /**
+     * Parse results shared by every PhpFileParser instance in the process, so a file is read,
+     * tokenized, parsed and name-resolved once per build instead of once per analyzer. Keyed by
+     * path + mtime + size, so any edit invalidates its own entry and nothing else.
+     *
+     * Sharing the AST *objects* is safe because Brain only ever reads the tree: every visitor in
+     * src/ returns null or a traversal-control int — none returns a replacement node — and the
+     * NameResolver in {@see parseCode()} runs in additive mode (`replaceNodes => false`).
+     *
+     * @var array<string, array{ast: Node\Stmt[]|null, useMap: array<string, string>}>
+     */
+    private static array $sharedCache = [];
+
+    /**
+     * Entry cap, enforced as insertion-ordered eviction of the oldest quarter. A single build
+     * cannot reach it. It bounds long-lived processes, where every edit mints a new key and the
+     * superseded entry would otherwise linger forever.
+     */
+    private const SHARED_CACHE_MAX = 8000;
+
+    /**
+     * Source parses performed in this process, i.e. shared-cache misses.
+     *
+     * @internal Counter for tests and benchmarks; never read by production code.
+     */
+    public static int $parseCount = 0;
+
     public function __construct()
     {
         $this->parser = (new ParserFactory)->createForNewestSupportedVersion();
+    }
+
+    /** Drop the shared parse cache, so a long-lived process can reclaim memory. */
+    public static function clearSharedCache(): void
+    {
+        self::$sharedCache = [];
     }
 
     /**
@@ -27,6 +60,48 @@ class PhpFileParser
      */
     public function parse(string $filePath): array
     {
+        $stat = @stat($filePath);
+        if ($stat === false) {
+            // Missing or unreadable — let the real read produce the null result, uncached.
+            return $this->parseFile($filePath);
+        }
+
+        // filemtime() has one-second resolution, so a file edited twice within the same second
+        // can keep both its mtime and its size (any single-character edit does). Such a file is
+        // "unsettled": caching it would let the first version's AST answer for the second in a
+        // watch-mode rescan or any long-lived process. Serve those files from source and keep
+        // them out of the cache entirely until their mtime falls into the past — the cost is
+        // re-parsing only the handful of files being edited at this very moment.
+        if ($stat['mtime'] >= time()) {
+            return $this->parseFile($filePath);
+        }
+
+        $key = $filePath.':'.$stat['mtime'].':'.$stat['size'];
+        if (isset(self::$sharedCache[$key])) {
+            return self::$sharedCache[$key];
+        }
+
+        if (count(self::$sharedCache) >= self::SHARED_CACHE_MAX) {
+            // Evict a quarter in one pass rather than one entry per insert from here on.
+            $evict = (int) (self::SHARED_CACHE_MAX / 4);
+            foreach (array_keys(self::$sharedCache) as $evictKey) {
+                unset(self::$sharedCache[$evictKey]);
+                if (--$evict <= 0) {
+                    break;
+                }
+            }
+        }
+
+        return self::$sharedCache[$key] = $this->parseFile($filePath);
+    }
+
+    /**
+     * @return array{ast: Node\Stmt[]|null, useMap: array<string, string>}
+     */
+    private function parseFile(string $filePath): array
+    {
+        self::$parseCount++;
+
         $code = file_get_contents($filePath);
         if ($code === false) {
             return ['ast' => null, 'useMap' => []];

--- a/tests/Unit/FacadeAnalyzerTest.php
+++ b/tests/Unit/FacadeAnalyzerTest.php
@@ -98,3 +98,34 @@ it('discovers a facade whose files open with declare(strict_types=1)', function 
         ->accessor->toBe('App\Support\SystemClock')
         ->concreteFqcn->toBe('App\Support\SystemClock');
 });
+
+it('still discovers a facade whose source spells the keyword EXTENDS', function () {
+    // Files with no `extends` keyword are skipped before parsing, since they cannot define a
+    // facade. PHP keywords are case-insensitive, so that test has to be too.
+    $root = sys_get_temp_dir().'/brain-facade-case-'.uniqid();
+    mkdir($root.'/app/Support', 0o777, true);
+
+    file_put_contents($root.'/app/Support/ShoutFacade.php', <<<'PHP'
+        <?php
+
+        namespace App\Support;
+
+        use Illuminate\Support\Facades\Facade;
+
+        class ShoutFacade EXTENDS Facade
+        {
+            protected static function getFacadeAccessor()
+            {
+                return 'shout';
+            }
+        }
+        PHP);
+
+    $registry = (new FacadeAnalyzer)->analyze($root);
+
+    expect($registry->get('App\Support\ShoutFacade'))
+        ->toBeInstanceOf(FacadeRecord::class)
+        ->accessor->toBe('shout');
+
+    exec('rm -rf '.escapeshellarg($root));
+});

--- a/tests/Unit/FindMethodNodeInChainTest.php
+++ b/tests/Unit/FindMethodNodeInChainTest.php
@@ -4,6 +4,28 @@ declare(strict_types=1);
 
 use LaraMint\LaravelBrain\Graph\GraphBuilder;
 
+/** Build a GraphBuilder whose PSR-4 map points App\ at $appDir, and expose the private walk. */
+function chainWalker(string $appDir): Closure
+{
+    $builder = new GraphBuilder;
+
+    $psr4 = new ReflectionProperty(GraphBuilder::class, 'psr4Map');
+
+    if (\PHP_VERSION_ID < 80100) {
+        $psr4->setAccessible(true);
+    }
+
+    $psr4->setValue($builder, ['App' => $appDir]);
+
+    $method = new ReflectionMethod(GraphBuilder::class, 'findMethodNodeInChain');
+
+    if (\PHP_VERSION_ID < 80100) {
+        $method->setAccessible(true);
+    }
+
+    return fn (string $fqcn, string $name) => $method->invoke($builder, $fqcn, $name);
+}
+
 it('walks the inheritance chain of a class that opens with declare(strict_types=1)', function () {
     $builder = new GraphBuilder;
 
@@ -27,4 +49,44 @@ it('walks the inheritance chain of a class that opens with declare(strict_types=
 
     expect($found)->not->toBeNull()
         ->and($found['declaringFqcn'])->toBe('App\Http\Controllers\StrictTypesBaseController');
+});
+
+it('returns the first declaration when one file declares the method twice', function () {
+    $dir = sys_get_temp_dir().'/brain-chain-'.uniqid();
+    mkdir($dir);
+    file_put_contents($dir.'/Duo.php', <<<'PHP'
+        <?php
+        namespace App;
+        class Duo { public function handle(int $first) {} }
+        class Sibling { public function handle(int $second) {} }
+        PHP);
+
+    $found = chainWalker($dir)('App\Duo', 'handle');
+
+    expect($found)->not->toBeNull()
+        ->and($found['methodNode']->params[0]->var->name)->toBe('first');
+
+    unlink($dir.'/Duo.php');
+    rmdir($dir);
+});
+
+it('does not resolve a method declared inside an anonymous class in a method body', function () {
+    $dir = sys_get_temp_dir().'/brain-chain-'.uniqid();
+    mkdir($dir);
+    file_put_contents($dir.'/Outer.php', <<<'PHP'
+        <?php
+        namespace App;
+        class Outer {
+            public function boot() {
+                return new class { public function handle() {} };
+            }
+        }
+        PHP);
+
+    // Outer::handle() does not exist; the handle() nested in boot()'s body belongs to an
+    // anonymous class and must not be reported as Outer's.
+    expect(chainWalker($dir)('App\Outer', 'handle'))->toBeNull();
+
+    unlink($dir.'/Outer.php');
+    rmdir($dir);
 });

--- a/tests/Unit/MethodTracerAnonymousClassTest.php
+++ b/tests/Unit/MethodTracerAnonymousClassTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use LaraMint\LaravelBrain\Analysis\MethodTracer;
+
+it('traces the real method body, not a same-named method of an anonymous class inside it', function () {
+    $root = sys_get_temp_dir().'/brain-anon-'.uniqid();
+    mkdir($root.'/app/Jobs', 0o777, true);
+
+    // handle() dispatches a job and returns an anonymous class that also declares handle().
+    // Collecting the class's methods must stop at the real declaration: the anonymous one is
+    // not App\Outer's method, and treating it as such loses everything the real body does.
+    file_put_contents($root.'/app/Outer.php', <<<'PHP'
+        <?php
+        namespace App;
+
+        use App\Jobs\ProcessThing;
+
+        class Outer
+        {
+            public function handle()
+            {
+                ProcessThing::dispatch();
+
+                return new class
+                {
+                    public function handle() {}
+                };
+            }
+        }
+        PHP);
+    file_put_contents($root.'/app/Jobs/ProcessThing.php', <<<'PHP'
+        <?php
+        namespace App\Jobs;
+
+        class ProcessThing {}
+        PHP);
+
+    $edges = (new MethodTracer)->traceMethod('App\Outer', 'handle', ['App' => [$root.'/app']], $root);
+
+    expect(array_map(fn ($edge) => $edge->calleeFqcn, $edges))->toContain('App\Jobs\ProcessThing');
+
+    exec('rm -rf '.escapeshellarg($root));
+});

--- a/tests/Unit/PhpFileParserSharedCacheTest.php
+++ b/tests/Unit/PhpFileParserSharedCacheTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use LaraMint\LaravelBrain\Parser\PhpFileParser;
+
+/**
+ * The shared parse cache has to satisfy three properties: it must actually deduplicate work
+ * across analyzers, it must never serve a stale AST for a file that has changed, and it must
+ * survive the one-second resolution of filemtime().
+ */
+beforeEach(function () {
+    PhpFileParser::clearSharedCache();
+    PhpFileParser::$parseCount = 0;
+
+    $this->dir = sys_get_temp_dir().'/brain-shared-cache-'.uniqid();
+    mkdir($this->dir);
+});
+
+afterEach(function () {
+    foreach (glob($this->dir.'/*') ?: [] as $file) {
+        unlink($file);
+    }
+    rmdir($this->dir);
+    PhpFileParser::clearSharedCache();
+});
+
+/** Write $code to $name and pin its mtime, so tests do not race the wall clock. */
+function writeSource(string $dir, string $name, string $code, int $mtime): string
+{
+    $path = $dir.'/'.$name;
+    file_put_contents($path, $code);
+    touch($path, $mtime);
+    clearstatcache(true, $path);
+
+    return $path;
+}
+
+it('parses a settled file once across parser instances', function () {
+    $file = writeSource($this->dir, 'Settled.php', "<?php class Settled {}\n", time() - 10);
+
+    (new PhpFileParser)->parse($file);
+    (new PhpFileParser)->parse($file);
+
+    // Separate instances: this is the deduplication every analyzer benefits from.
+    expect(PhpFileParser::$parseCount)->toBe(1);
+});
+
+it('re-parses a settled file after it is edited', function () {
+    $file = writeSource($this->dir, 'Edited.php', "<?php\nuse Old\\Alias;\nclass Edited {}\n", time() - 10);
+
+    $first = (new PhpFileParser)->parse($file);
+
+    writeSource($this->dir, 'Edited.php', "<?php\nuse New\\Thing;\nclass Edited {}\n", time() - 5);
+    $second = (new PhpFileParser)->parse($file);
+
+    expect($first['useMap'])->toBe(['Alias' => 'Old\Alias'])
+        ->and($second['useMap'])->toBe(['Thing' => 'New\Thing'])
+        ->and(PhpFileParser::$parseCount)->toBe(2);
+});
+
+it('does not cache a file edited within the current second', function () {
+    // Two versions of the same length, so an edit inside one second changes neither the mtime
+    // nor the size the cache key is built from — the collision this guard exists for. The mtime
+    // is pinned slightly ahead so the file counts as unsettled at both parses no matter where
+    // in the second the test runs.
+    $v1 = "<?php\nuse X\\Aaa;\nclass W {}\n";
+    $v2 = "<?php\nuse X\\Bbb;\nclass W {}\n";
+    expect(strlen($v2))->toBe(strlen($v1));
+
+    $unsettled = time() + 2;
+
+    $file = writeSource($this->dir, 'W.php', $v1, $unsettled);
+    $first = (new PhpFileParser)->parse($file);
+
+    writeSource($this->dir, 'W.php', $v2, $unsettled);
+    $second = (new PhpFileParser)->parse($file);
+
+    // Without the guard the second parse is answered by the first version's cached AST.
+    expect($first['useMap'])->toBe(['Aaa' => 'X\Aaa'])
+        ->and($second['useMap'])->toBe(['Bbb' => 'X\Bbb']);
+});

--- a/tests/Unit/ProjectFileIndexTest.php
+++ b/tests/Unit/ProjectFileIndexTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use LaraMint\LaravelBrain\Analysis\ProjectFileIndex;
+
+beforeEach(function () {
+    ProjectFileIndex::clear();
+
+    $this->root = sys_get_temp_dir().'/brain-file-index-'.uniqid();
+    mkdir($this->root.'/app/Nested', 0o777, true);
+    mkdir($this->root.'/src', 0o777, true);
+});
+
+afterEach(function () {
+    exec('rm -rf '.escapeshellarg($this->root));
+    ProjectFileIndex::clear();
+});
+
+it('honours the caller\'s directory precedence', function () {
+    file_put_contents($this->root.'/app/Thing.php', '<?php');
+    file_put_contents($this->root.'/src/Thing.php', '<?php');
+
+    expect(ProjectFileIndex::findFile($this->root, ['app', 'src'], 'Thing.php'))
+        ->toBe($this->root.'/app/Thing.php')
+        ->and(ProjectFileIndex::findFile($this->root, ['src', 'app'], 'Thing.php'))
+        ->toBe($this->root.'/src/Thing.php');
+});
+
+it('finds files in nested directories and reports misses as null', function () {
+    file_put_contents($this->root.'/app/Nested/Deep.php', '<?php');
+
+    expect(ProjectFileIndex::findFile($this->root, ['app'], 'Deep.php'))
+        ->toBe($this->root.'/app/Nested/Deep.php')
+        ->and(ProjectFileIndex::findFile($this->root, ['app'], 'Absent.php'))->toBeNull()
+        ->and(ProjectFileIndex::findFile($this->root, ['does-not-exist'], 'Deep.php'))->toBeNull();
+});
+
+it('sees files added after a previous build once cleared', function () {
+    expect(ProjectFileIndex::findFile($this->root, ['app'], 'Late.php'))->toBeNull();
+
+    file_put_contents($this->root.'/app/Late.php', '<?php');
+
+    // Within a build the index is deliberately stable; ProjectAnalyzer::analyze() clears it.
+    expect(ProjectFileIndex::findFile($this->root, ['app'], 'Late.php'))->toBeNull();
+
+    ProjectFileIndex::clear();
+
+    expect(ProjectFileIndex::findFile($this->root, ['app'], 'Late.php'))
+        ->toBe($this->root.'/app/Late.php');
+});


### PR DESCRIPTION
## What

A build asks the same questions over and over. Seventeen classes under `src/` construct their
own `PhpFileParser`, so each one read, tokenized, parsed and name-resolved the same files again.
Every FQCN that PSR-4 could not place triggered a fresh recursive walk of `app/` — once per
class asked about. Every `(file, method)` question ran a full-file traversal, and the
visibility lookup ran a second one over the same node.

Six changes make each of those happen once per build. What Brain discovers does not change: the
complete build output is byte-identical to `main` on three real applications.

| application | app files | `main` | this branch | | peak RSS |
|---|---:|---:|---:|---:|---|
| **A** — non-standard layout | 1,084 | 30.2 s | **2.36 s** | **12.8x** | 454 → 296 MB |
| **B** — Livewire-heavy | 1,885 | 25.0 s | **2.24 s** | **11.1x** | 369 → 304 MB |
| **C** — largest | 4,152 | 133.4 s | **3.54 s** | **37.7x** | 871 → 705 MB |

Peak memory falls *despite* the added caches: parsing a file once instead of several times over
produces far less garbage than the retained ASTs occupy.

Where the time went, on B's analyze phase. Two steps were 76% of it, and both were dominated by
work they repeated rather than by anything they uniquely do.

| step | `main` | this branch |
|---|---:|---:|
| graph | 10.64 s | 0.48 s |
| facades | 5.94 s | 0.37 s |
| lifecycle | 1.71 s | 0.33 s |
| the other 15 steps, combined | 1.24 s | 0.40 s |
| not attributed to a step | 2.36 s | 0.16 s |
| **analyze total** | **21.89 s** | **1.74 s** |

## Why

Found while building [richter](https://github.com/SanderMuller/richter) on top of Brain. Its
change-detection workflow rebuilds the graph on every run — the diff *is* the workload, so a
graph cache can never help — and Brain's build dominated its runtime. Profiling kept returning
the same shape: no single hot function, just the same file being resolved, read, parsed and
traversed once per consumer.

## The six changes, and what each is worth

Measured **leave-one-out**: each row is the build with everything in this PR *except* that one
change, so it answers the question that matters for a set of overlapping caches: what does this still buy
once the others are in place? Cumulative measurement would have credited whichever change
happened to be applied first.

| removed from the set | A | B | C |
|---|---:|---:|---:|
| shared parse cache — parse each file once per build, not once per analyzer | +387% | +250% | +126% |
| project filename index — walk each root once per build, not once per unresolved class | +303% | +448% | +3022% |
| per-file method map — collect a file's methods in one shallow pass | +26% | +9% | +8% |
| resolution memos — `resolveFile()` / `inspectFile()` are pure for a build | +9% | +14% | +11% |
| facade pre-filter — skip files that cannot define a facade before parsing | +7% | +8% | +10% |
| shallow class scan — stop descending into bodies to collect signatures | +3% | +2% | +1% |

Run-to-run drift, measured by repeating the full set first and last in every sweep, was 0.7%,
0.1% and 0.7% — so every row above is a real effect, including the small ones.

The two structural changes trade places by codebase: the parse cache leads on A, the filename
index leads on B, and on C the index is the difference between a two-minute build and a
four-second one. Neither is safe to drop on the evidence of one application. That is why they are here together.

## Behaviour

The gate is stronger than comparing node and edge counts. A harness serialises the entire
observable result of a build — the full graph, every subgraph, the tab manifest, the totals, the
unresolved-dispatch signal, and the entry-point tracer's complete edge list with types and
visibilities — and compares it byte-for-byte between `main` and this branch:

| | fixtures | A | B | C |
|---|---|---|---|---|
| dump size | 192 KB | 19.9 MB | 13.9 MB | 15.4 MB |
| subgraphs / traced edges | 14 / 0 | 537 / 3,536 | 358 / 1,968 | 404 / 1,269 |
| `main` vs branch | identical | identical | identical | identical |

Each arm was dumped twice as well, to show the comparison can detect anything at all and that a
build is deterministic to begin with. (Happy to push the harness somewhere if it is useful — it
is currently a scratch script, not part of this PR.)

**One deliberate exception**, where `main` was wrong. It has a regression test that fails on
`main` and passes here:

> **An anonymous class no longer shadows the method that contains it.** `loadClass()` collected
> methods by descending into method bodies, so `public function handle()` containing
> `return new class { public function handle() {} };` collected the anonymous one *last* and
> overwrote the real method. Tracing then walked the anonymous body and dropped the real
> method's entire call chain. `GraphBuilder`'s chain walk had the same blind spot from the other
> side: it could return that anonymous method as the outer class's own.

Neither shape occurs in the three applications above, which is why their output is unchanged.

One semantic that is deliberately *not* changed, but is now pinned by a test: where one file
declares the same method name twice, the **first** declaration still wins, matching the
stop-at-first-match traversal that was replaced. The natural way to build a method map — last
write wins — silently inverts it.

## Safety of the shared cache

This adds two pieces of process-wide state, so both are worth spelling out:

- **Sharing AST objects between analyzers is safe by inspection.** No visitor in `src/` returns a
  replacement node — every one returns `null` or a traversal-control int — and the `NameResolver`
  from #63 runs in additive mode. Brain reads the tree; it never rewrites it.
- **Keys are absolute paths**, so two projects analysed in one process cannot collide.
- **Watch mode and long-lived processes.** `ScanCommand::runScan()` builds a fresh
  `ProjectAnalyzer` per rescan, so every per-build memo really is per-build. The two static
  caches invalidate explicitly: the parse cache keys on mtime + size, and the filename index is
  cleared at the top of `analyze()` so a rescan sees files added since the last build.
- **`filemtime()` has one-second resolution**, so a same-size edit inside a single second — any
  single-character change — would collide with the cached entry's key. Files whose mtime is the
  current second are parsed from source and never cached, until their mtime settles into the
  past. That is the failure mode that would otherwise let watch mode serve a stale AST; it has a
  test that fails without the guard.
- The cache is bounded at 8,000 entries (oldest quarter evicted). A single build cannot reach it;
  it exists so a long editing session cannot accumulate superseded entries forever.
- One caveat worth knowing: code that drives `MethodTracer` directly, outside `analyze()`, in a
  long-lived process keeps whatever filename index the last build produced. `analyze()` callers
  are unaffected; anything else should call `ProjectFileIndex::clear()` between builds.

## Tests

New coverage: `PhpFileParserSharedCacheTest` (deduplication across instances, invalidation on
edit, the same-second race), `ProjectFileIndexTest` (directory precedence, nested files, misses,
and that `clear()` is what lets a new build see new files), `MethodTracerAnonymousClassTest` plus
two cases in `FindMethodNodeInChainTest` (the shadowing fix, and first-declaration-wins), and a
`FacadeAnalyzerTest` case pinning that the pre-filter is case-insensitive — `class X EXTENDS Y`
is valid PHP, and `str_contains` would have skipped it.

The 3 deprecation notices are pre-existing vendor tooling on PHP 8.5 (`pest-plugin-arch` calling
`ReflectionProperty::setAccessible()`), unrelated to this change.

## Method

Every arm is a fresh build with all build-scoped caches cleared, 1 warm-up plus 2–3 measured
iterations, median reported. Arms are interleaved and the reference arm is measured both first
and last in each sweep, so drift appears in the numbers instead of being assumed away. The
machine was shared, so the correctness claims rest on counts (parses, nodes, edges, byte-equal
dumps) and only the timings depend on load.