### PR TITLE
Read array route actions, and apply the namespace a provider gives them

### DIFF
--- a/src/Analysis/MethodTracer.php
+++ b/src/Analysis/MethodTracer.php
@@ -620,7 +620,7 @@ class MethodTracer
                     $val = $first instanceof Node\Arg ? $first->value : $first;
                     if ($val instanceof Node\Expr\New_ && $val->class instanceof Node\Name) {
                         $short = $val->class->toString();
-                        $nf = $this->useMap[$short] ?? $short;
+                        $nf = PhpFileParser::resolvedName($val->class) ?? $this->useMap[$short] ?? $short;
                         if ($this->tracer->looksLikeMail($nf)) {
                             $this->hops[] = [
                                 'fqcn' => $nf,
@@ -843,7 +843,7 @@ class MethodTracer
                     && $val->name->toString() === 'class'
                 ) {
                     $short = $val->class->toString();
-                    $fqcn = $this->useMap[$short] ?? $short;
+                    $fqcn = PhpFileParser::resolvedName($val->class) ?? $this->useMap[$short] ?? $short;
                     if ($this->looksLikeModel($fqcn)) {
                         $this->hops[] = ['fqcn' => $fqcn, 'method' => $ability, 'type' => 'model', 'visibility' => 'public'];
                     }
@@ -918,7 +918,9 @@ class MethodTracer
                 }
                 $value = $node instanceof Node\Arg ? $node->value : $node;
                 if ($value instanceof Node\Expr\New_ && $value->class instanceof Node\Name) {
-                    return $value->class->toString();
+                    // The resolved name first: a sibling in the same namespace needs no `use`,
+                    // so the written name has no useMap entry and would stay short.
+                    return PhpFileParser::resolvedName($value->class) ?? $value->class->toString();
                 }
 
                 return null;
@@ -1138,7 +1140,9 @@ class MethodTracer
                     return null;
                 }
                 if ($type instanceof Node\Name) {
-                    return $type->toString();
+                    // A promoted or injected dependency typed as a same-namespace sibling has
+                    // no `use` entry, so the written name would survive as a short one.
+                    return PhpFileParser::resolvedName($type) ?? $type->toString();
                 }
                 if ($type instanceof Node\NullableType) {
                     return $this->resolveType($type->type);

--- a/src/Analysis/ModelAnalyzer.php
+++ b/src/Analysis/ModelAnalyzer.php
@@ -416,7 +416,10 @@ class ModelAnalyzer
                 if ($node instanceof Node\Expr\ClassConstFetch && $node->class instanceof Node\Name) {
                     $name = $node->class->toString();
 
-                    return $this->useMap[$name] ?? $name;
+                    // A related model usually sits in the same namespace and so needs no import.
+                    // Left short it becomes a second node for a model the graph already has, and
+                    // the relationship points at that one instead of the real one.
+                    return PhpFileParser::resolvedName($node->class) ?? $this->useMap[$name] ?? $name;
                 }
                 if ($node instanceof Node\Scalar\String_) {
                     return $node->value;

--- a/src/Analysis/RouteAnalyzer.php
+++ b/src/Analysis/RouteAnalyzer.php
@@ -1532,8 +1532,10 @@ class RouteAnalyzer
                     if ($class instanceof Node\Name) {
                         $name = $class->toString();
 
-                        // Return FQCN from use-map, not the short name
-                        return $this->useMap[$name] ?? $name;
+                        // Return the FQCN, not the short name. A routes file that declares a
+                        // namespace can name a controller in that namespace with no import, so
+                        // the use-map alone leaves it short.
+                        return PhpFileParser::resolvedName($class) ?? $this->useMap[$name] ?? $name;
                     }
                 }
                 if ($node instanceof Node\Scalar\String_) {

--- a/src/Analysis/RouteAnalyzer.php
+++ b/src/Analysis/RouteAnalyzer.php
@@ -300,7 +300,7 @@ class RouteAnalyzer
      * @param  Node\Stmt[]  $ast
      * @return string[]
      */
-    private function collectIncludeTargets(array $ast, string $file): array
+    public function collectIncludeTargets(array $ast, string $file): array
     {
         $analyzer = $this;
         $traverser = new NodeTraverser;
@@ -412,9 +412,11 @@ class RouteAnalyzer
      * Recognised shapes (any class short-named `Route` qualifies):
      *   - Route::middleware('api')->prefix('api/admin')->group(base_path('routes/admin.php'));
      *   - Route::group(['prefix' => 'api/admin', 'middleware' => 'api'], base_path(...));
+     *   - Route::group([...], function () { require base_path('routes/web.php'); });
      *
-     * Calls whose routes-argument is a closure are ignored — those routes are
-     * defined inline and don't reference an external file.
+     * The closure form is what `laravel/laravel` shipped for years, and the file it requires
+     * needs the group's context just as much as one passed by path — without it those routes
+     * lose the group's namespace, middleware and prefix together.
      *
      * @return array<string, array{prefix: string, middlewares: string[], namespace: string, controller: string}>
      */
@@ -457,11 +459,50 @@ class RouteAnalyzer
      * @param  Node\Stmt[]  $ast
      * @return array<string, array{prefix: string, middlewares: string[], namespace: string, controller: string}>
      */
+    /**
+     * String property defaults declared anywhere in a parsed file, keyed by property name.
+     *
+     * Only literal strings are recorded; anything computed has no single value to record.
+     *
+     * @param  Node\Stmt[]  $ast
+     * @return array<string, string>
+     */
+    private function collectPropertyDefaults(array $ast): array
+    {
+        $traverser = new NodeTraverser;
+        $visitor = new class extends NodeVisitorAbstract
+        {
+            /** @var array<string, string> */
+            public array $defaults = [];
+
+            public function enterNode(Node $node): ?int
+            {
+                if (! $node instanceof Node\Stmt\Property) {
+                    return null;
+                }
+                foreach ($node->props as $prop) {
+                    if ($prop->default instanceof Node\Scalar\String_) {
+                        $this->defaults[$prop->name->toString()] = $prop->default->value;
+                    }
+                }
+
+                return null;
+            }
+        };
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($ast);
+
+        return $visitor->defaults;
+    }
+
     private function extractGroupRegistrations(array $ast, string $file): array
     {
         $analyzer = $this;
         $traverser = new NodeTraverser;
-        $visitor = new class($analyzer, $file) extends NodeVisitorAbstract
+        // Collected up front rather than while walking: a provider declares `$namespace` before
+        // the method that reads it, but nothing guarantees that order.
+        $propertyDefaults = $this->collectPropertyDefaults($ast);
+        $visitor = new class($analyzer, $file, $propertyDefaults) extends NodeVisitorAbstract
         {
             /** @var array<string, array{prefix: string, middlewares: string[], namespace: string, controller: string}> */
             public array $registrations = [];
@@ -470,10 +511,17 @@ class RouteAnalyzer
 
             private string $file;
 
-            public function __construct(RouteAnalyzer $analyzer, string $file)
+            /** @var array<string, string> property name => literal default */
+            private array $propertyDefaults;
+
+            /**
+             * @param  array<string, string>  $propertyDefaults
+             */
+            public function __construct(RouteAnalyzer $analyzer, string $file, array $propertyDefaults)
             {
                 $this->analyzer = $analyzer;
                 $this->file = $file;
+                $this->propertyDefaults = $propertyDefaults;
             }
 
             public function enterNode(Node $node): ?int
@@ -491,29 +539,39 @@ class RouteAnalyzer
                         continue;
                     }
                     $value = $arg->value;
-                    if ($value instanceof Node\Expr\Array_
-                        || $value instanceof Node\Expr\Closure
-                        || $value instanceof Node\Expr\ArrowFunction
-                    ) {
+                    if ($value instanceof Node\Expr\Array_) {
                         continue;
                     }
-                    $path = $this->analyzer->resolveIncludePath($value, $this->file);
-                    if ($path === null) {
-                        continue;
+
+                    // A closure body may `require` the routes file rather than the call naming
+                    // it directly; those routes still belong to this group.
+                    $paths = [];
+                    if ($value instanceof Node\Expr\Closure) {
+                        $paths = $this->analyzer->collectIncludeTargets($value->stmts, $this->file);
+                    } elseif ($value instanceof Node\Expr\ArrowFunction) {
+                        $paths = $this->analyzer->collectIncludeTargets(
+                            [new Node\Stmt\Expression($value->expr)],
+                            $this->file,
+                        );
+                    } else {
+                        $path = $this->analyzer->resolveIncludePath($value, $this->file);
+                        if ($path !== null) {
+                            $paths = [$path];
+                        }
                     }
-                    $real = realpath($path);
-                    if ($real === false) {
-                        continue;
+
+                    foreach ($paths as $path) {
+                        $real = realpath($path);
+                        if ($real === false || isset($this->registrations[$real])) {
+                            continue;
+                        }
+                        $this->registrations[$real] = [
+                            'prefix' => $prefix,
+                            'middlewares' => $middlewares,
+                            'namespace' => $namespace,
+                            'controller' => $controller,
+                        ];
                     }
-                    if (isset($this->registrations[$real])) {
-                        continue;
-                    }
-                    $this->registrations[$real] = [
-                        'prefix' => $prefix,
-                        'middlewares' => $middlewares,
-                        'namespace' => $namespace,
-                        'controller' => $controller,
-                    ];
                 }
 
                 return null;
@@ -581,7 +639,21 @@ class RouteAnalyzer
 
             private function literalString(Node $value): string
             {
-                return $value instanceof Node\Scalar\String_ ? $value->value : '';
+                if ($value instanceof Node\Scalar\String_) {
+                    return $value->value;
+                }
+
+                // `'namespace' => $this->namespace` — the controller namespace a provider applies
+                // is conventionally held in a property rather than written at the call.
+                if ($value instanceof Node\Expr\PropertyFetch
+                    && $value->var instanceof Node\Expr\Variable
+                    && $value->var->name === 'this'
+                    && $value->name instanceof Node\Identifier
+                ) {
+                    return $this->propertyDefaults[$value->name->toString()] ?? '';
+                }
+
+                return '';
             }
 
             private function literalClassRef(Node $value): string
@@ -1087,16 +1159,24 @@ class RouteAnalyzer
                 $stackController = end($this->controllerStack) ?: '';
                 $controllerContext = $chainController !== '' ? $chainController : $stackController;
 
-                [$controller, $actionMethod, $closureNode] = $this->extractAction($node->args[1] ?? null, $controllerContext);
+                [$controller, $actionMethod, $closureNode, $mayPrependNamespace] = $this->extractAction($node->args[1] ?? null, $controllerContext);
 
-                if ($controller !== 'Closure' && $controller !== '' && ! str_starts_with($controller, '\\')) {
+                // An array action can carry its own middleware alongside `uses`.
+                $actionArg = $node->args[1] ?? null;
+                $actionValue = $actionArg instanceof Node\Arg ? $actionArg->value : $actionArg;
+                if ($actionValue !== null) {
+                    $actionMiddleware = $this->arrayValueFor($actionValue, 'middleware');
+                    if ($actionMiddleware !== null) {
+                        $extraMiddlewares = array_merge($extraMiddlewares, $this->extractMiddlewareList($actionMiddleware));
+                    }
+                }
+
+                if ($mayPrependNamespace && $controller !== 'Closure' && $controller !== '') {
                     $namespace = implode('\\', array_filter($this->namespaceStack));
                     if ($chainNamespace) {
                         $namespace = $namespace ? $namespace.'\\'.$chainNamespace : $chainNamespace;
                     }
-                    if ($namespace) {
-                        $controller = rtrim($namespace, '\\').'\\'.ltrim($controller, '\\');
-                    }
+                    $controller = $this->prependNamespace($controller, $namespace);
                 }
 
                 $fullUri = $this->joinUri(implode('', $this->prefixStack).$chainPrefix, $uri);
@@ -1251,14 +1331,12 @@ class RouteAnalyzer
                     $this->walkChain($node->var, $chainPrefix, $chainMiddlewares, $chainNamespace);
                 }
 
-                if ($controllerFqcn !== '' && ! str_starts_with($controllerFqcn, '\\')) {
+                if ($controllerFqcn !== '') {
                     $namespace = implode('\\', array_filter($this->namespaceStack));
                     if ($chainNamespace) {
                         $namespace = $namespace ? $namespace.'\\'.$chainNamespace : $chainNamespace;
                     }
-                    if ($namespace) {
-                        $controllerFqcn = rtrim($namespace, '\\').'\\'.ltrim($controllerFqcn, '\\');
-                    }
+                    $controllerFqcn = $this->prependNamespace($controllerFqcn, $namespace);
                 }
                 $fullUri = $this->joinUri(implode('', $this->prefixStack).$chainPrefix, $uri);
                 $middlewares = array_merge(
@@ -1473,14 +1551,28 @@ class RouteAnalyzer
             }
 
             /**
-             * @return array{0: string, 1: string, 2: Node\Expr\Closure|Node\Expr\ArrowFunction|null}
+             * The fourth element says whether a group namespace may be prepended to the
+             * controller. The router only does that for an action written as a string, or an
+             * array whose `uses` is a string ({@see Router::actionReferencesController()}) — a
+             * `[Controller::class, 'method']` pair names the class outright and prefixing it
+             * would produce `App\\Http\\Controllers\\App\\Http\\Controllers\\Thing`.
+             *
+             * @return array{0: string, 1: string, 2: Node\Expr\Closure|Node\Expr\ArrowFunction|null, 3: bool}
              */
             private function extractAction(?Node $node, string $controllerContext = ''): array
             {
                 if ($node === null) {
-                    return ['', '', null];
+                    return ['', '', null, false];
                 }
                 $value = $node instanceof Node\Arg ? $node->value : $node;
+
+                // ['uses' => 'Controller@method', 'as' => ..., 'middleware' => ...]. Checked
+                // before the positional form below, which a two-entry ['as' => ..., 'uses' => ...]
+                // would otherwise match — taking the route's name as its controller.
+                $uses = $this->arrayValueFor($value, 'uses');
+                if ($uses !== null) {
+                    return $this->extractAction($uses, $controllerContext);
+                }
 
                 // [Controller::class, 'method']
                 if ($value instanceof Node\Expr\Array_ && count($value->items) >= 2) {
@@ -1490,7 +1582,7 @@ class RouteAnalyzer
                         $controller = $this->extractClassRef($classItem->value);
                         $actionMethod = $this->extractString($methodItem) ?? '';
 
-                        return [$controller, $actionMethod, null];
+                        return [$controller, $actionMethod, null, false];
                     }
                 }
 
@@ -1499,30 +1591,81 @@ class RouteAnalyzer
                     if (str_contains($value->value, '@')) {
                         $parts = explode('@', $value->value, 2);
 
-                        return [$parts[0], $parts[1], null];
+                        return [$parts[0], $parts[1], null, true];
                     }
 
                     // Inside Route::controller(X::class)->group(...) a bare string is a
                     // method name on the group controller, not an invokable controller.
                     if ($controllerContext !== '') {
-                        return [$controllerContext, $value->value, null];
+                        return [$controllerContext, $value->value, null, false];
                     }
 
-                    return [$value->value, '__invoke', null];
+                    return [$value->value, '__invoke', null, true];
                 }
 
                 // Controller::class (for __invoke)
                 $classRef = $this->extractClassRef($value);
                 if ($classRef !== '') {
-                    return [$classRef, '__invoke', null];
+                    return [$classRef, '__invoke', null, false];
                 }
 
                 // Closure routes
                 if ($value instanceof Node\Expr\Closure || $value instanceof Node\Expr\ArrowFunction) {
-                    return ['Closure', '__invoke', $value];
+                    return ['Closure', '__invoke', $value, false];
                 }
 
-                return ['', '', null];
+                return ['', '', null, false];
+            }
+
+            /**
+             * Qualify a controller with the group namespace, on the router's terms
+             * ({@see Router::prependGroupNamespace()}): a leading `\` means the name is already
+             * absolute, and a name that already begins with the group namespace is left alone —
+             * `Controller::class` evaluates to a fully-qualified string at runtime, so without
+             * that second guard a resource route inside a namespaced group would be prefixed
+             * twice.
+             *
+             * That second guard compares on a separator, where the router compares on the raw
+             * string. The router is always holding the whole merged namespace by then, so the
+             * distinction never shows there; here a group can contribute one segment at a time,
+             * and `Admin` is a string prefix of `AdminController` while being nothing of the kind.
+             */
+            private function prependNamespace(string $class, string $namespace): string
+            {
+                // A leading `\` marks the name absolute. Everything else keys a controller
+                // without one, so it is dropped here rather than left to key a second node
+                // that can never join the first.
+                if (str_starts_with($class, '\\')) {
+                    return ltrim($class, '\\');
+                }
+
+                $namespace = rtrim($namespace, '\\');
+                if ($namespace === '' || str_starts_with($class, $namespace.'\\')) {
+                    return $class;
+                }
+
+                return $namespace.'\\'.$class;
+            }
+
+            /**
+             * The value stored under a string key of an array literal, or null when the node is
+             * not an array or has no such key.
+             */
+            private function arrayValueFor(Node $node, string $key): ?Node
+            {
+                if (! $node instanceof Node\Expr\Array_) {
+                    return null;
+                }
+                foreach ($node->items as $item) {
+                    if ($item === null || ! $item->key instanceof Node\Scalar\String_) {
+                        continue;
+                    }
+                    if ($item->key->value === $key) {
+                        return $item->value;
+                    }
+                }
+
+                return null;
             }
 
             private function extractClassRef(Node $node): string

--- a/tests/Unit/MethodTracerResolutionTest.php
+++ b/tests/Unit/MethodTracerResolutionTest.php
@@ -42,3 +42,195 @@ it('resolves a same-namespace type stored in a variable (assign then call)', fun
     expect(array_filter($edges, fn ($e) => $e->calleeFqcn === 'App\\Services\\SameNs\\Reconciler'))
         ->not->toBeEmpty();
 });
+
+/**
+ * Build a throwaway project so these cases cannot shift the counts other suites assert on
+ * against the shared fixture project.
+ *
+ * @param  array<string, string>  $files  path under app/ => file contents
+ */
+function sameNsProject(array $files): string
+{
+    $root = sys_get_temp_dir().'/brain-samens-'.uniqid();
+    foreach ($files as $path => $contents) {
+        $full = $root.'/app/'.$path;
+        if (! is_dir(dirname($full))) {
+            mkdir(dirname($full), 0o777, true);
+        }
+        file_put_contents($full, $contents);
+    }
+
+    return $root;
+}
+
+it('resolves a same-namespace sibling injected as a constructor dependency', function () {
+    // The property-type path resolved through the import map alone, so a sibling needing no
+    // `use` stayed short. A short name is worse than a missing one: "PlainThing::label" is an
+    // edge under an id nothing else in the graph uses, and the bare word also trips the
+    // single-word model heuristic, so the hop came back typed 'model'.
+    $root = sameNsProject([
+        'Registry/PlainThing.php' => '<?php
+namespace App\Registry;
+
+class PlainThing
+{
+    public function label(): string { return "x"; }
+}',
+        'Registry/Shapes.php' => '<?php
+namespace App\Registry;
+
+class Shapes
+{
+    public function __construct(private ?PlainThing $thing = null) {}
+
+    public function viaProperty(): string { return $this->thing->label(); }
+}',
+    ]);
+
+    $edges = (new MethodTracer)->traceMethod('App\Registry\Shapes', 'viaProperty', ['App\\' => [$root.'/app']], $root);
+
+    expect(array_map(fn ($e) => $e->calleeFqcn, $edges))->toContain('App\Registry\PlainThing');
+    foreach ($edges as $edge) {
+        expect($edge->calleeFqcn)->not->toBe('PlainThing');
+    }
+
+    exec('rm -rf '.escapeshellarg($root));
+});
+
+it('resolves a same-namespace job passed to dispatch()', function () {
+    $root = sameNsProject([
+        'Jobs/SyncJob.php' => '<?php
+namespace App\Jobs;
+
+class SyncJob
+{
+    public function handle(): void {}
+}',
+        'Jobs/Kicker.php' => '<?php
+namespace App\Jobs;
+
+class Kicker
+{
+    public function go(): void { dispatch(new SyncJob()); }
+}',
+    ]);
+
+    $edges = (new MethodTracer)->traceMethod('App\Jobs\Kicker', 'go', ['App\\' => [$root.'/app']], $root);
+
+    expect(array_map(fn ($e) => $e->calleeFqcn, $edges))->toContain('App\Jobs\SyncJob');
+    foreach ($edges as $edge) {
+        expect($edge->calleeFqcn)->not->toBe('SyncJob');
+    }
+
+    exec('rm -rf '.escapeshellarg($root));
+});
+
+it('resolves a same-namespace model named in authorize()', function () {
+    $root = sameNsProject([
+        'Models/Invoice.php' => '<?php
+namespace App\Models;
+
+class Invoice {}',
+        'Models/Guarded.php' => '<?php
+namespace App\Models;
+
+class Guarded
+{
+    public function check(): void { $this->authorize("view", Invoice::class); }
+}',
+    ]);
+
+    $edges = (new MethodTracer)->traceMethod('App\Models\Guarded', 'check', ['App\\' => [$root.'/app']], $root);
+
+    expect(array_map(fn ($e) => $e->calleeFqcn, $edges))->toContain('App\Models\Invoice');
+    foreach ($edges as $edge) {
+        expect($edge->calleeFqcn)->not->toBe('Invoice');
+    }
+
+    exec('rm -rf '.escapeshellarg($root));
+});
+
+it('traces a same-namespace reference exactly as it traces the same class imported', function () {
+    // The invariant worth pinning: how a class is written should not change what is traced.
+    // Asserting equivalence rather than a hop count also keeps this test honest about the
+    // duplicate the facade paths already emit on main, which this does not change.
+    $root = sameNsProject([
+        'Events/ThingHappened.php' => '<?php
+namespace App\Events;
+
+class ThingHappened {}',
+        'Events/Sibling.php' => '<?php
+namespace App\Events;
+
+class Sibling
+{
+    public function go(): void { event(new ThingHappened()); }
+}',
+        'Outside/Importer.php' => '<?php
+namespace App\Outside;
+
+use App\Events\ThingHappened;
+
+class Importer
+{
+    public function go(): void { event(new ThingHappened()); }
+}',
+    ]);
+
+    $tracer = new MethodTracer;
+    $psr4 = ['App\\' => [$root.'/app']];
+
+    $describe = fn (array $edges) => array_map(
+        fn ($e) => $e->calleeFqcn.'::'.$e->calleeMethod.' ('.$e->type.')',
+        $edges,
+    );
+
+    $sibling = $describe($tracer->traceMethod('App\Events\Sibling', 'go', $psr4, $root));
+    $imported = $describe($tracer->traceMethod('App\Outside\Importer', 'go', $psr4, $root));
+
+    expect($sibling)->toBe($imported)
+        ->and($sibling)->toContain('App\Events\ThingHappened::__construct (event)');
+
+    exec('rm -rf '.escapeshellarg($root));
+});
+
+it('treats a same-namespace authorize() target the same as an imported one', function () {
+    // authorize() only records a target that looksLikeModel() accepts, and that helper takes any
+    // bare capitalised word. A model outside the conventional namespaces was therefore accepted
+    // while it stayed short and is rejected once resolved — so this call records nothing now.
+    //
+    // That is the invariant applied downwards rather than a new gap: written as an import, the
+    // qualified name fails the same check on main today. What is pinned here is that both forms
+    // agree; whether looksLikeModel() should recognise the class at all is a separate question.
+    $root = sameNsProject([
+        'Domain/Billing/Invoice.php' => '<?php
+namespace App\Domain\Billing;
+
+class Invoice {}',
+        'Domain/Billing/Guarded.php' => '<?php
+namespace App\Domain\Billing;
+
+class Guarded
+{
+    public function check(): void { $this->authorize("view", Invoice::class); }
+}',
+        'Outside/Importer.php' => '<?php
+namespace App\Outside;
+
+use App\Domain\Billing\Invoice;
+
+class Importer
+{
+    public function check(): void { $this->authorize("view", Invoice::class); }
+}',
+    ]);
+
+    $tracer = new MethodTracer;
+    $psr4 = ['App\\' => [$root.'/app']];
+    $describe = fn (array $edges) => array_map(fn ($e) => $e->calleeFqcn.'::'.$e->calleeMethod, $edges);
+
+    expect($describe($tracer->traceMethod('App\Domain\Billing\Guarded', 'check', $psr4, $root)))
+        ->toBe($describe($tracer->traceMethod('App\Outside\Importer', 'check', $psr4, $root)));
+
+    exec('rm -rf '.escapeshellarg($root));
+});

--- a/tests/Unit/ModelAnalyzerTest.php
+++ b/tests/Unit/ModelAnalyzerTest.php
@@ -37,3 +37,14 @@ it('detects belongsTo relationship on Order model', function () {
 
     expect($types)->ToBeArray()->toContain('belongsTo');
 });
+
+it('resolves a related model in the same namespace', function () {
+    // Order::user() does `$this->belongsTo(User::class)`. Related models almost always sit
+    // together in App\Models, so the target needs no import — and left short it became a second
+    // node for a model the graph already had, with the relationship pointing at that one.
+    $models = (new ModelAnalyzer)->analyze(fixture('laravel-project'), ['App\\Models\\Order']);
+    $related = array_column($models['App\\Models\\Order']->relationships, 'related');
+
+    expect($related)->toContain('App\\Models\\User')
+        ->and($related)->not->toContain('User');
+});

--- a/tests/Unit/RouteAnalyzerTest.php
+++ b/tests/Unit/RouteAnalyzerTest.php
@@ -463,3 +463,40 @@ function routeAnalyzerTestDeleteTree(string $dir): void
     }
     @rmdir($dir);
 }
+
+it('resolves a controller named in a namespaced routes file without an import', function () {
+    // A routes file may declare a namespace, and a controller in that namespace then needs no
+    // `use`. Resolving through the import map alone left the controller short, which keys every
+    // route and call-chain edge that touches it on a name nothing else in the graph uses.
+    $root = sys_get_temp_dir().'/brain-routens-'.uniqid();
+    mkdir($root.'/routes', 0o777, true);
+    mkdir($root.'/app/Http/Controllers/Dev', 0o777, true);
+
+    file_put_contents($root.'/routes/web.php', <<<'PHP'
+        <?php
+
+        namespace App\Http\Controllers\Dev;
+
+        use Illuminate\Support\Facades\Route;
+
+        Route::get('dev', DevOverviewController::class);
+        PHP);
+    file_put_contents($root.'/app/Http/Controllers/Dev/DevOverviewController.php', <<<'PHP'
+        <?php
+
+        namespace App\Http\Controllers\Dev;
+
+        class DevOverviewController
+        {
+            public function __invoke() {}
+        }
+        PHP);
+
+    $routes = (new RouteAnalyzer)->analyze($root);
+    $dev = findRoute($routes, fn ($r) => str_contains($r->uri, 'dev'));
+
+    expect($dev)->not->toBeNull()
+        ->and($dev->controller)->toBe('App\Http\Controllers\Dev\DevOverviewController');
+
+    exec('rm -rf '.escapeshellarg($root));
+});

--- a/tests/Unit/RouteAnalyzerTest.php
+++ b/tests/Unit/RouteAnalyzerTest.php
@@ -500,3 +500,172 @@ it('resolves a controller named in a namespaced routes file without an import', 
 
     exec('rm -rf '.escapeshellarg($root));
 });
+
+/**
+ * A throwaway project with a routes file and, optionally, a provider that loads it.
+ *
+ * @param  array<string, string>  $files  path relative to the project root => contents
+ */
+function routeProject(array $files): string
+{
+    $root = sys_get_temp_dir().'/brain-routes-'.uniqid();
+    foreach ($files as $path => $contents) {
+        $full = $root.'/'.$path;
+        if (! is_dir(dirname($full))) {
+            mkdir(dirname($full), 0o777, true);
+        }
+        file_put_contents($full, $contents);
+    }
+
+    return $root;
+}
+
+it('reads a controller from an array action rather than taking the route name as one', function () {
+    // ['as' => ..., 'uses' => ...] has two entries, so it matched the positional
+    // [Controller::class, 'method'] branch and the route's own name became its controller.
+    // The single-entry ['uses' => ...] matched nothing and the route was dropped outright.
+    $root = routeProject([
+        'routes/web.php' => '<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get("b", ["as" => "b.name", "uses" => "BetaController@show"]);
+Route::get("c", ["uses" => "GammaController@edit"]);
+Route::get("e", ["uses" => "EpsilonController@go", "middleware" => "auth"]);
+',
+    ]);
+
+    $routes = (new RouteAnalyzer)->analyze($root);
+    $by = fn (string $uri) => findRoute($routes, fn ($r) => $r->uri === $uri);
+
+    expect($by('/b'))->not->toBeNull()
+        ->and($by('/b')->controller)->toBe('BetaController')
+        ->and($by('/b')->action)->toBe('show')
+        ->and($by('/c'))->not->toBeNull()
+        ->and($by('/c')->controller)->toBe('GammaController')
+        ->and($by('/c')->action)->toBe('edit')
+        ->and($by('/e')->middlewares)->toContain('auth');
+
+    exec('rm -rf '.escapeshellarg($root));
+});
+
+it('applies the namespace and middleware of a provider group that requires its routes in a closure', function () {
+    // The registration scanner looked for a file path argument and skipped closures, so the
+    // shape laravel/laravel shipped for years recorded nothing and the routes file was parsed
+    // with no context — losing the group's namespace and middleware together. The namespace
+    // itself is a property default, which the literal-string reader returned '' for.
+    $root = routeProject([
+        'routes/web.php' => '<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::get("a", "AlphaController@index");
+',
+        'app/Providers/RouteServiceProvider.php' => '<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\Facades\Route;
+
+class RouteServiceProvider
+{
+    protected $namespace = "App\Http\Controllers";
+
+    protected function mapWebRoutes(): void
+    {
+        Route::group([
+            "middleware" => "web",
+            "namespace" => $this->namespace,
+        ], static function (): void {
+            require base_path("routes/web.php");
+        });
+    }
+}
+',
+    ]);
+
+    $route = findRoute((new RouteAnalyzer)->analyze($root), fn ($r) => $r->uri === '/a');
+
+    expect($route)->not->toBeNull()
+        ->and($route->controller)->toBe('App\Http\Controllers\AlphaController')
+        ->and($route->middlewares)->toContain('web');
+
+    exec('rm -rf '.escapeshellarg($root));
+});
+
+it('does not prepend a group namespace to a controller that already carries it', function () {
+    // Controller::class is a fully-qualified string at runtime, so prefixing it again yields
+    // App\Http\Controllers\App\Http\Controllers\Thing — a node nothing can join. The router
+    // guards this the same way, by leaving a name that already starts with the group namespace
+    // alone.
+    $root = routeProject([
+        'routes/web.php' => '<?php
+
+use App\Http\Controllers\ThingController;
+use Illuminate\Support\Facades\Route;
+
+Route::group(["namespace" => "App\Http\Controllers"], static function (): void {
+    Route::get("one", [ThingController::class, "index"]);
+    Route::resource("two", ThingController::class);
+});
+',
+        'app/Http/Controllers/ThingController.php' => '<?php
+
+namespace App\Http\Controllers;
+
+class ThingController {}
+',
+    ]);
+
+    foreach ((new RouteAnalyzer)->analyze($root) as $route) {
+        expect($route->controller)->toBe('App\Http\Controllers\ThingController');
+    }
+
+    exec('rm -rf '.escapeshellarg($root));
+});
+
+it('still qualifies a controller whose name merely begins with the namespace segment', function () {
+    // The "already carries it" guard has to compare on a separator: `Admin` is a string prefix
+    // of `AdminController` while being no namespace of it, and skipping there would leave the
+    // controller unqualified.
+    $root = routeProject([
+        'routes/web.php' => '<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::group(["namespace" => "Admin"], static function (): void {
+    Route::get("profile", "AdminController@profile");
+});
+',
+    ]);
+
+    $route = findRoute((new RouteAnalyzer)->analyze($root), fn ($r) => $r->uri === '/profile');
+
+    expect($route)->not->toBeNull()
+        ->and($route->controller)->toBe('Admin\AdminController');
+
+    exec('rm -rf '.escapeshellarg($root));
+});
+
+it('keys a controller written with a leading backslash without one', function () {
+    // A leading \ says the name is absolute, not that it is part of the name. Keeping it makes
+    // a second controller node that can never join the one every other reference produces.
+    $root = routeProject([
+        'routes/web.php' => '<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::group(["namespace" => "App\Http\Controllers"], static function (): void {
+    Route::get("s1", "\\\\App\\\\Http\\\\Controllers\\\\ZetaController@go");
+    Route::get("s2", ["uses" => "\\\\App\\\\Http\\\\Controllers\\\\ZetaController@go"]);
+});
+',
+    ]);
+
+    foreach ((new RouteAnalyzer)->analyze($root) as $route) {
+        expect($route->controller)->toBe('App\Http\Controllers\ZetaController')
+            ->and($route->action)->toBe('go');
+    }
+
+    exec('rm -rf '.escapeshellarg($root));
+});


