### PR TITLE
Resolve same-namespace class references instead of leaving them short

### DIFF
--- a/src/Analysis/MethodTracer.php
+++ b/src/Analysis/MethodTracer.php
@@ -620,7 +620,7 @@ class MethodTracer
                     $val = $first instanceof Node\Arg ? $first->value : $first;
                     if ($val instanceof Node\Expr\New_ && $val->class instanceof Node\Name) {
                         $short = $val->class->toString();
-                        $nf = $this->useMap[$short] ?? $short;
+                        $nf = PhpFileParser::resolvedName($val->class) ?? $this->useMap[$short] ?? $short;
                         if ($this->tracer->looksLikeMail($nf)) {
                             $this->hops[] = [
                                 'fqcn' => $nf,
@@ -843,7 +843,7 @@ class MethodTracer
                     && $val->name->toString() === 'class'
                 ) {
                     $short = $val->class->toString();
-                    $fqcn = $this->useMap[$short] ?? $short;
+                    $fqcn = PhpFileParser::resolvedName($val->class) ?? $this->useMap[$short] ?? $short;
                     if ($this->looksLikeModel($fqcn)) {
                         $this->hops[] = ['fqcn' => $fqcn, 'method' => $ability, 'type' => 'model', 'visibility' => 'public'];
                     }
@@ -918,7 +918,9 @@ class MethodTracer
                 }
                 $value = $node instanceof Node\Arg ? $node->value : $node;
                 if ($value instanceof Node\Expr\New_ && $value->class instanceof Node\Name) {
-                    return $value->class->toString();
+                    // The resolved name first: a sibling in the same namespace needs no `use`,
+                    // so the written name has no useMap entry and would stay short.
+                    return PhpFileParser::resolvedName($value->class) ?? $value->class->toString();
                 }
 
                 return null;
@@ -1138,7 +1140,9 @@ class MethodTracer
                     return null;
                 }
                 if ($type instanceof Node\Name) {
-                    return $type->toString();
+                    // A promoted or injected dependency typed as a same-namespace sibling has
+                    // no `use` entry, so the written name would survive as a short one.
+                    return PhpFileParser::resolvedName($type) ?? $type->toString();
                 }
                 if ($type instanceof Node\NullableType) {
                     return $this->resolveType($type->type);

--- a/src/Analysis/ModelAnalyzer.php
+++ b/src/Analysis/ModelAnalyzer.php
@@ -416,7 +416,10 @@ class ModelAnalyzer
                 if ($node instanceof Node\Expr\ClassConstFetch && $node->class instanceof Node\Name) {
                     $name = $node->class->toString();
 
-                    return $this->useMap[$name] ?? $name;
+                    // A related model usually sits in the same namespace and so needs no import.
+                    // Left short it becomes a second node for a model the graph already has, and
+                    // the relationship points at that one instead of the real one.
+                    return PhpFileParser::resolvedName($node->class) ?? $this->useMap[$name] ?? $name;
                 }
                 if ($node instanceof Node\Scalar\String_) {
                     return $node->value;

--- a/src/Analysis/RouteAnalyzer.php
+++ b/src/Analysis/RouteAnalyzer.php
@@ -1532,8 +1532,10 @@ class RouteAnalyzer
                     if ($class instanceof Node\Name) {
                         $name = $class->toString();
 
-                        // Return FQCN from use-map, not the short name
-                        return $this->useMap[$name] ?? $name;
+                        // Return the FQCN, not the short name. A routes file that declares a
+                        // namespace can name a controller in that namespace with no import, so
+                        // the use-map alone leaves it short.
+                        return PhpFileParser::resolvedName($class) ?? $this->useMap[$name] ?? $name;
                     }
                 }
                 if ($node instanceof Node\Scalar\String_) {

--- a/tests/Unit/MethodTracerResolutionTest.php
+++ b/tests/Unit/MethodTracerResolutionTest.php
@@ -42,3 +42,195 @@ it('resolves a same-namespace type stored in a variable (assign then call)', fun
     expect(array_filter($edges, fn ($e) => $e->calleeFqcn === 'App\\Services\\SameNs\\Reconciler'))
         ->not->toBeEmpty();
 });
+
+/**
+ * Build a throwaway project so these cases cannot shift the counts other suites assert on
+ * against the shared fixture project.
+ *
+ * @param  array<string, string>  $files  path under app/ => file contents
+ */
+function sameNsProject(array $files): string
+{
+    $root = sys_get_temp_dir().'/brain-samens-'.uniqid();
+    foreach ($files as $path => $contents) {
+        $full = $root.'/app/'.$path;
+        if (! is_dir(dirname($full))) {
+            mkdir(dirname($full), 0o777, true);
+        }
+        file_put_contents($full, $contents);
+    }
+
+    return $root;
+}
+
+it('resolves a same-namespace sibling injected as a constructor dependency', function () {
+    // The property-type path resolved through the import map alone, so a sibling needing no
+    // `use` stayed short. A short name is worse than a missing one: "PlainThing::label" is an
+    // edge under an id nothing else in the graph uses, and the bare word also trips the
+    // single-word model heuristic, so the hop came back typed 'model'.
+    $root = sameNsProject([
+        'Registry/PlainThing.php' => '<?php
+namespace App\Registry;
+
+class PlainThing
+{
+    public function label(): string { return "x"; }
+}',
+        'Registry/Shapes.php' => '<?php
+namespace App\Registry;
+
+class Shapes
+{
+    public function __construct(private ?PlainThing $thing = null) {}
+
+    public function viaProperty(): string { return $this->thing->label(); }
+}',
+    ]);
+
+    $edges = (new MethodTracer)->traceMethod('App\Registry\Shapes', 'viaProperty', ['App\\' => [$root.'/app']], $root);
+
+    expect(array_map(fn ($e) => $e->calleeFqcn, $edges))->toContain('App\Registry\PlainThing');
+    foreach ($edges as $edge) {
+        expect($edge->calleeFqcn)->not->toBe('PlainThing');
+    }
+
+    exec('rm -rf '.escapeshellarg($root));
+});
+
+it('resolves a same-namespace job passed to dispatch()', function () {
+    $root = sameNsProject([
+        'Jobs/SyncJob.php' => '<?php
+namespace App\Jobs;
+
+class SyncJob
+{
+    public function handle(): void {}
+}',
+        'Jobs/Kicker.php' => '<?php
+namespace App\Jobs;
+
+class Kicker
+{
+    public function go(): void { dispatch(new SyncJob()); }
+}',
+    ]);
+
+    $edges = (new MethodTracer)->traceMethod('App\Jobs\Kicker', 'go', ['App\\' => [$root.'/app']], $root);
+
+    expect(array_map(fn ($e) => $e->calleeFqcn, $edges))->toContain('App\Jobs\SyncJob');
+    foreach ($edges as $edge) {
+        expect($edge->calleeFqcn)->not->toBe('SyncJob');
+    }
+
+    exec('rm -rf '.escapeshellarg($root));
+});
+
+it('resolves a same-namespace model named in authorize()', function () {
+    $root = sameNsProject([
+        'Models/Invoice.php' => '<?php
+namespace App\Models;
+
+class Invoice {}',
+        'Models/Guarded.php' => '<?php
+namespace App\Models;
+
+class Guarded
+{
+    public function check(): void { $this->authorize("view", Invoice::class); }
+}',
+    ]);
+
+    $edges = (new MethodTracer)->traceMethod('App\Models\Guarded', 'check', ['App\\' => [$root.'/app']], $root);
+
+    expect(array_map(fn ($e) => $e->calleeFqcn, $edges))->toContain('App\Models\Invoice');
+    foreach ($edges as $edge) {
+        expect($edge->calleeFqcn)->not->toBe('Invoice');
+    }
+
+    exec('rm -rf '.escapeshellarg($root));
+});
+
+it('traces a same-namespace reference exactly as it traces the same class imported', function () {
+    // The invariant worth pinning: how a class is written should not change what is traced.
+    // Asserting equivalence rather than a hop count also keeps this test honest about the
+    // duplicate the facade paths already emit on main, which this does not change.
+    $root = sameNsProject([
+        'Events/ThingHappened.php' => '<?php
+namespace App\Events;
+
+class ThingHappened {}',
+        'Events/Sibling.php' => '<?php
+namespace App\Events;
+
+class Sibling
+{
+    public function go(): void { event(new ThingHappened()); }
+}',
+        'Outside/Importer.php' => '<?php
+namespace App\Outside;
+
+use App\Events\ThingHappened;
+
+class Importer
+{
+    public function go(): void { event(new ThingHappened()); }
+}',
+    ]);
+
+    $tracer = new MethodTracer;
+    $psr4 = ['App\\' => [$root.'/app']];
+
+    $describe = fn (array $edges) => array_map(
+        fn ($e) => $e->calleeFqcn.'::'.$e->calleeMethod.' ('.$e->type.')',
+        $edges,
+    );
+
+    $sibling = $describe($tracer->traceMethod('App\Events\Sibling', 'go', $psr4, $root));
+    $imported = $describe($tracer->traceMethod('App\Outside\Importer', 'go', $psr4, $root));
+
+    expect($sibling)->toBe($imported)
+        ->and($sibling)->toContain('App\Events\ThingHappened::__construct (event)');
+
+    exec('rm -rf '.escapeshellarg($root));
+});
+
+it('treats a same-namespace authorize() target the same as an imported one', function () {
+    // authorize() only records a target that looksLikeModel() accepts, and that helper takes any
+    // bare capitalised word. A model outside the conventional namespaces was therefore accepted
+    // while it stayed short and is rejected once resolved — so this call records nothing now.
+    //
+    // That is the invariant applied downwards rather than a new gap: written as an import, the
+    // qualified name fails the same check on main today. What is pinned here is that both forms
+    // agree; whether looksLikeModel() should recognise the class at all is a separate question.
+    $root = sameNsProject([
+        'Domain/Billing/Invoice.php' => '<?php
+namespace App\Domain\Billing;
+
+class Invoice {}',
+        'Domain/Billing/Guarded.php' => '<?php
+namespace App\Domain\Billing;
+
+class Guarded
+{
+    public function check(): void { $this->authorize("view", Invoice::class); }
+}',
+        'Outside/Importer.php' => '<?php
+namespace App\Outside;
+
+use App\Domain\Billing\Invoice;
+
+class Importer
+{
+    public function check(): void { $this->authorize("view", Invoice::class); }
+}',
+    ]);
+
+    $tracer = new MethodTracer;
+    $psr4 = ['App\\' => [$root.'/app']];
+    $describe = fn (array $edges) => array_map(fn ($e) => $e->calleeFqcn.'::'.$e->calleeMethod, $edges);
+
+    expect($describe($tracer->traceMethod('App\Domain\Billing\Guarded', 'check', $psr4, $root)))
+        ->toBe($describe($tracer->traceMethod('App\Outside\Importer', 'check', $psr4, $root)));
+
+    exec('rm -rf '.escapeshellarg($root));
+});

--- a/tests/Unit/ModelAnalyzerTest.php
+++ b/tests/Unit/ModelAnalyzerTest.php
@@ -37,3 +37,14 @@ it('detects belongsTo relationship on Order model', function () {
 
     expect($types)->ToBeArray()->toContain('belongsTo');
 });
+
+it('resolves a related model in the same namespace', function () {
+    // Order::user() does `$this->belongsTo(User::class)`. Related models almost always sit
+    // together in App\Models, so the target needs no import — and left short it became a second
+    // node for a model the graph already had, with the relationship pointing at that one.
+    $models = (new ModelAnalyzer)->analyze(fixture('laravel-project'), ['App\\Models\\Order']);
+    $related = array_column($models['App\\Models\\Order']->relationships, 'related');
+
+    expect($related)->toContain('App\\Models\\User')
+        ->and($related)->not->toContain('User');
+});

--- a/tests/Unit/RouteAnalyzerTest.php
+++ b/tests/Unit/RouteAnalyzerTest.php
@@ -463,3 +463,40 @@ function routeAnalyzerTestDeleteTree(string $dir): void
     }
     @rmdir($dir);
 }
