### PR TITLE
Extract each tab's subgraph from an index, not a full-graph rescan

### DIFF
--- a/src/Graph/GraphSplitter.php
+++ b/src/Graph/GraphSplitter.php
@@ -77,6 +77,7 @@ class GraphSplitter
         //    does NOT fan out to ALL sibling actions.
         // 2. Bidirectional (for the "all" tab only, kept for reference)
         $fwdAdj = $this->buildForwardAdjacency($fullGraph);
+        $this->buildExtractionIndexes($fullGraph);
 
         $subgraphs = [];
         $manifest = [];
@@ -539,6 +540,31 @@ class GraphSplitter
         return $adj;
     }
 
+    /**
+     * Position-indexed views of the full graph, built once per split(). Extracting a tab's
+     * subgraph used to rescan EVERY node and edge of the full graph per tab — O(tabs × (N+E)),
+     * quadratic in app size since both factors grow with it (the scale-8 sweep measured
+     * exponent 1.93, with split the largest analyze phase). With these indexes each tab only
+     * touches its own BFS-reachable set; original insertion order is restored from the stored
+     * positions so the emitted subgraph JSON is byte-identical.
+     */
+    private array $nodePositions = [];
+
+    /** @var array<string, list<array{int, Edge}>> source id → [original position, edge] */
+    private array $edgesBySource = [];
+
+    private function buildExtractionIndexes(Graph $fullGraph): void
+    {
+        $this->nodePositions = [];
+        foreach ($fullGraph->nodes() as $i => $node) {
+            $this->nodePositions[$node->id] = $i;
+        }
+        $this->edgesBySource = [];
+        foreach ($fullGraph->edges() as $i => $edge) {
+            $this->edgesBySource[$edge->source][] = [$i, $edge];
+        }
+    }
+
     private function extractSubgraphForward(
         Graph $fullGraph,
         array $fwdAdj,
@@ -551,15 +577,26 @@ class GraphSplitter
         $sub = new Graph;
         $sub->setMeta(['project' => $projectName, 'analyzedAt' => $analyzedAt]);
 
-        foreach ($fullGraph->nodes() as $node) {
-            if (isset($reachable[$node->id])) {
-                $sub->addNode($node);
+        $nodePositions = [];
+        $edgesByPosition = [];
+        foreach ($reachable as $id => $_) {
+            if (isset($this->nodePositions[$id])) {
+                $nodePositions[$this->nodePositions[$id]] = $id;
+            }
+            foreach ($this->edgesBySource[$id] ?? [] as [$pos, $edge]) {
+                if (isset($reachable[$edge->target])) {
+                    $edgesByPosition[$pos] = $edge;
+                }
             }
         }
-        foreach ($fullGraph->edges() as $edge) {
-            if (isset($reachable[$edge->source]) && isset($reachable[$edge->target])) {
-                $sub->addEdge($edge);
-            }
+
+        ksort($nodePositions);
+        foreach ($nodePositions as $id) {
+            $sub->addNode($fullGraph->getNode($id));
+        }
+        ksort($edgesByPosition);
+        foreach ($edgesByPosition as $edge) {
+            $sub->addEdge($edge);
         }
 
         return $sub;

--- a/tests/Unit/GraphSplitterTest.php
+++ b/tests/Unit/GraphSplitterTest.php
@@ -2,6 +2,7 @@
 
 use LaraMint\LaravelBrain\Analysis\RouteAnalyzer;
 use LaraMint\LaravelBrain\Analysis\RouteDefinition;
+use LaraMint\LaravelBrain\Graph\Edge;
 use LaraMint\LaravelBrain\Graph\Graph;
 use LaraMint\LaravelBrain\Graph\GraphSplitter;
 use LaraMint\LaravelBrain\Graph\Node;
@@ -137,4 +138,43 @@ it('emits issueCount and riskLevel in the manifest JSON only when there are issu
         ->and($tabs['POST /login']['riskLevel'])->toBe('medium')
         ->and($tabs['GET /ping'])->not->toHaveKey('issueCount')
         ->and($tabs['GET /ping'])->not->toHaveKey('riskLevel');
+});
+
+it('emits a subgraph in the full graph\'s node and edge order', function () {
+    // A tab's subgraph is a filtered view of the full graph, and the order it emits nodes and
+    // edges in is part of the file it produces. Reachability is discovered breadth-first, which
+    // is not the order the nodes were added in, so extraction has to restore the original one.
+    $graph = new Graph;
+    $graph->addNode(splitterRouteNode('GET', '/orders'));
+    foreach (['Zeta', 'Alpha', 'Mu'] as $name) {
+        $graph->addNode(new Node("action::App\\Http\\Controllers\\{$name}Controller::index", 'action', $name));
+    }
+    // An unreachable node in the middle, to prove filtering still happens.
+    $graph->addNode(new Node('action::App\\Http\\Controllers\\OtherController::index', 'action', 'Other'));
+
+    $edges = [
+        ['route::GET::/orders', 'action::App\\Http\\Controllers\\ZetaController::index'],
+        ['action::App\\Http\\Controllers\\ZetaController::index', 'action::App\\Http\\Controllers\\AlphaController::index'],
+        ['action::App\\Http\\Controllers\\AlphaController::index', 'action::App\\Http\\Controllers\\MuController::index'],
+    ];
+    foreach ($edges as $i => [$from, $to]) {
+        $graph->addEdge(new Edge("e{$i}", $from, $to, 'calls', 'flow'));
+    }
+
+    $split = (new GraphSplitter)->split(
+        $graph,
+        [splitterRoute('GET', '/orders', '/app/routes/web.php')],
+        [], [], [],
+        'proj',
+        '2026-05-16T00:00:00Z',
+    );
+
+    $sub = $split['subgraphs'][array_key_first($split['subgraphs'])];
+
+    $fullOrder = array_map(fn ($n) => $n->id, $graph->nodes());
+    $subOrder = array_map(fn ($n) => $n->id, $sub->nodes());
+
+    expect($subOrder)->toBe(array_values(array_filter($fullOrder, fn ($id) => in_array($id, $subOrder, true))))
+        ->and($subOrder)->not->toContain('action::App\Http\Controllers\OtherController::index')
+        ->and(array_map(fn ($e) => $e->id, $sub->edges()))->toBe(['e0', 'e1', 'e2']);
 });


### PR DESCRIPTION
## What

`GraphSplitter::extractSubgraphForward()` walked every node and every edge of the full graph
once per tab, keeping whatever was reachable from that tab's seeds. Both the tab count and the
graph grow with the application, so the split step costs O(tabs x (nodes + edges)).

`split()` now builds two indexes once — node id to its position, and edges grouped by source —
and each tab touches only its own reachable set. The stored positions restore the original
insertion order, so the subgraph that comes out is unchanged.

| | split step |
|---|---:|
| generated 3,160-file corpus (5,901 nodes, 15,337 edges, 1,553 tabs) | 683 ms → **29 ms** |
| real 1,885-file application (358 tabs) | 54 ms → **6 ms** |

Peak memory is unchanged at 502 MB on the large corpus: the indexes hold ids and positions
against nodes and edges the graph already owns.

## Why this is small today

Fifty milliseconds. On the applications I have to hand this is not a speedup anyone will
notice, and I would rather say so than dress it up.

What makes it worth fixing is the shape of the curve rather than its height. Measuring the same
generated corpus at four sizes:

| scale | nodes + edges | split step | vs previous |
|---|---:|---:|---:|
| 1x | 2,702 | 11.5 ms | |
| 2x | 5,350 | 43.6 ms | 3.8x |
| 4x | 10,646 | 162.5 ms | 3.7x |
| 8x | 21,238 | 682.5 ms | 4.2x |

Every doubling of the codebase roughly quadruples this step: a log-log fit puts the exponent at
1.97, against ~1.0 to 1.1 for every other step in the analyze phase. Eight times the graph costs
59 times as much here. That is the kind of thing you meet in a monorepo, long after the decision
that led to it.

Worth being precise about where it ranks. Against `main` today it is the fourth-largest step at
8x scale, behind graph (5.9 s), facades (4.7 s) and lifecycle (0.7 s). With #66 applied it
becomes the largest — 614 ms of a 2.5 s analyze — because that PR removes the repeated work the
other steps were doing and this one is left standing. Either PR is fine to merge first; they
touch different files.

The other reason to fix it now is that tab extraction stops being a once-per-build cost as soon
as builds become incremental, since re-splitting affected tabs after a change would run it
repeatedly.

## Behaviour

Unchanged, and checked rather than asserted. Building both arms and serialising everything a
consumer sees — the full graph, all 358 subgraphs, the tab manifest, the totals, and the
entry-point tracer's complete edge list — gives byte-identical output on a real application
(13,866,026 bytes, identical on `main` and on this branch). Each arm was dumped twice first, to
confirm that a build is deterministic and that the comparison can detect anything at all.

Ordering is the part most at risk here. Reachability is discovered breadth-first, which is not
the order nodes were added in, so the old code got insertion order for free by rescanning the
graph while the new code has to restore it deliberately. There is now a test pinning it, and it
passes on `main` too — that is the point, since it locks an invariant rather than blessing a
change.

## Tests

`151 passed (511 assertions)` · PHPStan level 5 + larastan **No errors** · Pint clean.

The 3 deprecation notices are pre-existing vendor tooling on PHP 8.5 (`pest-plugin-arch` calling
`ReflectionProperty::setAccessible()`), unrelated to this change.

## Note

Independent of #66. That PR never touches `GraphSplitter` and this one touches nothing else, so
the two can be reviewed in either order without conflicting.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