### PR DESCRIPTION
Fixes #74. Stacks on #73 — review that one first; this branch contains it.

## What

`Route::get($uri, ['as' => ..., 'uses' => 'Controller@method'])` was read as the positional
`[Controller::class, 'method']` form, because both are arrays of two entries. So the route's own
**name** became its controller, the `uses` string was left unsplit as the action, and any
`middleware` in the array was dropped. The one-entry `['uses' => ...]` matched neither shape and
produced no route at all.

This is current syntax rather than something removed. `Router::convertToControllerAction()` in
Laravel 12.26 still turns a string action into `['uses' => $action]`.

Separately, a controller named as a string was never qualified, for two reasons that compound:

- the registration scanner looked for a routes file passed to `Route::group()` **by path** and
  skipped closure arguments, so `Route::group($attrs, fn () => require base_path(...))` — the
  shape `laravel/laravel` shipped for years — recorded nothing, and the file was then parsed with
  no context at all, losing the group's middleware and prefix along with its namespace;
- the namespace is conventionally held in a provider property and written
  `'namespace' => $this->namespace`, which the literal-string reader returned `''` for even once
  the registration was found.

| shape | before | after |
|---|---|---|
| `['as' => 'b.name', 'uses' => 'BetaController@show']` | controller `b.name`, action `BetaController@show` | controller `BetaController`, action `show` |
| `['uses' => 'GammaController@edit']` | no route at all | controller `GammaController`, action `edit` |
| `['uses' => ..., 'middleware' => 'auth']` | middleware dropped | `auth` kept |
| provider group requiring its routes in a closure | no namespace, no middleware, no prefix | all three applied |

