### PR TITLE
Give each edge an id derived from the edge itself

### DIFF
--- a/src/Graph/GraphBuilder.php
+++ b/src/Graph/GraphBuilder.php
@@ -38,7 +38,8 @@ class GraphBuilder
 {
     private Graph $graph;
 
-    private int $edgeCounter = 0;
+    /** @var array<string, int> content-key => times emitted, for stable duplicate-edge id suffixes */
+    private array $edgeIdOccurrence = [];
 
     private FlowExtractor $flowExtractor;
 
@@ -437,6 +438,7 @@ class GraphBuilder
         }
         $this->projectRoot = $projectRoot;
         $this->classMetrics = [];
+        $this->edgeIdOccurrence = [];
         $this->seenControllerExtendsEdges = [];
         $this->seenBindingWires = [];
         $this->bindingRegistry = $bindingRegistry;
@@ -1912,16 +1914,27 @@ class GraphBuilder
 
     private function addEdge(string $source, string $target, string $label, string $type): void
     {
-        $id = "e{$this->edgeCounter}_{$source}_{$target}";
-        if ($this->graph->hasEdge($id)) {
-            return;
-        }
         // Prevent edges to/from non-existent nodes (safety guard)
         if (! $this->graph->hasNode($source) || ! $this->graph->hasNode($target)) {
             return;
         }
+
+        // Content-addressed id (graph format v2): derived from the edge itself rather than an
+        // insertion counter, so an edge keeps its id as unrelated edges come and go. Identical
+        // edges, which the graph keeps on purpose, take a per-occurrence suffix.
+        $key = $source."\x1f".$target."\x1f".$type."\x1f".$label;
+        $occurrence = $this->edgeIdOccurrence[$key] ?? 0;
+        $hash = hash('xxh128', $key);
+
+        // Not "e2_": a v1 id read "e{N}_...", so that prefix already belonged to the third edge.
+        $id = 'e_'.($occurrence === 0 ? $hash : $hash.'_'.$occurrence);
+
+        if ($this->graph->hasEdge($id)) {
+            return;
+        }
+
         $this->graph->addEdge(new Edge($id, $source, $target, $label, $type));
-        $this->edgeCounter++;
+        $this->edgeIdOccurrence[$key] = $occurrence + 1;
     }
 
     // ── Console commands ──────────────────────────────────────────────────────

