### PR TITLE
Optionally keep parse results between runs

### DIFF
--- a/config/laravel-brain.php
+++ b/config/laravel-brain.php
@@ -19,6 +19,36 @@ return [
     //
     'driver' => env('LARAVEL_BRAIN_DRIVER', 'file'),
 
+    // -------------------------------------------------------------------------
+    // Persistent AST Cache
+    // -------------------------------------------------------------------------
+    // A scan parses every PHP file in the application. Most of them have not
+    // changed since the last scan, so their parse results can be kept between
+    // runs and read back instead. Worth roughly a third of a repeated build,
+    // and most useful in CI, where every job starts with nothing in memory.
+    //
+    // Off by default: it requires the igbinary extension (without it Brain
+    // simply parses as usual), and it writes files, so it should not appear in
+    // storage/ unannounced.
+    //
+    // Entries are keyed by path, modification time, size and engine version, so
+    // an edited file is re-parsed and a PHP or php-parser upgrade invalidates
+    // what is stored. Deleting the directory is always safe.
+    //
+    'ast_cache' => [
+
+        // Enable with LARAVEL_BRAIN_AST_CACHE=true.
+        //
+        'enabled' => env('LARAVEL_BRAIN_AST_CACHE', false),
+
+        // Where to keep it. Defaults to storage/framework/cache/laravel-brain-ast
+        // under the scanned project. The directory holds serialized objects that
+        // Brain reads back, so keep it app-private and out of version control.
+        //
+        'path' => env('LARAVEL_BRAIN_AST_CACHE_PATH'),
+
+    ],
+
     // Settings for the 'database' driver.
     //
     'database' => [

--- a/src/Analysis/ProjectAnalyzer.php
+++ b/src/Analysis/ProjectAnalyzer.php
@@ -8,6 +8,7 @@ use LaraMint\LaravelBrain\Graph\Graph;
 use LaraMint\LaravelBrain\Graph\GraphBuilder;
 use LaraMint\LaravelBrain\Graph\GraphSplitter;
 use LaraMint\LaravelBrain\Graph\TabManifestEntry;
+use LaraMint\LaravelBrain\Parser\PhpFileParser;
 
 class AnalysisResult
 {
@@ -136,6 +137,8 @@ class ProjectAnalyzer
 
         // Rebuilt per analysis, so a rescan sees files added since the previous one.
         ProjectFileIndex::clear();
+
+        $this->enableAstCache($projectRoot);
 
         $appName = function_exists('config') ? config('app.name') : null;
         $projectName = (is_string($appName) && $appName !== '') ? $appName : 'Laravel Brain';
@@ -345,6 +348,10 @@ class ProjectAnalyzer
             unresolvedDispatchers: $this->methodTracer->unresolvedDispatchers(),
         );
 
+        // Everything parsed during the scan goes to disk in one pass, here rather than earlier:
+        // the graph phase parses too, and flushing before it would leave those results unwritten.
+        PhpFileParser::flushDiskCache();
+
         $this->emit('analysis:done', [
             'nodes' => $fullGraph->nodeCount(),
             'edges' => $fullGraph->edgeCount(),
@@ -358,6 +365,28 @@ class ProjectAnalyzer
         ]);
 
         return $result;
+    }
+
+    /**
+     * Turn on the persistent AST cache when the application asks for it.
+     *
+     * Only ever enables: a caller that pointed the parser at its own directory keeps it, and a
+     * scan never silently switches the cache off underneath one.
+     */
+    private function enableAstCache(string $projectRoot): void
+    {
+        $config = function_exists('config') ? config('laravel-brain.ast_cache', []) : [];
+        if (! is_array($config) || ! filter_var($config['enabled'] ?? false, FILTER_VALIDATE_BOOL)) {
+            return;
+        }
+
+        $path = $config['path'] ?? null;
+
+        PhpFileParser::useDiskCache(
+            is_string($path) && $path !== ''
+                ? $path
+                : $projectRoot.'/storage/framework/cache/laravel-brain-ast',
+        );
     }
 
     private function emit(string $event, array $data = []): void

--- a/src/Parser/PhpFileParser.php
+++ b/src/Parser/PhpFileParser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LaraMint\LaravelBrain\Parser;
 
+use Composer\InstalledVersions;
 use PhpParser\Error;
 use PhpParser\ErrorHandler;
 use PhpParser\Node;
@@ -44,6 +45,50 @@ class PhpFileParser
      */
     public static int $parseCount = 0;
 
+    /**
+     * Directory backing the persistent cache, or null when it is off (the default).
+     *
+     * The in-memory cache above dies with the process, so a CLI scan or a CI job re-parses
+     * everything every time even though almost no file changed between runs. Storing parse
+     * results here lets the next process read back the files that did not change.
+     */
+    private static ?string $diskCacheDir = null;
+
+    /**
+     * Bump whenever the stored structure changes — a new attribute on the nodes, a different
+     * result shape — so a cache written by an older Brain is skipped rather than misread. The
+     * PHP and php-parser versions are part of the key separately, since either can change the
+     * node classes underneath us.
+     */
+    private const AST_SCHEMA_VERSION = 1;
+
+    /** Memoized key prefix; see cacheVersion(). */
+    private static ?string $cacheVersion = null;
+
+    /** Length of the key prefix that selects a bundle: 2 hex characters, so 256 of them. */
+    private const SHARD_PREFIX_LENGTH = 2;
+
+    /**
+     * Entries kept per bundle. An edit adds an entry rather than replacing one, so bundles grow
+     * until this trims them. 256 bundles x 80 entries is 20,000 results, several times the file
+     * count of a large application, and at 15-25 KB each that caps the directory near 400 MB.
+     */
+    private const MAX_ENTRIES_PER_SHARD = 80;
+
+    /** @var array<string, array<string, string>> shard => entry key => serialized result, unwritten */
+    private static array $pendingEntries = [];
+
+    /** @var array<string, array<string, string>|null> shard => its entries, null when there is no bundle */
+    private static array $loadedShards = [];
+
+    /** Whether the shutdown flush is already registered; see useDiskCache(). */
+    private static bool $flushOnShutdownRegistered = false;
+
+    /** Buffered entries awaiting a flush, and the point at which one is forced. */
+    private static int $pendingCount = 0;
+
+    private const MAX_PENDING_ENTRIES = 500;
+
     public function __construct()
     {
         $this->parser = (new ParserFactory)->createForNewestSupportedVersion();
@@ -56,34 +101,100 @@ class PhpFileParser
     }
 
     /**
+     * Point the persistent cache at $dir, creating it if needed, or pass null to turn it off.
+     *
+     * Requires igbinary. The cache stores serialized AST objects, and igbinary is both much
+     * faster than the alternative and outside the object-injection surface this project's arch
+     * tests forbid. Without the extension the cache stays off and Brain simply parses.
+     *
+     * The directory holds objects Brain will unserialize, so it must be app-private —
+     * storage/framework/cache is the default for that reason. Anyone who can write there can
+     * already run code in a Laravel application, but it is worth being deliberate about.
+     */
+    public static function useDiskCache(?string $dir): void
+    {
+        if ($dir === null || ! function_exists('igbinary_serialize')) {
+            self::$diskCacheDir = null;
+
+            return;
+        }
+
+        if (! is_dir($dir)) {
+            @mkdir($dir, 0o755, true);
+        }
+
+        self::$diskCacheDir = is_dir($dir) && is_writable($dir) ? rtrim($dir, '/') : null;
+
+        // Bundles already read belong to whatever directory was in use before.
+        self::$loadedShards = [];
+        self::$pendingEntries = [];
+        self::$pendingCount = 0;
+
+        // A scan flushes when it finishes, but code driving the parser directly has no obvious
+        // moment to do that, and silently parsing without ever storing anything would be a poor
+        // way to fail. Registered once, and a no-op when there is nothing buffered.
+        if (self::$diskCacheDir !== null && ! self::$flushOnShutdownRegistered) {
+            self::$flushOnShutdownRegistered = true;
+            register_shutdown_function(static fn () => self::flushDiskCache());
+        }
+    }
+
+    /** Whether the persistent cache is currently on. */
+    public static function diskCacheEnabled(): bool
+    {
+        return self::$diskCacheDir !== null;
+    }
+
+    /** Key prefix that invalidates every entry when the engine or the stored shape changes. */
+    private static function cacheVersion(): string
+    {
+        if (self::$cacheVersion === null) {
+            $phpParser = '';
+            if (class_exists(InstalledVersions::class)) {
+                try {
+                    $phpParser = (string) InstalledVersions::getVersion('nikic/php-parser');
+                } catch (\Throwable) {
+                    $phpParser = '';
+                }
+            }
+            self::$cacheVersion = 'ast'.self::AST_SCHEMA_VERSION
+                .'|php'.PHP_VERSION_ID
+                .'|pp'.$phpParser
+                .'|ig'.phpversion('igbinary');
+        }
+
+        return self::$cacheVersion;
+    }
+
+    /**
      * @return array{ast: Node\Stmt[]|null, useMap: array<string, string>}
      */
     public function parse(string $filePath): array
     {
         $stat = @stat($filePath);
-        if ($stat === false) {
-            // Missing or unreadable — let the real read produce the null result, uncached.
-            return $this->parseFile($filePath);
-        }
 
         // filemtime() has one-second resolution, so a file edited twice within the same second
         // can keep both its mtime and its size (any single-character edit does). Such a file is
-        // "unsettled": caching it would let the first version's AST answer for the second in a
-        // watch-mode rescan or any long-lived process. Serve those files from source and keep
-        // them out of the cache entirely until their mtime falls into the past — the cost is
-        // re-parsing only the handful of files being edited at this very moment.
-        if ($stat['mtime'] >= time()) {
-            return $this->parseFile($filePath);
+        // "unsettled" and must stay out of the in-memory cache, whose key is built from exactly
+        // those two values, until its mtime falls into the past.
+        $settled = $stat !== false && $stat['mtime'] < time();
+
+        $memoryKey = $settled ? $filePath.':'.$stat['mtime'].':'.$stat['size'] : null;
+        if ($memoryKey !== null && isset(self::$sharedCache[$memoryKey])) {
+            return self::$sharedCache[$memoryKey];
         }
 
-        $key = $filePath.':'.$stat['mtime'].':'.$stat['size'];
-        if (isset(self::$sharedCache[$key])) {
-            return self::$sharedCache[$key];
+        $result = self::$diskCacheDir !== null
+            ? $this->parseViaDiskCache($filePath)
+            : $this->parseFile($filePath);
+
+        if ($memoryKey === null) {
+            return $result;
         }
 
         if (count(self::$sharedCache) >= self::SHARED_CACHE_MAX) {
             // Evict a quarter in one pass rather than one entry per insert from here on.
-            $evict = (int) (self::SHARED_CACHE_MAX / 4);
+            $evict = intdiv(self::SHARED_CACHE_MAX, 4);
             foreach (array_keys(self::$sharedCache) as $evictKey) {
                 unset(self::$sharedCache[$evictKey]);
                 if (--$evict <= 0) {
@@ -92,7 +203,204 @@ class PhpFileParser
             }
         }
 
-        return self::$sharedCache[$key] = $this->parseFile($filePath);
+        return self::$sharedCache[$memoryKey] = $result;
+    }
+
+    /**
+     * Read the file, and either unserialize a stored result for those exact bytes or parse them.
+     *
+     * Entries are addressed by a hash of the contents rather than by path and timestamp, which
+     * costs a read the in-memory layer does not need — but a parse needs that read anyway, and
+     * timestamps do not survive the thing this cache exists for. A CI job checks the repository
+     * out fresh, so every file arrives with a new mtime and identical content: keyed by
+     * timestamp the cache would miss every entry and then write a second copy of it, which is
+     * slower than not caching at all. Keyed by content it hits.
+     *
+     * @return array{ast: Node\Stmt[]|null, useMap: array<string, string>}
+     */
+    private function parseViaDiskCache(string $filePath): array
+    {
+        $code = @file_get_contents($filePath);
+        if ($code === false) {
+            return ['ast' => null, 'useMap' => []];
+        }
+
+        $key = hash('xxh128', $code);
+
+        $stored = $this->readDisk($key);
+        if ($stored !== null) {
+            return $stored;
+        }
+
+        $result = $this->parseSource($code);
+
+        // A file that failed to parse is not worth storing: it is cheap to re-read, and the
+        // failure is usually being actively fixed.
+        if ($result['ast'] !== null) {
+            $this->writeDisk($key, $result);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Entries live in bundles, grouped by the first byte of their key, rather than one file
+     * each. A file per entry means thousands of writes on a first scan and thousands of small
+     * files to move around afterwards, and moving them is the expensive part: packing and
+     * unpacking a directory costs far more per file than per byte, so a cache small enough to
+     * be worth restoring is still slow to restore. Grouping cuts a first scan's write cost by
+     * about two thirds and its pack-and-unpack cost by three quarters.
+     */
+    private static function shardPath(string $shard): string
+    {
+        return self::$diskCacheDir.'/'.$shard.'.shard';
+    }
+
+    /** Entry key within its shard: the content hash, tied to the engine and format versions. */
+    private function entryKey(string $contentHash): string
+    {
+        return hash('xxh128', self::cacheVersion().'|'.$contentHash);
+    }
+
+    /**
+     * Read back a previously stored parse result, or null to parse from source.
+     *
+     * Anything unexpected counts as a miss: a truncated write, a bundle from another version, a
+     * file that is not ours. The shape is checked before the result is used, so a corrupt cache
+     * costs a re-parse rather than a crash.
+     *
+     * @return array{ast: Node\Stmt[]|null, useMap: array<string, string>}|null
+     */
+    private function readDisk(string $contentHash): ?array
+    {
+        $entryKey = $this->entryKey($contentHash);
+        $shard = substr($entryKey, 0, self::SHARD_PREFIX_LENGTH);
+
+        $blob = self::$pendingEntries[$shard][$entryKey]
+            ?? (self::loadShard($shard)[$entryKey] ?? null);
+
+        if (! is_string($blob)) {
+            return null;
+        }
+
+        $data = self::decode($blob);
+
+        if (! is_array($data) || ! array_key_exists('ast', $data) || ! is_array($data['useMap'] ?? null)) {
+            return null;
+        }
+        if (! is_array($data['ast']) || ($data['ast'] !== [] && ! reset($data['ast']) instanceof Node\Stmt)) {
+            return null;
+        }
+
+        return $data;
+    }
+
+    /**
+     * Buffer an entry for the next flush. Nothing touches the filesystem until then, so a scan
+     * pays one write per shard it added to rather than one per file it parsed.
+     *
+     * @param  array{ast: Node\Stmt[]|null, useMap: array<string, string>}  $result
+     */
+    private function writeDisk(string $contentHash, array $result): void
+    {
+        $blob = igbinary_serialize($result);
+        if ($blob === null) {
+            return;
+        }
+
+        $entryKey = $this->entryKey($contentHash);
+        self::$pendingEntries[substr($entryKey, 0, self::SHARD_PREFIX_LENGTH)][$entryKey] = $blob;
+        self::$pendingCount++;
+
+        // Holding every blob until the scan ends would add the whole cache to peak memory on a
+        // large codebase. Flushing in batches keeps the write batched without that.
+        if (self::$pendingCount >= self::MAX_PENDING_ENTRIES) {
+            self::flushDiskCache();
+        }
+    }
+
+    /**
+     * Merge everything parsed during this scan into its bundles.
+     *
+     * ProjectAnalyzer calls this once a scan is finished. It is public because a consumer
+     * driving the parser itself — the entry-point tracer does, outside analyze() — has to be
+     * able to persist what it parsed.
+     */
+    public static function flushDiskCache(): void
+    {
+        $pending = self::$pendingEntries;
+        self::$pendingEntries = [];
+        self::$pendingCount = 0;
+
+        if (self::$diskCacheDir === null || $pending === []) {
+            return;
+        }
+
+        foreach ($pending as $shard => $entries) {
+            // A shard of only digits would otherwise arrive here as an int.
+            $shard = (string) $shard;
+            $merged = $entries + (self::loadShard($shard) ?? []);
+
+            // Newest first, so trimming to the cap drops what has gone longest untouched. An
+            // edit adds an entry rather than replacing one, so bundles only ever grow.
+            if (count($merged) > self::MAX_ENTRIES_PER_SHARD) {
+                $merged = array_slice($merged, 0, self::MAX_ENTRIES_PER_SHARD, true);
+            }
+
+            $blob = igbinary_serialize($merged);
+            if ($blob === null) {
+                continue;
+            }
+
+            // Write then rename, so a reader never sees a half-written bundle.
+            $path = self::shardPath($shard);
+            $tmp = $path.'.'.getmypid().'.tmp';
+            if (@file_put_contents($tmp, $blob) === false || ! @rename($tmp, $path)) {
+                @unlink($tmp);
+
+                continue;
+            }
+
+            self::$loadedShards[$shard] = $merged;
+        }
+    }
+
+    /**
+     * @return array<string, string>|null entry key => serialized result
+     */
+    private static function loadShard(string $shard): ?array
+    {
+        if (array_key_exists($shard, self::$loadedShards)) {
+            return self::$loadedShards[$shard];
+        }
+
+        $path = self::shardPath($shard);
+        $blob = is_file($path) ? @file_get_contents($path) : false;
+        if ($blob === false) {
+            return self::$loadedShards[$shard] = null;
+        }
+
+        $map = self::decode($blob);
+
+        return self::$loadedShards[$shard] = is_array($map) ? $map : null;
+    }
+
+    /**
+     * A damaged bundle makes igbinary emit a warning, and @ is not enough: an application that
+     * promotes warnings to exceptions would turn a corrupt cache into a failed scan. Nothing
+     * here is worth failing over, so swallow it locally and treat it as a miss.
+     */
+    private static function decode(string $blob): mixed
+    {
+        set_error_handler(static fn (): bool => true);
+
+        try {
+            return igbinary_unserialize($blob);
+        } catch (\Throwable) {
+            return null;
+        } finally {
+            restore_error_handler();
+        }
     }
 
     /**
@@ -100,12 +408,20 @@ class PhpFileParser
      */
     private function parseFile(string $filePath): array
     {
-        self::$parseCount++;
-
-        $code = file_get_contents($filePath);
+        $code = @file_get_contents($filePath);
         if ($code === false) {
             return ['ast' => null, 'useMap' => []];
         }
+
+        return $this->parseSource($code);
+    }
+
+    /**
+     * @return array{ast: Node\Stmt[]|null, useMap: array<string, string>}
+     */
+    private function parseSource(string $code): array
+    {
+        self::$parseCount++;
 
         return $this->parseCode($code);
     }

--- a/tests/Feature/AstCacheWiringTest.php
+++ b/tests/Feature/AstCacheWiringTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Config\Repository;
+use Illuminate\Container\Container;
+use LaraMint\LaravelBrain\Analysis\ProjectAnalyzer;
+use LaraMint\LaravelBrain\Parser\PhpFileParser;
+
+/**
+ * The cache is only useful if turning it on in config actually turns it on during a scan, and
+ * only safe if leaving it alone leaves the filesystem alone.
+ */
+function bindBrainConfig(array $astCache): void
+{
+    $container = new Container;
+    Container::setInstance($container);
+    $container->instance('config', new Repository([
+        'app' => ['name' => 'CacheWiringApp'],
+        'laravel-brain' => ['ast_cache' => $astCache],
+    ]));
+}
+
+function analyzeFixture(): void
+{
+    (new ProjectAnalyzer)->analyze(fixture('laravel-project'), static function (): void {});
+}
+
+beforeEach(function () {
+    if (! function_exists('igbinary_serialize')) {
+        $this->markTestSkipped('igbinary is not installed');
+    }
+
+    $this->cacheDir = sys_get_temp_dir().'/brain-ast-wiring-'.uniqid();
+    PhpFileParser::useDiskCache(null);
+    PhpFileParser::clearSharedCache();
+    PhpFileParser::$parseCount = 0;
+});
+
+afterEach(function () {
+    PhpFileParser::useDiskCache(null);
+    PhpFileParser::clearSharedCache();
+    Container::setInstance(null);
+    exec('rm -rf '.escapeshellarg($this->cacheDir));
+});
+
+it('populates the cache on the first scan and reads it back on the next', function () {
+    bindBrainConfig(['enabled' => true, 'path' => $this->cacheDir]);
+
+    analyzeFixture();
+
+    $written = glob($this->cacheDir.'/*.shard') ?: [];
+    expect($written)->not->toBeEmpty()
+        ->and(PhpFileParser::$parseCount)->toBeGreaterThan(0);
+
+    // A second scan in a fresh process: every in-memory layer is gone, the directory is not.
+    PhpFileParser::clearSharedCache();
+    PhpFileParser::useDiskCache($this->cacheDir);
+    PhpFileParser::$parseCount = 0;
+
+    analyzeFixture();
+
+    expect(PhpFileParser::$parseCount)->toBe(0)
+        ->and(glob($this->cacheDir.'/*.shard') ?: [])->toHaveCount(count($written));
+});
+
+it('leaves the filesystem alone when the config does not ask for a cache', function () {
+    bindBrainConfig([]);
+
+    analyzeFixture();
+
+    expect(PhpFileParser::diskCacheEnabled())->toBeFalse()
+        ->and(is_dir($this->cacheDir))->toBeFalse();
+});
+
+it('accepts the env-style string values a config file produces', function () {
+    // env('LARAVEL_BRAIN_AST_CACHE') hands through whatever is in .env, so "true" arrives as a
+    // string rather than a boolean.
+    bindBrainConfig(['enabled' => 'true', 'path' => $this->cacheDir]);
+
+    analyzeFixture();
+
+    expect(PhpFileParser::diskCacheEnabled())->toBeTrue()
+        ->and(glob($this->cacheDir.'/*.shard') ?: [])->not->toBeEmpty();
+});
+
+it('produces the same graph with the cache on as with it off', function () {
+    bindBrainConfig([]);
+    $withoutCache = (new ProjectAnalyzer)->analyze(fixture('laravel-project'), static function (): void {});
+
+    bindBrainConfig(['enabled' => true, 'path' => $this->cacheDir]);
+    PhpFileParser::clearSharedCache();
+    (new ProjectAnalyzer)->analyze(fixture('laravel-project'), static function (): void {});
+
+    // Third scan: everything now comes back from disk rather than from source.
+    PhpFileParser::clearSharedCache();
+    PhpFileParser::useDiskCache($this->cacheDir);
+    PhpFileParser::$parseCount = 0;
+    $fromCache = (new ProjectAnalyzer)->analyze(fixture('laravel-project'), static function (): void {});
+
+    expect(PhpFileParser::$parseCount)->toBe(0)
+        ->and($fromCache->fullGraph->toJson())->toBe($withoutCache->fullGraph->toJson());
+});

--- a/tests/Unit/PhpFileParserDiskCacheTest.php
+++ b/tests/Unit/PhpFileParserDiskCacheTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+use LaraMint\LaravelBrain\Parser\PhpFileParser;
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * The persistent cache is only worth having if it is impossible to serve a stale or foreign
+ * result from it. These cover the ways that could happen: an edited file, a corrupt blob, a
+ * file being edited right now, and the cache being off.
+ */
+beforeEach(function () {
+    if (! function_exists('igbinary_serialize')) {
+        $this->markTestSkipped('igbinary is not installed');
+    }
+
+    PhpFileParser::clearSharedCache();
+    PhpFileParser::$parseCount = 0;
+
+    $this->dir = sys_get_temp_dir().'/brain-disk-cache-'.uniqid();
+    $this->cacheDir = $this->dir.'/cache';
+    mkdir($this->dir);
+    PhpFileParser::useDiskCache($this->cacheDir);
+});
+
+afterEach(function () {
+    PhpFileParser::useDiskCache(null);
+    PhpFileParser::clearSharedCache();
+    exec('rm -rf '.escapeshellarg($this->dir));
+});
+
+/** Write $code to $name with a settled mtime, and return its path. */
+function diskCacheSource(string $dir, string $name, string $code, int $age = 10): string
+{
+    $path = $dir.'/'.$name;
+    file_put_contents($path, $code);
+    touch($path, time() - $age);
+    clearstatcache(true, $path);
+
+    return $path;
+}
+
+/**
+ * Simulate the next process: buffered entries written, every in-memory layer dropped, bundles
+ * left on disk. Pointing useDiskCache() at the directory again is what clears the decoded
+ * bundles — without that a "second process" would still be answering from this one's memory,
+ * and these tests would prove nothing about what actually reached the filesystem.
+ */
+function nextProcess(string $cacheDir): void
+{
+    PhpFileParser::flushDiskCache();
+    PhpFileParser::clearSharedCache();
+    PhpFileParser::useDiskCache($cacheDir);
+    PhpFileParser::$parseCount = 0;
+}
+
+/** Entries actually stored across all bundles. */
+function storedEntries(string $dir): int
+{
+    $total = 0;
+    foreach (glob($dir.'/*.shard') ?: [] as $shard) {
+        $map = igbinary_unserialize((string) file_get_contents($shard));
+        $total += is_array($map) ? count($map) : 0;
+    }
+
+    return $total;
+}
+
+it('serves a second process from disk without parsing', function () {
+    $file = diskCacheSource($this->dir, 'Warm.php', "<?php\nuse App\\Thing;\nclass Warm {}\n");
+
+    $first = (new PhpFileParser)->parse($file);
+    expect(PhpFileParser::$parseCount)->toBe(1)
+        // Entries are buffered and written together, so nothing is on disk until the flush.
+        ->and(storedEntries($this->cacheDir))->toBe(0);
+
+    nextProcess($this->cacheDir);
+
+    expect(storedEntries($this->cacheDir))->toBe(1);
+
+    $second = (new PhpFileParser)->parse($file);
+
+    expect(PhpFileParser::$parseCount)->toBe(0)
+        ->and($second['useMap'])->toBe($first['useMap'])
+        ->and($second['ast'])->toEqual($first['ast']);
+});
+
+it('keeps the resolved names the parser attaches to the tree', function () {
+    // parseCode() runs NameResolver, which annotates Name nodes with a resolvedName attribute.
+    // Those attributes are the reason analyzers can stop guessing FQCNs, and they have to
+    // survive the round trip through the cache.
+    $file = diskCacheSource($this->dir, 'Resolved.php', <<<'PHP'
+        <?php
+        namespace App;
+
+        use App\Models\User;
+
+        class Resolved
+        {
+            public function handle()
+            {
+                return User::query();
+            }
+        }
+        PHP);
+
+    $fresh = (new PhpFileParser)->parse($file);
+    nextProcess($this->cacheDir);
+    $cached = (new PhpFileParser)->parse($file);
+
+    $nameOf = static function (array $parsed): ?string {
+        $found = null;
+        (new NodeTraverser(new class($found) extends NodeVisitorAbstract
+        {
+            public function __construct(private ?string &$found) {}
+
+            public function enterNode(Node $node): null
+            {
+                if ($node instanceof StaticCall) {
+                    $this->found ??= PhpFileParser::resolvedName($node->class);
+                }
+
+                return null;
+            }
+        }))->traverse($parsed['ast']);
+
+        return $found;
+    };
+
+    expect($nameOf($fresh))->toBe('App\Models\User')
+        ->and($nameOf($cached))->toBe('App\Models\User')
+        ->and(PhpFileParser::$parseCount)->toBe(0);
+});
+
+it('re-parses a file that changed since it was cached', function () {
+    $file = diskCacheSource($this->dir, 'Edited.php', "<?php\nuse Old\\Alias;\nclass Edited {}\n");
+    (new PhpFileParser)->parse($file);
+
+    nextProcess($this->cacheDir);
+    diskCacheSource($this->dir, 'Edited.php', "<?php\nuse New\\Thing;\nclass Edited {}\n", age: 5);
+
+    $result = (new PhpFileParser)->parse($file);
+
+    expect($result['useMap'])->toBe(['Thing' => 'New\Thing'])
+        ->and(PhpFileParser::$parseCount)->toBe(1);
+});
+
+it('serves the current bytes of a file that is being edited right now', function () {
+    // Two versions of the same length written inside one second share an mtime and a size, so
+    // the in-memory key cannot tell them apart and that layer has to skip the file. The stored
+    // entries are addressed by content, so they stay correct regardless: each version gets its
+    // own, and neither can answer for the other.
+    $path = $this->dir.'/Unsettled.php';
+    $unsettled = time() + 2;
+
+    file_put_contents($path, "<?php\nuse X\\Aaa;\nclass W {}\n");
+    touch($path, $unsettled);
+    clearstatcache(true, $path);
+    $first = (new PhpFileParser)->parse($path);
+
+    file_put_contents($path, "<?php\nuse X\\Bbb;\nclass W {}\n");
+    touch($path, $unsettled);
+    clearstatcache(true, $path);
+    $second = (new PhpFileParser)->parse($path);
+
+    PhpFileParser::flushDiskCache();
+
+    expect($first['useMap'])->toBe(['Aaa' => 'X\Aaa'])
+        ->and($second['useMap'])->toBe(['Bbb' => 'X\Bbb'])
+        ->and(storedEntries($this->cacheDir))->toBe(2);
+});
+
+it('shares one entry between files whose contents are identical', function () {
+    // The stored result depends on the bytes and nothing else, so two copies of the same source
+    // are one entry rather than two — and the second copy is never parsed.
+    $source = "<?php\nnamespace App;\n\nclass Duplicated {}\n";
+    $a = diskCacheSource($this->dir, 'CopyA.php', $source);
+    $b = diskCacheSource($this->dir, 'CopyB.php', $source);
+
+    (new PhpFileParser)->parse($a);
+    (new PhpFileParser)->parse($b);
+
+    PhpFileParser::flushDiskCache();
+
+    expect(storedEntries($this->cacheDir))->toBe(1)
+        ->and(PhpFileParser::$parseCount)->toBe(1);
+});
+
+it('falls back to parsing when a stored entry is corrupt', function () {
+    $file = diskCacheSource($this->dir, 'Corrupt.php', "<?php\nclass Corrupt {}\n");
+    (new PhpFileParser)->parse($file);
+    PhpFileParser::flushDiskCache();
+
+    $bundle = glob($this->cacheDir.'/*.shard')[0];
+    file_put_contents($bundle, 'not igbinary at all');
+
+    nextProcess($this->cacheDir);
+    $result = (new PhpFileParser)->parse($file);
+
+    expect($result['ast'])->not->toBeNull()
+        ->and(PhpFileParser::$parseCount)->toBe(1);
+});
+
+it('rejects a stored entry holding something other than a parse result', function () {
+    // The directory is app-private, but a blob that unserializes into the wrong shape must be
+    // treated as a miss rather than handed to the analyzers.
+    $file = diskCacheSource($this->dir, 'Foreign.php', "<?php\nclass Foreign {}\n");
+    (new PhpFileParser)->parse($file);
+    PhpFileParser::flushDiskCache();
+
+    $bundle = glob($this->cacheDir.'/*.shard')[0];
+    $entries = igbinary_unserialize((string) file_get_contents($bundle));
+    $entries[array_key_first($entries)] = igbinary_serialize(['ast' => [new stdClass], 'useMap' => []]);
+    file_put_contents($bundle, igbinary_serialize($entries));
+
+    nextProcess($this->cacheDir);
+    $result = (new PhpFileParser)->parse($file);
+
+    expect($result['ast'][0])->toBeInstanceOf(Class_::class)
+        ->and(PhpFileParser::$parseCount)->toBe(1);
+});
+
+it('writes nothing once the cache is switched off', function () {
+    PhpFileParser::useDiskCache(null);
+    expect(PhpFileParser::diskCacheEnabled())->toBeFalse();
+
+    $file = diskCacheSource($this->dir, 'Off.php', "<?php\nclass Off {}\n");
+    (new PhpFileParser)->parse($file);
+    PhpFileParser::flushDiskCache();
+
+    expect(glob($this->cacheDir.'/*.shard') ?: [])->toBeEmpty();
+});


### PR DESCRIPTION
## What

A scan parses every PHP file in the application. Almost none of them changed since the last
scan, but the results live in memory and the process exits, so the next run pays for all of it
again. This keeps them under `storage/framework/cache/laravel-brain-ast` and reads them back.

Off by default. `LARAVEL_BRAIN_AST_CACHE=true` turns it on.

| application | scan today | first run with the cache | every run after |
|---|---:|---:|---:|
| A — 1,084 files | 1.91 s | 2.23 s (+17%) | **1.29 s (−33%)** |
| B — 1,885 files | 1.71 s | 2.07 s (+21%) | **1.03 s (−40%)** |
| C — 4,152 files | 3.20 s | 4.24 s (+32%) | **1.45 s (−55%)** |

The first run is slower because it writes what it parsed. It earns that back inside the first
repeat on all three — 0.5, 0.5 and 0.6 runs — and everything after is profit. Disk cost is
20 MB, 22 MB and 60 MB.

Peak memory is the real price, and it is why this stays off by default: on application C a scan
goes from 666 MB to 1.14 GB. That is inherent to holding serialized trees — the per-file layout
this started as costs the same — rather than something the storage format can tune away.

## Entries are addressed by content, not by timestamp

Worth explaining, because the cheaper key is the wrong one and it took a simulation to see it.

Keying on path, size and modification time costs a `stat` and nothing else. But any workflow
that materialises the tree afresh — a CI checkout, a container build, a deploy that copies files
into place — hands every file a new modification time with byte-identical content. Simulating a
fresh checkout on application B:

| | | |
|---|---:|---|
| job 1, populates the cache | 1,971 ms | 1,556 entries written |
| job 2, same workspace | 1,008 ms | 0 parses |
| job 3, after a fresh checkout, **keyed by timestamp** | 2,010 ms | 1,556 re-parses, cache grows to 3,113 entries |
| job 3, after a fresh checkout, **keyed by content** | 1,017 ms | 0 parses, cache stays at 1,556 |

Both arms run the shipped storage layout, so the only thing varying is the key. Each job is its
own process, medians of three. The same scan with no cache at all is 1,599 ms.

Keyed by timestamp it misses everything, writes a second copy of the whole cache, and lands 26%
slower than having no cache at all. Each further checkout adds another full copy, until the
per-bundle cap starts dropping entries that were never stale. Keyed by content it hits, and
comes out 36% faster than no cache.

Hashing the bytes costs a read, which a `stat` avoids. That is about 2% of a warm scan (job 2
above, where both keys hit), and a parse needs the read anyway, so a miss pays nothing extra.
Two files with identical contents also collapse to one entry, which is free.

The in-memory cache keeps its path+mtime+size key: it is exact within one process, and files
modified in the current second still stay out of it.

## Why it is worth having

Measured against a ceiling rather than against nothing. Two builds in one process, where the
second re-parses literally nothing, put parsing at 49% of a build on B and 70% on C — it is the
dominant remaining cost. A cache on disk cannot reach that, since it still has to read and
unserialize; it gets about four fifths of the way.

The case it is built for is the one where the in-memory cache cannot help: short-lived
processes on a machine that keeps the directory. Running `php artisan brain:scan` repeatedly
while working, restarting watch mode, a self-hosted runner or a container with a mounted
volume. A long-running process — an editor daemon, a queue worker — already gets the full
benefit in memory and gains nothing here after its first build.

Hosted CI works too, but only if the workflow caches the directory itself — a runner discards
the workspace between jobs. That restore has to be cheap enough to be worth it, which is why
entries are grouped into 256 bundles rather than written one file each. On application C:

| | files | packed | pack | unpack |
|---|---:|---:|---:|---:|
| one file per entry | 3,689 | 69.6 MB | 1.40 s | 1.46 s |
| 256 bundles | 256 | 60.5 MB | **0.14 s** | **0.16 s** |

The same entries either way. The extra 9 MB is tar's per-file header and padding, which is the
same per-file cost the timings show, and the round trip is 89% cheaper because moving a
directory costs far more per file than per byte. At one file per entry it costs 2.9 s to save
1.75 s of scanning, so the cache is not worth restoring at all; at 0.3 s it clearly is.

## Correctness

Storing syntax trees and reading them back later is either exactly right or quietly wrong, so
the gate is the whole observable output of a build: the full graph, all 358 subgraphs, the
manifest, the totals, the unresolved-dispatch signal, and the entry-point tracer's complete edge
list. On a real 1,885-file application, with the cache off, cold and warm, that is
**13,956,374 bytes — identical in all three**.

An entry is keyed by the content hash plus the PHP version, the php-parser version, the igbinary
version and a schema version for the stored shape. Any of those moving invalidates what is
stored, which matters because each can change the classes being unserialized. Deleting the
directory is always safe.

Anything unexpected is a miss rather than a result — a truncated write, a foreign blob, an entry
from another version — and each costs a re-parse. Corruption cannot escalate into a failed scan
either, including in an application that promotes warnings to exceptions: igbinary warns on
damaged input and `@` does not stop a strict error handler seeing it, so the call is wrapped
rather than suppressed.

## The igbinary requirement

`serialize()`/`unserialize()` are on the list this project's arch tests forbid, for good reason.
igbinary sits outside that surface and is faster besides. Without the extension the cache stays
off and Brain parses as it does today, so this is a soft requirement rather than a new
dependency.

The directory holds objects Brain will unserialize, so it belongs somewhere app-private, which
is why the default is under `storage/`. Anyone able to write there can already run code in a
Laravel application, so this opens no new door — but it is not a directory to point at `/tmp` on
a shared host, and the config comment says so.

## Tests

`186 passed (590 assertions)` · PHPStan level 5 + larastan **No errors** · Pint clean.

Twelve new. The unit tests cover a second process reading from disk without parsing, an edited
file being re-parsed, a corrupt blob falling back, a blob holding the wrong kind of object being
rejected, two identical files sharing one entry, and a file being edited in the current second
getting the right bytes from each of two same-length versions. One checks that the
`resolvedName` attributes from #63 survive the round trip, since those are what let analyzers
stop guessing FQCNs and they would be easy to lose silently. The feature tests cover the wiring:
a scan populating the directory, the next scan parsing nothing, an env-style `'true'` being
honoured, the filesystem left alone when nothing asks for a cache, and the graph coming out the
same either way.

## Note

One line outside the feature: the in-memory cache's eviction counter moves to `intdiv()`, because
the control flow #66 introduced left PHPStan unable to narrow the float cast it replaced.