## Prepending a namespace needs the router's guards

The existing code applied a group namespace to any controller not starting with `\`. That was
harmless only because the namespace was almost always empty; with the registration above it
starts arriving, and the missing guards show up immediately. The router has two, and both matter:

1. **Only a string action takes a group namespace.** `actionReferencesController()` is true for a
   string, or an array whose `uses` is a string — a `[Controller::class, 'method']` pair names the
   class outright and is left alone.
2. **A name that already begins with the namespace is left alone.** `Controller::class` evaluates
   to a fully-qualified string at runtime, so without this a `Route::resource` inside a namespaced
   group is prefixed twice.

Both are implemented here. The second compares on a separator where the router compares on the
raw string, and the difference is load-bearing: the router is always holding the whole merged
namespace by the time it checks, while a group here contributes one segment at a time, so `Admin`
turns up as a string prefix of `AdminController` while being no namespace of it. Comparing raw
would silently un-qualify that controller.

## Effect on a real graph

Measured against #73, this branch's base. Edges compared on `(source, target, type, label)`.

| application | routes with an unusable controller | nodes | edges | edges vanished |
|---|---:|---:|---:|---:|
| A — 1,084 files | 321 of 451 → **0** | 2,891 → 3,543 | 5,576 → 8,972 | **0** |
| B — 1,885 files | 0 → 0 | unchanged | unchanged | **0** |
| C — 4,152 files | 0 → 0 | 2,467 → 2,457 | 5,018 → 5,007 | **0** |

A is the application written in this style, and its routes also go from 66 with no middleware to
none. The graph grows because 321 routes that previously dead-ended now reach a controller, and
the call chains hanging off those controllers get traced for the first time.

B does not move at all. C loses twelve nodes and gains two: six of its controllers were being
**double-prefixed** already — `Api\Plugin\App\Http\Controllers\Api\Plugin\PluginSessionDataController`
— and guard 2 collapses those onto the real ones. That is a pre-existing defect this happens to
fix rather than anything new.

## Cost

This is the expensive one, and the cost is real rather than an artefact. Medians of five, three
rounds:

| application | #73 | this branch | |
|---|---:|---:|---|
| A | 1,837 ms | 2,449 ms | **+34%** |
| B | 1,635 ms | 1,635 ms | 0% |
| C | 3,008 ms | 3,016 ms | 0% |

All of it lands on A, whose edge count grows 61%. It is the price of tracing 321 routes that were
previously being skipped, not a slower way of doing the same work — B and C, which gain no routes,
do not move at all. Worth knowing before merging: an application in this style pays a third more
scan time, and gets a graph that actually contains its controllers.

## Tests

`198 passed (696 assertions)` · PHPStan level 5 + larastan **No errors** · Pint clean.

Five new. Four fail on #73 and pass here: the array action form, the provider group that requires
its routes in a closure, the double-prefixing guard, and the leading-backslash controller. The
fifth — a controller whose name merely begins with the namespace segment — passes on #73 too,
because #73 has no such guard to get wrong. It is a regression test for guard 2 rather than a fix,
and it is here because I got that comparison wrong the first time and it cost C its `Admin\`
prefix before the separator went in.