--- a/src/Graph/GraphSplitter.php
+++ b/src/Graph/GraphSplitter.php
@@ -435,6 +435,9 @@ class GraphSplitter
         $json = json_encode([
             'project' => $projectName,
             'analyzedAt' => $analyzedAt,
+            // Bumped to 2 when edge ids became content-addressed (stable across rebuilds) instead
+            // of insertion-sequential. Consumers that persisted v1 edge ids should invalidate once.
+            'graphFormatVersion' => 2,
             'totalRoutes' => $totalRoutes,
             'totalNodes' => $fullGraph->nodeCount(),
             'totalEdges' => $fullGraph->edgeCount(),

--- a/tests/Unit/GraphBuilderTest.php
+++ b/tests/Unit/GraphBuilderTest.php
@@ -150,3 +150,59 @@ it('adds IoC binding edges from service providers to interfaces and implementati
         ->toBeInstanceOf(Edge::class)
         ->label->toContain('SqlThingRepository');
 });
+
+it('assigns content-addressed edge ids that are stable across rebuilds (graph format v2)', function () {
+    $build = function () {
+        $routes = (new RouteAnalyzer)->analyze(fixture('laravel-project'));
+        $middlewareRegistry = new MiddlewareRegistry([], [], []);
+        $controllers = (new ControllerAnalyzer)->analyze(fixture('laravel-project'), $routes);
+        $traces = (new MethodTracer)->trace($controllers);
+        $modelFqcns = array_map(fn ($t) => $t->calleeFqcn, array_filter($traces, fn ($t) => $t->type === 'model'));
+        $models = (new ModelAnalyzer)->analyze(fixture('laravel-project'), $modelFqcns);
+
+        return (new GraphBuilder)->build('test', $routes, $middlewareRegistry, $controllers, $traces, $models);
+    };
+
+    $ids1 = array_map(fn ($e) => $e['id'], json_decode($build()->toJson(), true)['edges']);
+    $ids2 = array_map(fn ($e) => $e['id'], json_decode($build()->toJson(), true)['edges']);
+
+    // Deterministic across independent builds (the incremental-analyze prerequisite)...
+    expect($ids1)->toEqual($ids2);
+    // ...content-addressed (v2 format), never the old insertion-sequential "e{N}_" ids...
+    foreach ($ids1 as $id) {
+        expect($id)->toStartWith('e_');
+    }
+    // ...and unique (duplicate edges get a stable per-occurrence suffix, edge set preserved).
+    expect(count($ids1))->toBe(count(array_unique($ids1)));
+});
+
+it('keeps every existing edge id when a new edge appears', function () {
+    // The reason for content-addressed ids. Under the old insertion-counter scheme any edge
+    // added mid-build renumbered every edge after it, so a one-line code change rewrote most of
+    // the graph's ids — which is what made diffing two builds, or rebuilding part of one,
+    // impractical. A build that differs by one call must differ by one id.
+    $build = function (array $extraTraces = []) {
+        $routes = (new RouteAnalyzer)->analyze(fixture('laravel-project'));
+        $middlewareRegistry = new MiddlewareRegistry([], [], []);
+        $controllers = (new ControllerAnalyzer)->analyze(fixture('laravel-project'), $routes);
+        $traces = (new MethodTracer)->trace($controllers);
+        $modelFqcns = array_map(fn ($t) => $t->calleeFqcn, array_filter($traces, fn ($t) => $t->type === 'model'));
+        $models = (new ModelAnalyzer)->analyze(fixture('laravel-project'), $modelFqcns);
+
+        return (new GraphBuilder)->build(
+            'test', $routes, $middlewareRegistry, $controllers, [...$traces, ...$extraTraces], $models,
+        );
+    };
+
+    $before = array_map(fn ($e) => $e['id'], json_decode($build()->toJson(), true)['edges']);
+
+    // Repeat an existing call, the way an added line of code would: same endpoints, so the nodes
+    // are certain to exist and only the edge is new.
+    $traces = (new MethodTracer)->trace(
+        (new ControllerAnalyzer)->analyze(fixture('laravel-project'), (new RouteAnalyzer)->analyze(fixture('laravel-project'))),
+    );
+    $after = array_map(fn ($e) => $e['id'], json_decode($build([$traces[0]])->toJson(), true)['edges']);
+
+    expect(array_diff($before, $after))->toBe([])
+        ->and(count($after))->toBe(count($before) + 1);
+});


### PR DESCRIPTION
## Heads-up: this changes edge ids, once

The manifest now carries `graphFormatVersion: 2`. Edge ids change format in this PR, so anything
holding v1 ids — a saved layout, a stored diff, an external tool keyed on them — should discard
them once. Nothing inside this repository does: the viewer looks ids up by equality and never
parses them, and the only persisted state in the frontend is keyed by route. Node ids are
untouched.

## What

An edge's id came from a build-order counter: `e{N}_{source}_{target}`. The counter advanced
with every edge added, so inserting one edge renumbered every edge built after it. Adding a
single call to a controller rewrote most of the ids in the graph.

Each id now comes from the edge itself — its source, target, type and label. An edge keeps its
id for as long as it describes the same relationship, regardless of what else the build finds.

```
before   e0_route::GET::/errors/render-exception_middleware::web
after    e_2056369c5f93e260385517edb39b4c52
```

## Why it matters

Two builds of the same project can now be compared, because an unchanged relationship has an
unchanged id, so a graph diff shows what actually changed rather than a renumbering.

That matters for consumers outside the build. Code inside it can always compute its own content
key from the edge, and the incremental-rebuild work does exactly that rather than depending on
this, so treat stable ids as something that makes a diff meaningful to whoever reads it, not as
a precondition for rebuilding.

It is also the honest answer to a smaller annoyance: the old ids embedded the source and target,
so they were both long and duplicated data the edge already carried.

## The graph is otherwise unchanged

Ids are supposed to differ here, so byte-comparison cannot express the gate. What a consumer
depends on is the node set and the edge set, and those are compared directly — nodes
byte-for-byte, edges as a multiset of (source, target, type, label), since the builder
deliberately keeps genuinely identical edges and dropping one would have to show up.

On a real 1,885-file application:

| | `main` | this branch |
|---|---:|---:|
| nodes | 2,572, byte-identical | 2,572 |
| edges | 4,469 | 4,469, multiset equal |
| distinct edge ids | 4,469 | 4,469 |

Identical edges get a stable per-occurrence suffix, which is what keeps the count and the
distinct-id count equal to each other.

## Tests

`176 passed (624 assertions)` · PHPStan level 5 + larastan **No errors** · Pint clean.

Two new cases, both of which fail on the old scheme:

- ids are identical across two independent builds, and every one is content-addressed;
- **every existing id survives a new edge appearing.** This is the property the change exists
  for, and determinism alone does not demonstrate it — two identical builds produce identical
  counter-based ids too. The test rebuilds with one extra call, the way an added line of code
  would produce one, and asserts the build differs by exactly one id.

## On the prefix

Ids read `e_<hash>` rather than `e2_<hash>`. The format version belongs in the manifest, and
`e2_` was itself a valid v1 prefix — it is what the third edge of any old build was called — so
it cannot be used to tell the formats apart. A v1 id always has a digit after the `e`; a v2 id
never does, which makes a stale id obvious if one turns up somewhere during the migration.

## Note

Nothing here depends on the incremental-rebuild work that motivated it — this stands on its own
as diff-stable ids, and that work can follow whenever it is ready.