+
+it('resolves a controller named in a namespaced routes file without an import', function () {
+    // A routes file may declare a namespace, and a controller in that namespace then needs no
+    // `use`. Resolving through the import map alone left the controller short, which keys every
+    // route and call-chain edge that touches it on a name nothing else in the graph uses.
+    $root = sys_get_temp_dir().'/brain-routens-'.uniqid();
+    mkdir($root.'/routes', 0o777, true);
+    mkdir($root.'/app/Http/Controllers/Dev', 0o777, true);
+
+    file_put_contents($root.'/routes/web.php', <<<'PHP'
+        <?php
+
+        namespace App\Http\Controllers\Dev;
+
+        use Illuminate\Support\Facades\Route;
+
+        Route::get('dev', DevOverviewController::class);
+        PHP);
+    file_put_contents($root.'/app/Http/Controllers/Dev/DevOverviewController.php', <<<'PHP'
+        <?php
+
+        namespace App\Http\Controllers\Dev;
+
+        class DevOverviewController
+        {
+            public function __invoke() {}
+        }
+        PHP);
+
+    $routes = (new RouteAnalyzer)->analyze($root);
+    $dev = findRoute($routes, fn ($r) => str_contains($r->uri, 'dev'));
+
+    expect($dev)->not->toBeNull()
+        ->and($dev->controller)->toBe('App\Http\Controllers\Dev\DevOverviewController');
+
+    exec('rm -rf '.escapeshellarg($root));
+});


### PR DESCRIPTION
Fixes #72.

## What

A class in the same namespace needs no `use` statement, so it has no entry in the file's import
map. Three analyzers resolved written class names through that map alone, and the name stayed
short.

A short name is worse than a missing one. Where the real class is already in the graph, the short
one becomes a **second node for it**, and the edge points at that one instead — so a relationship
or a call looks connected while joining nothing, and it is indistinguishable from a real edge
without reading the id. A bare word also trips the single-word model heuristic, so a traced hop
comes back typed as a model.

| analyzer | where |
|---|---|
| `MethodTracer` | the `new X()` extractor feeding the event, job and `Bus` dispatch handlers; the `Mail`/`Notification` `send()` handler; `authorize()`'s `Model::class`; the constructor-dependency type the property-call path reads |
| `RouteAnalyzer` | a controller named in a routes file that **declares a namespace**, where a sibling controller needs no import |
| `ModelAnalyzer` | a relationship target — `$this->hasMany(Book::class)` — the most common case of all, since related models normally sit together in `App\Models` |

All six sites now prefer `PhpFileParser::resolvedName()`. #63 already annotates every `Name` with
its resolved form, and several other sites were already reading it — these were the ones left
behind. It applies the rule PHP itself applies, so no separate qualification step is needed, and
the existing `useMap` fallback still covers a `Name` from an AST this parser did not produce. The
one place that deliberately shortens a name, matching the `Route` facade, is left alone.

`new Sibling()` on its own already resolved and is covered by tests from #63. The issue reports it
as broken, but that half is already fixed on `main`; what remained were the paths above, which read
the class name from somewhere other than the `new` handler.

## Effect on a real graph

The measure that matters is the duplicate node — a short name that stands in for a class the graph
already has under its real name. Edges are compared on `(source, target, type, label)` so a
re-keyed endpoint shows up rather than being normalised away.

| application | duplicate nodes | nodes | edges | edges vanished |
|---|---:|---:|---:|---:|
| A — 1,084 files | 47 → **2** | 2,934 → 2,891 | 5,574 → 5,576 | **0** |
| B — 1,885 files | 67 → **0** | 2,746 → 2,766 | 4,795 → 4,986 | **0** |
| C — 4,152 files | 65 → **0** | 2,532 → 2,467 | 5,018 → 5,018 | **0** |

Nothing vanished anywhere. Node counts fall on A and C because the duplicates collapse into the
real nodes they were standing in for, and the relationship edges re-point at those — C keeps
exactly its 5,018 edges while losing 65 phantom nodes. B gains 191 edges instead, because its
controllers were the ones being renamed, and once qualified they join the rest of the graph.

Counting it a second way, every short class name `MethodTracer` produces during a full build of B:

| | short names |
|---|---:|
| `main` | 440 |
| tracer sites only | 370 |
| all three analyzers | **5** |

The five are `Throwable`, a real root-namespace class where no separator is correct. This is also
why the PR covers three analyzers rather than the one the issue names: of the 370 the tracer fix
alone left behind, 365 were a controller referring to itself, inheriting a short name handed in
from a namespaced routes file.

What still remains is a different mechanism. A names its controllers with Laravel's legacy string
syntax — `Route::resource('users', 'UsersController')` — resolved against a namespace prefix in
`RouteServiceProvider`, not against PHP imports. Nothing here addresses that. The other leftovers
are middleware group names like `web` and `api`, which are not class names.

## Cost

Scan time, medians of five, three rounds alternating between a checkout of each:

| application | `main` | this branch | |
|---|---:|---:|---|
| A | 1,903 ms | 1,894 ms | −0.5% |
| B | 1,663 ms | 1,709 ms | +2.8% |
| C | 3,182 ms | 3,130 ms | −1.6% |

The direction follows what happens to the graph rather than the resolution itself. B pays about
3%, repeatably across all three rounds, and it is the application that gains 191 edges — the extra
time is spent tracing reach that was previously invisible. C comes out slightly ahead because it
sheds 65 nodes and the splitter has less to lay out. A does not move.

## One case where a resolved name is emitted less, not more

`authorize('view', Invoice::class)` only records the target when `looksLikeModel()` accepts it,
and that helper treats **any** bare capitalised word as a model. So a model outside the
conventional namespaces — `App\Domain\Billing\Invoice`, say — was accepted while it stayed short
and is rejected once resolved. That call now records nothing where it previously recorded
`Invoice`.

This is the same invariant, applied in the less comfortable direction. Write that class as an
import and `main` records nothing either, today, before this change: the qualified name fails the
same check. The same-namespace form was only being kept by the accident of being short, and the
node it produced was a phantom of the kind this PR exists to remove.

The real gap is that `looksLikeModel()` recognises models by location, so a project that keeps
them elsewhere loses the `authorize()` target either way. Widening it is a heuristic change that
would alter edge counts on its own terms, so it is not folded in here. None of the three
applications hit this — no edge vanished on any of them — and it is the only heuristic that can
flip this way: the job, mail, notification and resource checks all match on substrings, so a
longer name can only match more.

## One thing this deliberately does not change

On the `Mail`, `Notification` and `event` paths the specific handler and the generic `new` handler
both emit a hop for the same expression, so the call is recorded twice. That is pre-existing and
unrelated to name resolution: an **imported** class duplicates identically on `main` today, before
and after this change.

Resolving the name makes the same-namespace form reach the same handler, so it now duplicates the
same way. The invariant is that how a class is written no longer changes what is traced, and one
test asserts exactly that by comparing the two forms rather than counting hops. Collapsing the
duplicate changes edge counts for every application, which does not belong in a resolution change.

## Tests

`193 passed (671 assertions)` · PHPStan level 5 + larastan **No errors** · Pint clean.

Seven new cases, each failing on `main` and passing here: the constructor-injected sibling, the
dispatched sibling job, the model named in `authorize()`, the controller in a namespaced routes
file, the related model in the same namespace, and two equivalences between a same-namespace
reference and the same class imported — one where resolving gains an edge, one where it gives one
up.

The model case needed no new fixture — `Order::user()` already does `$this->belongsTo(User::class)`
with `User` a same-namespace sibling, so the bug was sitting in the fixture project the whole time,
untested. The others build throwaway projects in a temp directory rather than extending that
fixture, whose route, node and edge counts other suites assert against.
