### PR TITLE
Rescan only what changed in watch mode

### DIFF
--- a/src/Analysis/Incremental/BuildFingerprint.php
+++ b/src/Analysis/Incremental/BuildFingerprint.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaraMint\LaravelBrain\Analysis\Incremental;
+
+/**
+ * Per-file content fingerprints for a build, used to decide which files changed between
+ * two analyze() runs. Keyed by absolute path → a content hash (not mtime: mtime is
+ * integer-second and collides on fast edit→rebuild→edit cycles — the same class of race
+ * the parse cache guards against). Content-hashing is O(bytes read) but reads are cheap
+ * relative to parsing/analysis, and this runs once per build.
+ */
+final class BuildFingerprint
+{
+    /**
+     * @param  array<string, string>  $files  absolute path => content hash
+     */
+    public function __construct(
+        public readonly array $files,
+    ) {}
+
+    /**
+     * Fingerprint every PHP file under the given roots (relative to $projectRoot).
+     *
+     * @param  string[]  $relativeRoots  e.g. ['app', 'routes', 'config']
+     */
+    public static function capture(string $projectRoot, array $relativeRoots = ['app', 'routes', 'config']): self
+    {
+        $projectRoot = rtrim($projectRoot, '/');
+        $files = [];
+
+        foreach ($relativeRoots as $rel) {
+            $base = $projectRoot.'/'.$rel;
+            if (! is_dir($base)) {
+                continue;
+            }
+            $it = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($base, \FilesystemIterator::SKIP_DOTS)
+            );
+            foreach ($it as $file) {
+                if ($file->getExtension() !== 'php') {
+                    continue;
+                }
+                $path = $file->getPathname();
+                $contents = @file_get_contents($path);
+                if ($contents === false) {
+                    continue;
+                }
+                $files[$path] = hash('xxh128', $contents);
+            }
+        }
+
+        ksort($files);
+
+        return new self($files);
+    }
+
+    /**
+     * Files that were added, modified, or deleted relative to a previous fingerprint.
+     *
+     * @return array{added: string[], modified: string[], deleted: string[]}
+     */
+    public function diff(self $previous): array
+    {
+        $added = $modified = $deleted = [];
+
+        foreach ($this->files as $path => $hash) {
+            if (! array_key_exists($path, $previous->files)) {
+                $added[] = $path;
+            } elseif ($previous->files[$path] !== $hash) {
+                $modified[] = $path;
+            }
+        }
+        foreach (array_keys($previous->files) as $path) {
+            if (! array_key_exists($path, $this->files)) {
+                $deleted[] = $path;
+            }
+        }
+
+        return ['added' => $added, 'modified' => $modified, 'deleted' => $deleted];
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->files === $other->files;
+    }
+}

--- a/src/Analysis/Incremental/GraphProvenance.php
+++ b/src/Analysis/Incremental/GraphProvenance.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaraMint\LaravelBrain\Analysis\Incremental;
+
+use LaraMint\LaravelBrain\Graph\Graph;
+
+/**
+ * Partitions a built graph by the source file each element derives from — the basis for a
+ * diff-scoped rebuild: when a file changes, only the elements it owns need recomputing.
+ *
+ * Ownership rules (why they hold):
+ *  - A NODE is owned by its `data.file` (every node carries it; blade/virtual nodes without a
+ *    real file land in the '' bucket and are treated as always-rebuilt).
+ *  - An EDGE is owned by the file of its SOURCE node — the call originates in that file's code,
+ *    so editing the caller is what adds/removes the edge. (An edge also implicitly depends on
+ *    its TARGET node existing; the merge step, not this partition, prunes edges left dangling
+ *    when a target file is deleted — that cross-file case is why incremental falls back to a
+ *    full rebuild unless the change is provably contained.)
+ *
+ * Content-addressed ids (ID1 for edges, nodeIdForHop for nodes) make every id stable across
+ * rebuilds, so a partition captured from one build is directly comparable to the next.
+ */
+final class GraphProvenance
+{
+    /**
+     * @param  array<string, array{nodes: string[], edges: string[]}>  $byFile
+     * @param  array<string, string>  $nodeFile  nodeId => owning file
+     * @param  array<string, string>  $edgeFile  edgeId => owning file
+     */
+    private function __construct(
+        public readonly array $byFile,
+        public readonly array $nodeFile,
+        public readonly array $edgeFile,
+    ) {}
+
+    public static function of(Graph $graph): self
+    {
+        $byFile = [];
+        $nodeFile = [];
+        $edgeFile = [];
+
+        foreach ($graph->nodes() as $node) {
+            $file = is_string($node->data['file'] ?? null) ? $node->data['file'] : '';
+            $nodeFile[$node->id] = $file;
+            $byFile[$file]['nodes'][] = $node->id;
+            $byFile[$file]['edges'] ??= [];
+        }
+
+        foreach ($graph->edges() as $edge) {
+            // Owned by the source node's file (the caller). Falls to '' when the source is a
+            // virtual/blade node without a file.
+            $file = $nodeFile[$edge->source] ?? '';
+            $edgeFile[$edge->id] = $file;
+            $byFile[$file]['edges'][] = $edge->id;
+            $byFile[$file]['nodes'] ??= [];
+        }
+
+        return new self($byFile, $nodeFile, $edgeFile);
+    }
+
+    /** Node ids owned by the given files (elements to invalidate when those files change). */
+    public function nodeIdsForFiles(string ...$files): array
+    {
+        $ids = [];
+        foreach ($files as $f) {
+            foreach ($this->byFile[$f]['nodes'] ?? [] as $id) {
+                $ids[] = $id;
+            }
+        }
+
+        return array_values(array_unique($ids));
+    }
+
+    /** Edge ids owned by the given files. */
+    public function edgeIdsForFiles(string ...$files): array
+    {
+        $ids = [];
+        foreach ($files as $f) {
+            foreach ($this->byFile[$f]['edges'] ?? [] as $id) {
+                $ids[] = $id;
+            }
+        }
+
+        return array_values(array_unique($ids));
+    }
+}

--- a/src/Analysis/Incremental/GraphProvenance.php
+++ b/src/Analysis/Incremental/GraphProvenance.php
@@ -14,13 +14,23 @@ use LaraMint\LaravelBrain\Graph\Graph;
  *  - A NODE is owned by its `data.file` (every node carries it; blade/virtual nodes without a
  *    real file land in the '' bucket and are treated as always-rebuilt).
  *  - An EDGE is owned by the file of its SOURCE node — the call originates in that file's code,
- *    so editing the caller is what adds/removes the edge. (An edge also implicitly depends on
- *    its TARGET node existing; the merge step, not this partition, prunes edges left dangling
- *    when a target file is deleted — that cross-file case is why incremental falls back to a
- *    full rebuild unless the change is provably contained.)
+ *    so editing the caller is what adds/removes the edge.
  *
- * Content-addressed ids (ID1 for edges, nodeIdForHop for nodes) make every id stable across
- * rebuilds, so a partition captured from one build is directly comparable to the next.
+ * IMPORTANT — this partition is NECESSARY BUT NOT SUFFICIENT as a merge dirty set (proven on a
+ * real corpus; a fixtures-only check missed it). Editing a controller to dispatch a job adds an
+ * edge whose SOURCE is the controller (correctly in the controller's partition) but whose TARGET
+ * node (job::handle) is owned by the JOB's file — so a partition-only dirty set silently
+ * under-updates the dispatch target. The sound merge dirty set is therefore:
+ *
+ *     dirty = (edited files' partitions)  ∪  (1-hop closure over the edit's EDGE DELTA:
+ *             for every edge added / removed / changed while re-analysing the edited files,
+ *             also refresh the FOREIGN node that edge targets)
+ *
+ * The blast-radius census measured that closure at ≤1 node/edit, so it stays cheap. The merge
+ * step owns that closure (and dangling-edge pruning when a target file is deleted); this class
+ * only provides the partition it starts from. Content-addressed ids (ID1 for edges, nodeIdForHop
+ * for nodes) make every id stable across rebuilds, so a partition captured from one build is
+ * directly comparable to the next.
  */
 final class GraphProvenance
 {

--- a/src/Analysis/Incremental/IncrementalAnalyzer.php
+++ b/src/Analysis/Incremental/IncrementalAnalyzer.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaraMint\LaravelBrain\Analysis\Incremental;
+
+use LaraMint\LaravelBrain\Graph\Graph;
+
+/**
+ * Diff-scoped graph rebuild. Holds the previous build in memory (the watch-mode case: keep one
+ * IncrementalAnalyzer across rescans) and, when a rescan changes only a few files, refreshes just
+ * those files' contribution instead of rebuilding the whole graph.
+ *
+ * Conservative by construction — it only takes the fast path when it is provably output-identical
+ * to a full rebuild, and falls back to a full build otherwise:
+ *   - files added or deleted, or any non-app (routes/config) file changed  -> full
+ *   - a changed file whose CALL GRAPH changed (its owned edge-id set differs from the scoped
+ *     rebuild's) -> full (edge add/remove + cross-file reachability is the next slice)
+ *   - otherwise (node bodies changed, call graph intact) -> scoped refresh + IncrementalMerge
+ *
+ * fullBuild and scopedBuild are injected so this stays decoupled from ProjectAnalyzer's container
+ * wiring and testable with the raw analyzers; production supplies a ProjectAnalyzer-backed full
+ * build and a scoped GraphBuilder for the changed files' contribution.
+ */
+final class IncrementalAnalyzer
+{
+    /** @var \Closure(string): Graph */
+    private \Closure $fullBuild;
+
+    /** @var \Closure(string, string[]): Graph  (projectRoot, changedFiles) => partial graph */
+    private \Closure $scopedBuild;
+
+    /** @var string[] */
+    private array $roots;
+
+    private ?Graph $prevGraph = null;
+
+    private ?BuildFingerprint $prevFp = null;
+
+    /**
+     * @param  \Closure(string): Graph  $fullBuild
+     * @param  \Closure(string, string[]): Graph  $scopedBuild
+     * @param  string[]  $roots
+     */
+    public function __construct(\Closure $fullBuild, \Closure $scopedBuild, array $roots = ['app', 'routes', 'config'])
+    {
+        $this->fullBuild = $fullBuild;
+        $this->scopedBuild = $scopedBuild;
+        $this->roots = $roots;
+    }
+
+    /**
+     * @return array{graph: Graph, mode: 'full'|'incremental'|'unchanged'}
+     */
+    public function analyze(string $projectRoot): array
+    {
+        $fp = BuildFingerprint::capture($projectRoot, $this->roots);
+
+        if ($this->prevGraph === null) {
+            return $this->full($projectRoot, $fp);
+        }
+
+        $diff = $fp->diff($this->prevFp);
+
+        // Structural: added/deleted files, or a routes/config change, can shift the route table,
+        // entry points or reachability wholesale — always a full rebuild.
+        if ($diff['added'] !== [] || $diff['deleted'] !== [] || $this->touchesNonApp($diff['modified'])) {
+            return $this->full($projectRoot, $fp);
+        }
+
+        $modified = $diff['modified'];
+        if ($modified === []) {
+            return ['graph' => $this->prevGraph, 'mode' => 'unchanged'];
+        }
+
+        $partial = ($this->scopedBuild)($projectRoot, $modified);
+
+        // Precondition for the fast path: the changed files' call graph is intact (same owned
+        // edge ids old vs scoped). If not, the edit changed edges/reachability -> full rebuild.
+        if (IncrementalMerge::ownedEdgeIdSet($this->prevGraph, $modified)
+            != IncrementalMerge::ownedEdgeIdSet($partial, $modified)) {
+            return $this->full($projectRoot, $fp);
+        }
+
+        $merged = IncrementalMerge::applyPartial($this->prevGraph, $partial, $modified);
+        $this->prevGraph = $merged;
+        $this->prevFp = $fp;
+
+        return ['graph' => $merged, 'mode' => 'incremental'];
+    }
+
+    /**
+     * @return array{graph: Graph, mode: 'full'}
+     */
+    private function full(string $projectRoot, BuildFingerprint $fp): array
+    {
+        $graph = ($this->fullBuild)($projectRoot);
+        $this->prevGraph = $graph;
+        $this->prevFp = $fp;
+
+        return ['graph' => $graph, 'mode' => 'full'];
+    }
+
+    /**
+     * @param  string[]  $files
+     */
+    private function touchesNonApp(array $files): bool
+    {
+        foreach ($files as $f) {
+            if (! str_contains($f, '/app/')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Analysis/Incremental/IncrementalAnalyzer.php
+++ b/src/Analysis/Incremental/IncrementalAnalyzer.php
@@ -75,10 +75,11 @@ final class IncrementalAnalyzer
 
         $partial = ($this->scopedBuild)($projectRoot, $modified);
 
-        // Precondition for the fast path: the changed files' call graph is intact (same owned
-        // edge ids old vs scoped). If not, the edit changed edges/reachability -> full rebuild.
-        if (IncrementalMerge::ownedEdgeIdSet($this->prevGraph, $modified)
-            != IncrementalMerge::ownedEdgeIdSet($partial, $modified)) {
+        // Precondition for the fast path: the changed files' call graph is intact (the same owned
+        // edges old vs scoped, compared by content). If not, the edit changed edges/reachability
+        // -> full rebuild.
+        if (IncrementalMerge::ownedEdgeKeySet($this->prevGraph, $modified)
+            != IncrementalMerge::ownedEdgeKeySet($partial, $modified)) {
             return $this->full($projectRoot, $fp);
         }
 

--- a/src/Analysis/Incremental/IncrementalMerge.php
+++ b/src/Analysis/Incremental/IncrementalMerge.php
@@ -143,15 +143,15 @@ final class IncrementalMerge
         }
 
         $result = new Graph;
-        // Reused, untouched nodes from the previous build...
+        // One pass, in the previous build's order: an untouched node is carried over, and a
+        // changed file's node is substituted in place by its freshly rebuilt self. Rebuilding
+        // them in a second pass would move every one to the end, leaving a merged graph holding
+        // the same nodes as a rebuild in a different sequence — which anything diffing or
+        // caching the output would see as churn.
         foreach ($old->nodes() as $n) {
             if (! isset($dirtyNodes[$n->id])) {
                 $result->addNode($n);
-            }
-        }
-        // ...and the changed files' own nodes, freshly rebuilt.
-        foreach ($old->nodes() as $n) {
-            if (isset($dirtyNodes[$n->id]) && isset($partialNodes[$n->id])) {
+            } elseif (isset($partialNodes[$n->id])) {
                 $result->addNode($partialNodes[$n->id]);
             }
         }

--- a/src/Analysis/Incremental/IncrementalMerge.php
+++ b/src/Analysis/Incremental/IncrementalMerge.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaraMint\LaravelBrain\Analysis\Incremental;
+
+use LaraMint\LaravelBrain\Graph\Edge;
+use LaraMint\LaravelBrain\Graph\Graph;
+
+/**
+ * The correctness core of incremental analyze(): given the PREVIOUS full graph and the set of
+ * changed files, decide the exact "dirty" element set that must be refreshed, and reconstruct
+ * the new graph by reusing every unchanged element from the previous build.
+ *
+ * The dirty-set rule (empirically validated on a real corpus — see GraphProvenance):
+ *
+ *     dirty = (changed files' partitions, in BOTH the old and new provenance)
+ *           ∪ (1-hop closure over the edge delta: for every edge whose presence changed between
+ *              the two builds, also refresh the nodes it connects — this catches edges a caller
+ *              edit adds whose TARGET node is owned by a different file, e.g. a new job dispatch)
+ *
+ * This class is the deterministic, side-effect-free heart that the full engine is gated on:
+ * `reconstruct(old, new, changed)` MUST equal a full rebuild `new`. It takes `new` as the oracle
+ * for the changed files' fresh contribution; the perf-delivering step (computing that fresh
+ * contribution from a SCOPED re-analysis of only the changed files, instead of a full rebuild)
+ * layers on top without changing this logic — which is exactly why it can be proven correct now.
+ */
+final class IncrementalMerge
+{
+    /**
+     * The sound dirty set: node ids and edge ids that must be taken from the fresh build.
+     *
+     * @param  string[]  $changedFiles
+     * @return array{nodes: array<string, true>, edges: array<string, true>}
+     */
+    public static function dirtyIds(Graph $old, Graph $new, array $changedFiles): array
+    {
+        $oldProv = GraphProvenance::of($old);
+        $newProv = GraphProvenance::of($new);
+
+        $dirtyNodes = [];
+        $dirtyEdges = [];
+
+        // (a) Everything the changed files own, in either build (covers modified + added + removed
+        //     elements whose owner is a changed file).
+        foreach ([$oldProv, $newProv] as $prov) {
+            foreach ($prov->nodeIdsForFiles(...$changedFiles) as $id) {
+                $dirtyNodes[$id] = true;
+            }
+            foreach ($prov->edgeIdsForFiles(...$changedFiles) as $id) {
+                $dirtyEdges[$id] = true;
+            }
+        }
+
+        // (b) 1-hop closure over the edge delta. Edge ids are content-addressed (ID1), so an edge
+        //     whose id is present in exactly one build is an add or a remove; refresh the foreign
+        //     nodes it connects (the caller edit may own the edge but not its target node).
+        $oldEdges = self::edgeMap($old);
+        $newEdges = self::edgeMap($new);
+        foreach ([$oldEdges, $newEdges] as $edges) {
+            foreach ($edges as $id => $edge) {
+                $inOld = isset($oldEdges[$id]);
+                $inNew = isset($newEdges[$id]);
+                if ($inOld && $inNew) {
+                    continue; // unchanged edge
+                }
+                $dirtyEdges[$id] = true;
+                $dirtyNodes[$edge->source] = true;
+                $dirtyNodes[$edge->target] = true;
+            }
+        }
+
+        return ['nodes' => $dirtyNodes, 'edges' => $dirtyEdges];
+    }
+
+    /**
+     * Rebuild the new graph by taking dirty elements from $new and reusing every other element
+     * from $old. If the dirty set is complete, this equals $new exactly; a gap surfaces as a
+     * difference from $new (that is the correctness gate). Meta is taken from $new.
+     */
+    public static function reconstruct(Graph $old, Graph $new, array $changedFiles): Graph
+    {
+        $dirty = self::dirtyIds($old, $new, $changedFiles);
+
+        $oldNodes = [];
+        foreach ($old->nodes() as $n) {
+            $oldNodes[$n->id] = $n;
+        }
+        $oldEdges = self::edgeMap($old);
+
+        $result = new Graph;
+
+        foreach ($new->nodes() as $n) {
+            // Reuse the previous instance for an unchanged, non-dirty node; otherwise take the fresh one.
+            $result->addNode(
+                (! isset($dirty['nodes'][$n->id]) && isset($oldNodes[$n->id])) ? $oldNodes[$n->id] : $n
+            );
+        }
+
+        foreach ($new->edges() as $e) {
+            $result->addEdge(
+                (! isset($dirty['edges'][$e->id]) && isset($oldEdges[$e->id])) ? $oldEdges[$e->id] : $e
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * Content signature of a graph's elements, independent of build metadata (analyzedAt etc.) and
+     * insertion order — for asserting two graphs are behaviourally identical.
+     *
+     * @return array{nodes: array<string, string>, edges: array<string, string>}
+     */
+    public static function signature(Graph $graph): array
+    {
+        $nodes = [];
+        foreach ($graph->nodes() as $n) {
+            $nodes[$n->id] = hash('xxh128', serialize([$n->type, $n->label, $n->data]));
+        }
+        $edges = [];
+        foreach ($graph->edges() as $e) {
+            $edges[$e->id] = hash('xxh128', serialize([$e->source, $e->target, $e->label, $e->type]));
+        }
+        ksort($nodes);
+        ksort($edges);
+
+        return ['nodes' => $nodes, 'edges' => $edges];
+    }
+
+    /**
+     * @return array<string, Edge>
+     */
+    private static function edgeMap(Graph $graph): array
+    {
+        $map = [];
+        foreach ($graph->edges() as $e) {
+            $map[$e->id] = $e;
+        }
+
+        return $map;
+    }
+}

--- a/src/Analysis/Incremental/IncrementalMerge.php
+++ b/src/Analysis/Incremental/IncrementalMerge.php
@@ -42,29 +42,31 @@ final class IncrementalMerge
         $dirtyEdges = [];
 
         // (a) Everything the changed files own, in either build (covers modified + added + removed
-        //     elements whose owner is a changed file).
-        foreach ([$oldProv, $newProv] as $prov) {
+        //     elements whose owner is a changed file). Provenance indexes edges by id, so the ids
+        //     are translated to content identity here to stay in one key space with (b).
+        foreach ([[$oldProv, $old], [$newProv, $new]] as [$prov, $graph]) {
+            $keysById = self::edgeKeysById($graph);
             foreach ($prov->nodeIdsForFiles(...$changedFiles) as $id) {
                 $dirtyNodes[$id] = true;
             }
             foreach ($prov->edgeIdsForFiles(...$changedFiles) as $id) {
-                $dirtyEdges[$id] = true;
+                if (isset($keysById[$id])) {
+                    $dirtyEdges[$keysById[$id]] = true;
+                }
             }
         }
 
-        // (b) 1-hop closure over the edge delta. Edge ids are content-addressed (ID1), so an edge
-        //     whose id is present in exactly one build is an add or a remove; refresh the foreign
-        //     nodes it connects (the caller edit may own the edge but not its target node).
+        // (b) 1-hop closure over the edge delta. Edges are compared by content identity, so an
+        //     edge present in exactly one build is an add or a remove; refresh the foreign nodes
+        //     it connects (the caller edit may own the edge but not its target node).
         $oldEdges = self::edgeMap($old);
         $newEdges = self::edgeMap($new);
         foreach ([$oldEdges, $newEdges] as $edges) {
-            foreach ($edges as $id => $edge) {
-                $inOld = isset($oldEdges[$id]);
-                $inNew = isset($newEdges[$id]);
-                if ($inOld && $inNew) {
+            foreach ($edges as $key => $edge) {
+                if (isset($oldEdges[$key]) && isset($newEdges[$key])) {
                     continue; // unchanged edge
                 }
-                $dirtyEdges[$id] = true;
+                $dirtyEdges[$key] = true;
                 $dirtyNodes[$edge->source] = true;
                 $dirtyNodes[$edge->target] = true;
             }
@@ -97,9 +99,15 @@ final class IncrementalMerge
             );
         }
 
+        $seen = [];
         foreach ($new->edges() as $e) {
+            $key = self::edgeKey($e);
+            $n = $seen[$key] ?? 0;
+            $seen[$key] = $n + 1;
+            $key .= '#'.$n;
+
             $result->addEdge(
-                (! isset($dirty['edges'][$e->id]) && isset($oldEdges[$e->id])) ? $oldEdges[$e->id] : $e
+                (! isset($dirty['edges'][$key]) && isset($oldEdges[$key])) ? $oldEdges[$key] : $e
             );
         }
 
@@ -147,7 +155,7 @@ final class IncrementalMerge
                 $result->addNode($partialNodes[$n->id]);
             }
         }
-        // Edges are unchanged under the precondition — carry them all from $old (stable ids).
+        // Edges are unchanged under the precondition, so carry them all from $old.
         foreach ($old->edges() as $e) {
             $result->addEdge($e);
         }
@@ -156,19 +164,55 @@ final class IncrementalMerge
     }
 
     /**
-     * Edge ids owned by the given files within a graph — used by the orchestrator to verify the
-     * scoped rebuild's call graph matches the previous build (the applyPartial precondition).
+     * The call graph the given files own, as content identities — used by the orchestrator to
+     * verify a scoped rebuild matches the previous build (the applyPartial precondition).
+     *
+     * Occurrences are numbered within the owned set rather than across the whole graph, so the
+     * comparison isn't disturbed by duplicate edges elsewhere: the previous build is a full graph
+     * and the scoped one is not, and only the owned slice is being compared.
      *
      * @return array<string, true>
      */
-    public static function ownedEdgeIdSet(Graph $graph, array $files): array
+    public static function ownedEdgeKeySet(Graph $graph, array $files): array
     {
-        $set = [];
+        $owned = [];
         foreach (GraphProvenance::of($graph)->edgeIdsForFiles(...$files) as $id) {
-            $set[$id] = true;
+            $owned[$id] = true;
+        }
+
+        $set = [];
+        $seen = [];
+        foreach ($graph->edges() as $e) {
+            if (! isset($owned[$e->id])) {
+                continue;
+            }
+            $key = self::edgeKey($e);
+            $n = $seen[$key] ?? 0;
+            $seen[$key] = $n + 1;
+            $set[$key.'#'.$n] = true;
         }
 
         return $set;
+    }
+
+    /**
+     * Edge id => content identity, numbered in the same iteration order as {@see self::edgeMap()}
+     * so the two agree on which copy of a duplicated edge is which.
+     *
+     * @return array<string, string>
+     */
+    private static function edgeKeysById(Graph $graph): array
+    {
+        $out = [];
+        $seen = [];
+        foreach ($graph->edges() as $e) {
+            $key = self::edgeKey($e);
+            $n = $seen[$key] ?? 0;
+            $seen[$key] = $n + 1;
+            $out[$e->id] = $key.'#'.$n;
+        }
+
+        return $out;
     }
 
     /**
@@ -183,9 +227,11 @@ final class IncrementalMerge
         foreach ($graph->nodes() as $n) {
             $nodes[$n->id] = hash('xxh128', serialize([$n->type, $n->label, $n->data]));
         }
+        // Keyed by content identity, not by id: two builds of the same project must compare equal
+        // whether or not the id scheme numbers edges by build order.
         $edges = [];
-        foreach ($graph->edges() as $e) {
-            $edges[$e->id] = hash('xxh128', serialize([$e->source, $e->target, $e->label, $e->type]));
+        foreach (self::edgeMap($graph) as $key => $e) {
+            $edges[$key] = hash('xxh128', serialize([$e->source, $e->target, $e->label, $e->type]));
         }
         ksort($nodes);
         ksort($edges);
@@ -194,13 +240,38 @@ final class IncrementalMerge
     }
 
     /**
+     * An edge's identity for merge purposes: what the edge says, not what it is called.
+     *
+     * Deliberately derived from the edge's own fields rather than from `$e->id`. An id is only
+     * usable as an identity if it is stable across builds, and that is a property of whichever
+     * id scheme the graph happens to use — under a build-order counter, the same relationship
+     * gets a different id whenever anything upstream of it changes, and every comparison here
+     * would report the whole graph as changed. Computing identity from content keeps this layer
+     * correct under any id scheme.
+     *
+     * The graph deliberately keeps genuinely identical edges, so callers append a per-occurrence
+     * index to keep them distinct.
+     */
+    private static function edgeKey(Edge $e): string
+    {
+        return $e->source."\x1f".$e->target."\x1f".$e->type."\x1f".$e->label;
+    }
+
+    /**
+     * Edges by content identity. Identical edges are numbered in iteration order, so a graph
+     * holding N copies of one relationship yields N distinct keys in both builds.
+     *
      * @return array<string, Edge>
      */
     private static function edgeMap(Graph $graph): array
     {
         $map = [];
+        $seen = [];
         foreach ($graph->edges() as $e) {
-            $map[$e->id] = $e;
+            $key = self::edgeKey($e);
+            $n = $seen[$key] ?? 0;
+            $seen[$key] = $n + 1;
+            $map[$key.'#'.$n] = $e;
         }
 
         return $map;

--- a/src/Analysis/Incremental/IncrementalMerge.php
+++ b/src/Analysis/Incremental/IncrementalMerge.php
@@ -107,6 +107,71 @@ final class IncrementalMerge
     }
 
     /**
+     * Apply a SCOPED rebuild: fold the fresh contribution of the changed files ($partial — a graph
+     * built from only those files plus their reachable downstream) into the previous full graph,
+     * reusing every element the change didn't touch.
+     *
+     * Correctness precondition (the caller MUST enforce, falling back to a full rebuild otherwise):
+     * the set of edges owned by the changed files is IDENTICAL in $old and $partial — i.e. the edit
+     * changed node bodies but not the call graph. Under that precondition there is no edge delta and
+     * no reachability change, so the dirty set is exactly the changed files' own nodes (their
+     * flow/metrics data), and every other node and every edge is reused verbatim from $old. (Edge
+     * additions/removals and their cross-file reachability effects are the next slice; until then
+     * they take the full-rebuild path, so output is always correct.)
+     */
+    public static function applyPartial(Graph $old, Graph $partial, array $changedFiles): Graph
+    {
+        $dirtyNodes = [];
+        foreach (GraphProvenance::of($old)->nodeIdsForFiles(...$changedFiles) as $id) {
+            $dirtyNodes[$id] = true;
+        }
+        foreach (GraphProvenance::of($partial)->nodeIdsForFiles(...$changedFiles) as $id) {
+            $dirtyNodes[$id] = true;
+        }
+
+        $partialNodes = [];
+        foreach ($partial->nodes() as $n) {
+            $partialNodes[$n->id] = $n;
+        }
+
+        $result = new Graph;
+        // Reused, untouched nodes from the previous build...
+        foreach ($old->nodes() as $n) {
+            if (! isset($dirtyNodes[$n->id])) {
+                $result->addNode($n);
+            }
+        }
+        // ...and the changed files' own nodes, freshly rebuilt.
+        foreach ($old->nodes() as $n) {
+            if (isset($dirtyNodes[$n->id]) && isset($partialNodes[$n->id])) {
+                $result->addNode($partialNodes[$n->id]);
+            }
+        }
+        // Edges are unchanged under the precondition — carry them all from $old (stable ids).
+        foreach ($old->edges() as $e) {
+            $result->addEdge($e);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Edge ids owned by the given files within a graph — used by the orchestrator to verify the
+     * scoped rebuild's call graph matches the previous build (the applyPartial precondition).
+     *
+     * @return array<string, true>
+     */
+    public static function ownedEdgeIdSet(Graph $graph, array $files): array
+    {
+        $set = [];
+        foreach (GraphProvenance::of($graph)->edgeIdsForFiles(...$files) as $id) {
+            $set[$id] = true;
+        }
+
+        return $set;
+    }
+
+    /**
      * Content signature of a graph's elements, independent of build metadata (analyzedAt etc.) and
      * insertion order — for asserting two graphs are behaviourally identical.
      *

--- a/src/Analysis/Incremental/ScopedRebuildNotApplicable.php
+++ b/src/Analysis/Incremental/ScopedRebuildNotApplicable.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaraMint\LaravelBrain\Analysis\Incremental;
+
+/**
+ * Thrown when a scoped rebuild cannot stand in for a full one after all.
+ *
+ * A scoped run reuses every edge from the previous graph, which only holds while the changed
+ * files' own call graph is intact — an edit that adds or removes a call has to be rebuilt in
+ * full. That is not knowable until the scoped build has run and can be compared, so it surfaces
+ * as an exception rather than a return value: a partial graph must never be mistaken for a
+ * whole one by a caller that forgot to check a flag.
+ */
+final class ScopedRebuildNotApplicable extends \RuntimeException
+{
+    public function __construct(string $reason = 'the changed files\' call graph moved')
+    {
+        parent::__construct('Scoped rebuild not applicable: '.$reason.'. Run a full analysis.');
+    }
+}

--- a/src/Analysis/ProjectAnalyzer.php
+++ b/src/Analysis/ProjectAnalyzer.php
@@ -147,8 +147,9 @@ class ProjectAnalyzer
      * every controller in the project, which is nearly all of the rest.
      *
      * The caller owns the decision to use this: it is only sound when no file was added or
-     * deleted and nothing outside `app/` moved, which is what {@see IncrementalAnalyzer}
-     * checks before it calls.
+     * deleted and nothing outside `app/` moved. Whether the changed files' own call graph
+     * survived the edit is not knowable up front, so that part is checked here and raises
+     * {@see ScopedRebuildNotApplicable} when it does not hold.
      *
      * @param  string[]  $changedFiles
      */
@@ -177,6 +178,13 @@ class ProjectAnalyzer
 
         $this->emit('project:start', ['name' => $projectName, 'message' => "Analyzing project: {$projectName}"]);
 
+        // Consumed for this run only: leaving it set would silently scope the next analyze() on
+        // a reused instance, and merge it into a graph that has since gone stale.
+        $scopeToFiles = $this->scopeToFiles;
+        $mergeInto = $this->mergeInto;
+        $this->scopeToFiles = null;
+        $this->mergeInto = null;
+
         $this->emit('step:start', ['step' => 'routes', 'label' => 'Scanning routes', 'message' => '  → Scanning routes...']);
         $routes = $this->routeAnalyzer->analyze($projectRoot);
         $this->emit('step:done', ['step' => 'routes', 'count' => count($routes), 'unit' => 'route', 'message' => '    Found '.count($routes).' route(s)']);
@@ -189,8 +197,8 @@ class ProjectAnalyzer
         $controllers = $this->controllerAnalyzer->analyze($projectRoot, $routes);
 
         // A scoped run traces only the controllers declared in the changed files.
-        if ($this->scopeToFiles !== null) {
-            $wanted = array_flip(array_map(static fn (string $f): string => realpath($f) ?: $f, $this->scopeToFiles));
+        if ($scopeToFiles !== null) {
+            $wanted = array_flip(array_map(static fn (string $f): string => realpath($f) ?: $f, $scopeToFiles));
             $controllers = array_filter(
                 $controllers,
                 static fn (ControllerDefinition $c): bool => isset($wanted[realpath($c->file) ?: $c->file]),
@@ -373,13 +381,13 @@ class ProjectAnalyzer
         // files' own call graph is intact. Comparing the owned edges before and after is what
         // establishes it, and a mismatch means the edit moved a call — nothing here can stand in
         // for a full run then.
-        if ($this->mergeInto !== null && $this->scopeToFiles !== null) {
-            if (IncrementalMerge::ownedEdgeKeySet($this->mergeInto, $this->scopeToFiles)
-                != IncrementalMerge::ownedEdgeKeySet($fullGraph, $this->scopeToFiles)) {
+        if ($mergeInto !== null && $scopeToFiles !== null) {
+            if (IncrementalMerge::ownedEdgeKeySet($mergeInto, $scopeToFiles)
+                != IncrementalMerge::ownedEdgeKeySet($fullGraph, $scopeToFiles)) {
                 throw new ScopedRebuildNotApplicable;
             }
 
-            $fullGraph = IncrementalMerge::applyPartial($this->mergeInto, $fullGraph, $this->scopeToFiles);
+            $fullGraph = IncrementalMerge::applyPartial($mergeInto, $fullGraph, $scopeToFiles);
         }
 
         $this->emit('step:done', ['step' => 'graph', 'count' => $fullGraph->nodeCount(), 'unit' => 'node', 'extra' => $fullGraph->edgeCount().' edges', 'message' => "    {$fullGraph->nodeCount()} nodes, {$fullGraph->edgeCount()} edges"]);

--- a/src/Analysis/ProjectAnalyzer.php
+++ b/src/Analysis/ProjectAnalyzer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace LaraMint\LaravelBrain\Analysis;
 
+use LaraMint\LaravelBrain\Analysis\Incremental\IncrementalMerge;
+use LaraMint\LaravelBrain\Analysis\Incremental\ScopedRebuildNotApplicable;
 use LaraMint\LaravelBrain\Graph\Graph;
 use LaraMint\LaravelBrain\Graph\GraphBuilder;
 use LaraMint\LaravelBrain\Graph\GraphSplitter;
@@ -130,6 +132,34 @@ class ProjectAnalyzer
         };
     }
 
+    /** @var string[]|null files to scope tracing to; null means trace everything */
+    private ?array $scopeToFiles = null;
+
+    /** Graph from the previous full run, which a scoped run merges its result into. */
+    private ?Graph $mergeInto = null;
+
+    /**
+     * Trace only the controllers declared in these files, and merge the result into the graph
+     * a previous full run produced.
+     *
+     * Everything else on the pass still runs in full — routes, commands, channels, the split —
+     * because those are a couple of percent of a scan between them. What it skips is tracing
+     * every controller in the project, which is nearly all of the rest.
+     *
+     * The caller owns the decision to use this: it is only sound when no file was added or
+     * deleted and nothing outside `app/` moved, which is what {@see IncrementalAnalyzer}
+     * checks before it calls.
+     *
+     * @param  string[]  $changedFiles
+     */
+    public function scopedTo(array $changedFiles, Graph $previous): static
+    {
+        $this->scopeToFiles = $changedFiles;
+        $this->mergeInto = $previous;
+
+        return $this;
+    }
+
     public function analyze(string $projectRoot, ?callable $onProgress = null): AnalysisResult
     {
         if ($onProgress !== null) {
@@ -157,6 +187,15 @@ class ProjectAnalyzer
 
         $this->emit('step:start', ['step' => 'controllers', 'label' => 'Analyzing controllers', 'message' => '  → Analyzing controllers...']);
         $controllers = $this->controllerAnalyzer->analyze($projectRoot, $routes);
+
+        // A scoped run traces only the controllers declared in the changed files.
+        if ($this->scopeToFiles !== null) {
+            $wanted = array_flip(array_map(static fn (string $f): string => realpath($f) ?: $f, $this->scopeToFiles));
+            $controllers = array_filter(
+                $controllers,
+                static fn (ControllerDefinition $c): bool => isset($wanted[realpath($c->file) ?: $c->file]),
+            );
+        }
         $this->emit('step:done', ['step' => 'controllers', 'count' => count($controllers), 'unit' => 'controller', 'message' => '    Found '.count($controllers).' controller(s)']);
 
         $this->emit('step:start', ['step' => 'lifecycle', 'label' => 'Tracing full lifecycle', 'message' => '  → Tracing full lifecycle (deep)...']);
@@ -196,6 +235,7 @@ class ProjectAnalyzer
             }
         }
         $modelFqcns = array_unique(array_merge($modelFqcns, $this->modelAnalyzer->discoverModels($projectRoot)));
+
         $models = $this->modelAnalyzer->analyze($projectRoot, $modelFqcns);
         $this->emit('step:done', ['step' => 'models', 'count' => count($models), 'unit' => 'model', 'message' => '    Found '.count($models).' model(s)']);
 
@@ -326,12 +366,35 @@ class ProjectAnalyzer
         $this->graphBuilder->addViewComposition($viewComposition);
         $this->emit('step:done', ['step' => 'views', 'count' => count($viewComposition), 'unit' => 'composed view', 'message' => '    Mapped '.count($viewComposition).' composing view(s)']);
 
+        // A scoped run has built only the changed files' share of the graph; the rest of it comes
+        // from the previous full run, with those files' nodes substituted in place.
+        //
+        // That reuses every edge from the previous graph, which is only sound while the changed
+        // files' own call graph is intact. Comparing the owned edges before and after is what
+        // establishes it, and a mismatch means the edit moved a call — nothing here can stand in
+        // for a full run then.
+        if ($this->mergeInto !== null && $this->scopeToFiles !== null) {
+            if (IncrementalMerge::ownedEdgeKeySet($this->mergeInto, $this->scopeToFiles)
+                != IncrementalMerge::ownedEdgeKeySet($fullGraph, $this->scopeToFiles)) {
+                throw new ScopedRebuildNotApplicable;
+            }
+
+            $fullGraph = IncrementalMerge::applyPartial($this->mergeInto, $fullGraph, $this->scopeToFiles);
+        }
+
         $this->emit('step:done', ['step' => 'graph', 'count' => $fullGraph->nodeCount(), 'unit' => 'node', 'extra' => $fullGraph->edgeCount().' edges', 'message' => "    {$fullGraph->nodeCount()} nodes, {$fullGraph->edgeCount()} edges"]);
 
         $this->emit('step:start', ['step' => 'split', 'label' => 'Splitting into tab subgraphs', 'message' => '  → Splitting into tab subgraphs...']);
         $split = $this->graphSplitter->split($fullGraph, $routes, $commands, $channels, $schedules, $projectName, $analyzedAt, $filamentResult['panels'], $filamentResult['resources'], $filamentResult['pages']);
 
-        $erd = $this->graphSplitter->buildErdTab($models, $projectName, $analyzedAt);
+        // Ordered by name, because $models arrives led by whatever the call chain reached first
+        // and the ERD is laid out in that order. Left as traced, the diagram reshuffles whenever
+        // an unrelated controller changes which model it happens to touch first — and a scoped
+        // rescan, tracing fewer controllers, would reorder it on every tick.
+        $erdModels = $models;
+        ksort($erdModels);
+
+        $erd = $this->graphSplitter->buildErdTab($erdModels, $projectName, $analyzedAt);
         if ($erd !== null) {
             $split['subgraphs'][$erd['id']] = $erd['graph'];
             $split['manifest'][] = $erd['manifest'];

--- a/src/Commands/ScanCommand.php
+++ b/src/Commands/ScanCommand.php
@@ -66,7 +66,7 @@ class ScanCommand extends Command
                 $this->newLine();
                 $this->line('  <fg=yellow>⚡ Changed:</> '.$this->summariseChanged($changed));
 
-                $scope = $this->scopeForRescan($mtimes, $current);
+                $scope = $this->scopeForRescan($projectPath, $mtimes, $current);
                 $started = microtime(true);
                 try {
                     $this->runScan($projectPath, verbose: false, scopeToFiles: $scope);
@@ -122,7 +122,7 @@ class ScanCommand extends Command
      * @param  array<string, int>  $new
      * @return string[]|null
      */
-    private function scopeForRescan(array $old, array $new): ?array
+    private function scopeForRescan(string $projectPath, array $old, array $new): ?array
     {
         if (count($old) !== count($new) || array_diff_key($old, $new) !== [] || array_diff_key($new, $old) !== []) {
             return null;
@@ -133,7 +133,10 @@ class ScanCommand extends Command
             if ($old[$path] === $mtime) {
                 continue;
             }
-            if (! str_contains($path, '/app/')) {
+            // Anchored at the project root: a substring test calls every file "in app/" when
+            // the project itself lives under a directory of that name, which would let a routes
+            // change take the scoped path and leave watch showing the previous graph.
+            if (! str_starts_with($path, rtrim($projectPath, '/').'/app/')) {
                 return null;
             }
             $modified[] = $path;

--- a/src/Commands/ScanCommand.php
+++ b/src/Commands/ScanCommand.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace LaraMint\LaravelBrain\Commands;
 
 use Illuminate\Console\Command;
+use LaraMint\LaravelBrain\Analysis\Incremental\ScopedRebuildNotApplicable;
 use LaraMint\LaravelBrain\Analysis\ProjectAnalyzer;
+use LaraMint\LaravelBrain\Graph\Graph;
 use LaraMint\LaravelBrain\Storage\GraphStoreFactory;
 
 class ScanCommand extends Command
@@ -63,7 +65,19 @@ class ScanCommand extends Command
             if (! empty($changed)) {
                 $this->newLine();
                 $this->line('  <fg=yellow>⚡ Changed:</> '.$this->summariseChanged($changed));
-                $this->runScan($projectPath, verbose: false);
+
+                $scope = $this->scopeForRescan($mtimes, $current);
+                $started = microtime(true);
+                try {
+                    $this->runScan($projectPath, verbose: false, scopeToFiles: $scope);
+                    $mode = $scope === null ? 'full' : 'scoped';
+                } catch (ScopedRebuildNotApplicable) {
+                    // The edit moved a call, so the previous graph's edges no longer hold.
+                    $this->runScan($projectPath, verbose: false);
+                    $mode = 'full (the change moved a call)';
+                }
+                $this->line(sprintf('  <fg=gray>%s rescan in %dms</>', $mode, (int) ((microtime(true) - $started) * 1000)));
+
                 $mtimes = $current;
             }
         }
@@ -94,6 +108,38 @@ class ScanCommand extends Command
         }
 
         return $mtimes;
+    }
+
+    /**
+     * The files a scoped rescan may be limited to, or null when only a full one will do.
+     *
+     * A scoped rescan reuses the previous graph's edges wholesale, so it holds only while the
+     * shape of the project is unchanged: a file appearing or disappearing can move the route
+     * table or reachability, and anything outside `app/` — routes, config — can rewrite the
+     * graph from the top. Those cases are not worth reasoning about incrementally.
+     *
+     * @param  array<string, int>  $old
+     * @param  array<string, int>  $new
+     * @return string[]|null
+     */
+    private function scopeForRescan(array $old, array $new): ?array
+    {
+        if (count($old) !== count($new) || array_diff_key($old, $new) !== [] || array_diff_key($new, $old) !== []) {
+            return null;
+        }
+
+        $modified = [];
+        foreach ($new as $path => $mtime) {
+            if ($old[$path] === $mtime) {
+                continue;
+            }
+            if (! str_contains($path, '/app/')) {
+                return null;
+            }
+            $modified[] = $path;
+        }
+
+        return $modified === [] ? null : $modified;
     }
 
     private function detectChanges(array $old, array $new): array
@@ -172,7 +218,14 @@ class ScanCommand extends Command
 
     // ── Shared scan logic ─────────────────────────────────────────────────────
 
-    private function runScan(string $projectPath, bool $verbose): int
+    /** Graph from the last completed scan, reused by a scoped rescan in watch mode. */
+    private ?Graph $lastGraph = null;
+
+    /**
+     * @param  string[]|null  $scopeToFiles  trace only these files' controllers and merge into
+     *                                       the previous graph; null runs a full analysis
+     */
+    private function runScan(string $projectPath, bool $verbose, ?array $scopeToFiles = null): int
     {
         $totalStart = microtime(true);
 
@@ -188,10 +241,15 @@ class ScanCommand extends Command
         }
 
         $analyzer = new ProjectAnalyzer;
+        if ($scopeToFiles !== null && $this->lastGraph !== null) {
+            $analyzer->scopedTo($scopeToFiles, $this->lastGraph);
+        }
 
         $result = $analyzer->analyze($projectPath, function (string $event, array $data) use ($verbose): void {
             $this->handleProgress($event, $data, $verbose);
         });
+
+        $this->lastGraph = $result->fullGraph;
 
         $store = GraphStoreFactory::make();
         $store->ensureSchema();

--- a/tests/Unit/BuildFingerprintTest.php
+++ b/tests/Unit/BuildFingerprintTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use LaraMint\LaravelBrain\Analysis\Incremental\BuildFingerprint;
+
+function tmpProject(): string
+{
+    $dir = sys_get_temp_dir().'/brain-fp-'.bin2hex(random_bytes(6));
+    mkdir($dir.'/app', 0o755, true);
+
+    return $dir;
+}
+
+it('captures content hashes for php files under the roots', function () {
+    $root = tmpProject();
+    file_put_contents($root.'/app/A.php', "<?php\nclass A {}\n");
+    file_put_contents($root.'/app/notes.txt', 'ignored');
+
+    $fp = BuildFingerprint::capture($root);
+
+    expect($fp->files)->toHaveKey($root.'/app/A.php');
+    expect($fp->files)->not->toHaveKey($root.'/app/notes.txt'); // non-php ignored
+});
+
+it('detects added, modified and deleted files by content (not mtime)', function () {
+    $root = tmpProject();
+    file_put_contents($root.'/app/A.php', "<?php\nclass A {}\n");
+    file_put_contents($root.'/app/B.php', "<?php\nclass B {}\n");
+    $before = BuildFingerprint::capture($root);
+
+    // Modify A's CONTENT while pinning mtime — mtime-keyed detection would miss this.
+    $mtime = filemtime($root.'/app/A.php');
+    file_put_contents($root.'/app/A.php', "<?php\nclass A { public function x() {} }\n");
+    touch($root.'/app/A.php', $mtime);
+    // Add C, delete B.
+    file_put_contents($root.'/app/C.php', "<?php\nclass C {}\n");
+    unlink($root.'/app/B.php');
+
+    $after = BuildFingerprint::capture($root);
+    $diff = $after->diff($before);
+
+    expect($diff['modified'])->toContain($root.'/app/A.php');
+    expect($diff['added'])->toContain($root.'/app/C.php');
+    expect($diff['deleted'])->toContain($root.'/app/B.php');
+    expect($after->equals($before))->toBeFalse();
+});
+
+it('reports no changes for an identical tree', function () {
+    $root = tmpProject();
+    file_put_contents($root.'/app/A.php', "<?php\nclass A {}\n");
+
+    $a = BuildFingerprint::capture($root);
+    $b = BuildFingerprint::capture($root);
+
+    expect($a->equals($b))->toBeTrue();
+    expect($a->diff($b))->toBe(['added' => [], 'modified' => [], 'deleted' => []]);
+});

--- a/tests/Unit/GraphProvenanceTest.php
+++ b/tests/Unit/GraphProvenanceTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use LaraMint\LaravelBrain\Analysis\ControllerAnalyzer;
+use LaraMint\LaravelBrain\Analysis\Incremental\GraphProvenance;
+use LaraMint\LaravelBrain\Analysis\MethodTracer;
+use LaraMint\LaravelBrain\Analysis\MiddlewareRegistry;
+use LaraMint\LaravelBrain\Analysis\ModelAnalyzer;
+use LaraMint\LaravelBrain\Analysis\RouteAnalyzer;
+use LaraMint\LaravelBrain\Graph\Graph;
+use LaraMint\LaravelBrain\Graph\GraphBuilder;
+
+function buildFixtureGraph(): Graph
+{
+    $routes = (new RouteAnalyzer)->analyze(fixture('laravel-project'));
+    $middlewareRegistry = new MiddlewareRegistry([], [], []);
+    $controllers = (new ControllerAnalyzer)->analyze(fixture('laravel-project'), $routes);
+    $traces = (new MethodTracer)->trace($controllers);
+    $modelFqcns = array_map(fn ($t) => $t->calleeFqcn, array_filter($traces, fn ($t) => $t->type === 'model'));
+    $models = (new ModelAnalyzer)->analyze(fixture('laravel-project'), $modelFqcns);
+
+    return (new GraphBuilder)->build('test', $routes, $middlewareRegistry, $controllers, $traces, $models);
+}
+
+it('partitions every node and edge into exactly one owning file (lossless round-trip)', function () {
+    $graph = buildFixtureGraph();
+    $prov = GraphProvenance::of($graph);
+
+    $allNodeIds = array_map(fn ($n) => $n->id, $graph->nodes());
+    $allEdgeIds = array_map(fn ($e) => $e->id, $graph->edges());
+
+    // Every element is assigned to exactly one file, and the partition covers the whole graph.
+    expect(count($prov->nodeFile))->toBe(count($allNodeIds));
+    expect(count($prov->edgeFile))->toBe(count($allEdgeIds));
+
+    $partitionNodeIds = [];
+    $partitionEdgeIds = [];
+    foreach ($prov->byFile as $bucket) {
+        $partitionNodeIds = array_merge($partitionNodeIds, $bucket['nodes'] ?? []);
+        $partitionEdgeIds = array_merge($partitionEdgeIds, $bucket['edges'] ?? []);
+    }
+
+    sort($allNodeIds);
+    sort($allEdgeIds);
+    sort($partitionNodeIds);
+    sort($partitionEdgeIds);
+
+    expect($partitionNodeIds)->toBe($allNodeIds);   // no element lost or duplicated
+    expect($partitionEdgeIds)->toBe($allEdgeIds);
+});
+
+it('resolves the elements owned by a specific file', function () {
+    $graph = buildFixtureGraph();
+    $prov = GraphProvenance::of($graph);
+
+    // A file that actually owns nodes should return a non-empty, in-graph set.
+    $ownedFiles = array_values(array_filter(array_keys($prov->byFile), fn ($f) => $f !== ''));
+    expect($ownedFiles)->not->toBeEmpty();
+
+    $someFile = $ownedFiles[0];
+    $nodeIds = $prov->nodeIdsForFiles($someFile);
+    expect($nodeIds)->not->toBeEmpty();
+    foreach ($nodeIds as $id) {
+        expect($graph->hasNode($id))->toBeTrue();
+        expect($prov->nodeFile[$id])->toBe($someFile);
+    }
+});

--- a/tests/Unit/GraphSplitterTest.php
+++ b/tests/Unit/GraphSplitterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use LaraMint\LaravelBrain\Analysis\ModelAnalyzer;
+use LaraMint\LaravelBrain\Analysis\ModelDefinition;
 use LaraMint\LaravelBrain\Analysis\RouteAnalyzer;
 use LaraMint\LaravelBrain\Analysis\RouteDefinition;
 use LaraMint\LaravelBrain\Graph\Edge;
@@ -10,6 +12,8 @@ use LaraMint\LaravelBrain\Graph\Node;
 // RouteDefinition is declared alongside RouteAnalyzer in RouteAnalyzer.php;
 // reference RouteAnalyzer so PSR-4 autoloading pulls in that file.
 class_exists(RouteAnalyzer::class);
+// ModelDefinition likewise lives in ModelAnalyzer.php.
+class_exists(ModelAnalyzer::class);
 
 function splitterRouteNode(string $method, string $uri, ?array $security = null): Node
 {
@@ -177,4 +181,22 @@ it('emits a subgraph in the full graph\'s node and edge order', function () {
     expect($subOrder)->toBe(array_values(array_filter($fullOrder, fn ($id) => in_array($id, $subOrder, true))))
         ->and($subOrder)->not->toContain('action::App\Http\Controllers\OtherController::index')
         ->and(array_map(fn ($e) => $e->id, $sub->edges()))->toBe(['e0', 'e1', 'e2']);
+});
+
+it('lays the ERD out in the order the models are given', function () {
+    // Pins why ProjectAnalyzer sorts before calling this: the tab is built in iteration order,
+    // so an unsorted list makes the diagram reshuffle whenever tracing reaches models in a
+    // different order — which a scoped rescan, tracing fewer controllers, does every time.
+    $model = fn (string $fqcn) => new ModelDefinition($fqcn, '/tmp/'.$fqcn.'.php', [], []);
+
+    $ordered = ['App\Models\Alpha' => $model('App\Models\Alpha'), 'App\Models\Beta' => $model('App\Models\Beta')];
+    $reversed = array_reverse($ordered, preserve_keys: true);
+
+    $ids = function (array $models): array {
+        $tab = (new GraphSplitter)->buildErdTab($models, 'proj', '2026-01-01T00:00:00Z');
+
+        return array_map(fn ($n) => $n->id, $tab['graph']->nodes());
+    };
+
+    expect($ids($ordered))->not->toBe($ids($reversed));
 });

--- a/tests/Unit/IncrementalAnalyzerTest.php
+++ b/tests/Unit/IncrementalAnalyzerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+use LaraMint\LaravelBrain\Analysis\ControllerAnalyzer;
+use LaraMint\LaravelBrain\Analysis\Incremental\IncrementalAnalyzer;
+use LaraMint\LaravelBrain\Analysis\Incremental\IncrementalMerge;
+use LaraMint\LaravelBrain\Analysis\MethodTracer;
+use LaraMint\LaravelBrain\Analysis\MiddlewareRegistry;
+use LaraMint\LaravelBrain\Analysis\ModelAnalyzer;
+use LaraMint\LaravelBrain\Analysis\RouteAnalyzer;
+use LaraMint\LaravelBrain\Graph\Graph;
+use LaraMint\LaravelBrain\Graph\GraphBuilder;
+use LaraMint\LaravelBrain\Parser\PhpFileParser;
+
+/** Two-controller project so a one-file change makes scoped != full. $aBody is ControllerA::index's body. */
+function ia_writeProject(string $dir, string $aBody): void
+{
+    foreach (['/app/Http/Controllers', '/app/Services', '/app/Jobs', '/routes', '/vendor/composer'] as $s) {
+        is_dir($dir.$s) || mkdir($dir.$s, 0o755, true);
+    }
+    file_put_contents($dir.'/composer.json', '{"autoload":{"psr-4":{"App\\\\":"app/"}}}');
+    file_put_contents($dir.'/vendor/composer/autoload_psr4.php', "<?php\n\nreturn array('App\\\\' => array(\$baseDir . '/app'));\n");
+    file_put_contents($dir.'/routes/api.php', "<?php\n\nuse Illuminate\\Support\\Facades\\Route;\n\nRoute::get('/a', [\\App\\Http\\Controllers\\ControllerA::class, 'index']);\nRoute::get('/b', [\\App\\Http\\Controllers\\ControllerB::class, 'index']);\n");
+    file_put_contents($dir.'/app/Services/DemoService.php', "<?php\n\nnamespace App\\Services;\n\nclass DemoService\n{\n    public function run(): void {}\n}\n");
+    file_put_contents($dir.'/app/Jobs/DemoJob.php', "<?php\n\nnamespace App\\Jobs;\n\nclass DemoJob\n{\n    public function handle(): void {}\n}\n");
+    file_put_contents($dir.'/app/Http/Controllers/ControllerB.php', "<?php\n\nnamespace App\\Http\\Controllers;\n\nuse App\\Services\\DemoService;\n\nclass ControllerB\n{\n    public function __construct(private DemoService \$svc) {}\n\n    public function index()\n    {\n        \$this->svc->run();\n    }\n}\n");
+    file_put_contents($dir.'/app/Http/Controllers/ControllerA.php', "<?php\n\nnamespace App\\Http\\Controllers;\n\nuse App\\Services\\DemoService;\n\nclass ControllerA\n{\n    public function __construct(private DemoService \$svc) {}\n\n    public function index()\n    {\n$aBody\n    }\n}\n");
+}
+
+/** @param string[] $onlyControllerFiles  if non-empty, restrict routes to controllers in these files */
+function ia_build(string $dir, array $onlyControllerFiles = []): Graph
+{
+    PhpFileParser::clearSharedCache();
+    $routes = (new RouteAnalyzer(['routes/*.php']))->analyze($dir);
+    if ($onlyControllerFiles !== []) {
+        $want = array_map(fn ($f) => basename($f, '.php'), $onlyControllerFiles);
+        $routes = array_values(array_filter($routes, function ($r) use ($want) {
+            $short = str_contains((string) $r->controller, '\\') ? substr((string) $r->controller, strrpos((string) $r->controller, '\\') + 1) : (string) $r->controller;
+
+            return in_array($short, $want, true);
+        }));
+    }
+    $controllers = (new ControllerAnalyzer)->analyze($dir, $routes);
+    $traces = (new MethodTracer)->trace($controllers, ['App' => [$dir.'/app']], $dir);
+    $modelFqcns = array_map(fn ($t) => $t->calleeFqcn, array_filter($traces, fn ($t) => $t->type === 'model'));
+    $models = (new ModelAnalyzer)->analyze($dir, $modelFqcns);
+
+    return (new GraphBuilder)->build('t', $routes, new MiddlewareRegistry([], [], []), $controllers, $traces, $models, $dir);
+}
+
+function ia_analyzer(): IncrementalAnalyzer
+{
+    return new IncrementalAnalyzer(
+        fn (string $root) => ia_build($root),
+        fn (string $root, array $changed) => ia_build($root, $changed),
+    );
+}
+
+function ia_rmrf(string $dir): void
+{
+    if (! is_dir($dir)) {
+        return;
+    }
+    foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS), RecursiveIteratorIterator::CHILD_FIRST) as $f) {
+        $f->isDir() ? rmdir($f->getPathname()) : unlink($f->getPathname());
+    }
+    rmdir($dir);
+}
+
+it('does a full build first, then an incremental body-edit rebuild identical to a full rebuild', function () {
+    $dir = sys_get_temp_dir().'/brain-ia-'.bin2hex(random_bytes(6));
+    $aFile = $dir.'/app/Http/Controllers/ControllerA.php';
+    $ia = ia_analyzer();
+
+    ia_writeProject($dir, '        $this->svc->run();');
+    $first = $ia->analyze($dir);
+    expect($first['mode'])->toBe('full');
+
+    usleep(1_100_000); // let mtime settle past the current second (unsettled-file guard)
+
+    // Body-only edit to ControllerA: same calls, extra local work -> action node data changes, call graph intact.
+    ia_writeProject($dir, "        \$x = 41 + 1;\n        \$this->svc->run();");
+    $inc = $ia->analyze($dir);
+
+    expect($inc['mode'])->toBe('incremental');
+    expect(IncrementalMerge::signature($inc['graph']))->toEqual(IncrementalMerge::signature(ia_build($dir)));
+
+    ia_rmrf($dir);
+});
+
+it('falls back to a full rebuild when the call graph changes, still identical to full', function () {
+    $dir = sys_get_temp_dir().'/brain-ia-'.bin2hex(random_bytes(6));
+    $ia = ia_analyzer();
+
+    ia_writeProject($dir, '        $this->svc->run();');
+    $ia->analyze($dir);
+
+    usleep(1_100_000);
+
+    // Structural edit: add a cross-file job dispatch -> new edge -> must NOT take the fast path.
+    ia_writeProject($dir, "        \$this->svc->run();\n        \\App\\Jobs\\DemoJob::dispatch();");
+    $out = $ia->analyze($dir);
+
+    expect($out['mode'])->toBe('full');
+    expect(IncrementalMerge::signature($out['graph']))->toEqual(IncrementalMerge::signature(ia_build($dir)));
+
+    ia_rmrf($dir);
+});
+
+it('reports unchanged when nothing changed', function () {
+    $dir = sys_get_temp_dir().'/brain-ia-'.bin2hex(random_bytes(6));
+    $ia = ia_analyzer();
+
+    ia_writeProject($dir, '        $this->svc->run();');
+    $ia->analyze($dir);
+    usleep(1_100_000);
+    $again = $ia->analyze($dir);
+
+    expect($again['mode'])->toBe('unchanged');
+
+    ia_rmrf($dir);
+});

--- a/tests/Unit/IncrementalMergeTest.php
+++ b/tests/Unit/IncrementalMergeTest.php
@@ -111,3 +111,26 @@ it('reconstructs correctly for a method-body edit that changes only the caller n
 
     rmrfDir($dir);
 });
+
+it('keeps the node order a full rebuild would produce, not just the same nodes', function () {
+    // signature() normalises order, so it cannot see this: applyPartial used to add the
+    // untouched nodes first and the rebuilt ones afterwards, which moved every rebuilt node to
+    // the end. The graph held the right nodes in the wrong sequence, and anything diffing or
+    // caching the output saw churn on every incremental tick.
+    $dir = sys_get_temp_dir().'/brain-merge-'.bin2hex(random_bytes(6));
+    $controllerFile = $dir.'/app/Http/Controllers/DemoController.php';
+
+    writeMergeProject($dir, '        $this->svc->run();');
+    $old = buildMergeGraph($dir);
+
+    writeMergeProject($dir, "        \$x = 1 + 1;\n        \$this->svc->run();");
+    $rebuilt = buildMergeGraph($dir);
+
+    $merged = IncrementalMerge::applyPartial($old, $rebuilt, [$controllerFile]);
+
+    $ids = fn ($graph) => array_map(fn ($n) => $n->id, $graph->nodes());
+
+    expect($ids($merged))->toBe($ids($rebuilt));
+
+    rmrfDir($dir);
+});

--- a/tests/Unit/IncrementalMergeTest.php
+++ b/tests/Unit/IncrementalMergeTest.php
@@ -1,0 +1,113 @@
+<?php
+
+use LaraMint\LaravelBrain\Analysis\ControllerAnalyzer;
+use LaraMint\LaravelBrain\Analysis\Incremental\IncrementalMerge;
+use LaraMint\LaravelBrain\Analysis\MethodTracer;
+use LaraMint\LaravelBrain\Analysis\MiddlewareRegistry;
+use LaraMint\LaravelBrain\Analysis\ModelAnalyzer;
+use LaraMint\LaravelBrain\Analysis\RouteAnalyzer;
+use LaraMint\LaravelBrain\Graph\Graph;
+use LaraMint\LaravelBrain\Graph\GraphBuilder;
+use LaraMint\LaravelBrain\Parser\PhpFileParser;
+
+/** Write a minimal but real Laravel-shaped project (with the vendor psr4 map GraphBuilder needs). */
+function writeMergeProject(string $dir, string $controllerIndexBody): void
+{
+    foreach (['/app/Http/Controllers', '/app/Services', '/app/Jobs', '/routes', '/vendor/composer'] as $sub) {
+        is_dir($dir.$sub) || mkdir($dir.$sub, 0o755, true);
+    }
+
+    file_put_contents($dir.'/composer.json', '{"autoload":{"psr-4":{"App\\\\":"app/"}}}');
+    file_put_contents($dir.'/vendor/composer/autoload_psr4.php', "<?php\n\nreturn array('App\\\\' => array(\$baseDir . '/app'));\n");
+    file_put_contents($dir.'/routes/api.php', "<?php\n\nuse Illuminate\\Support\\Facades\\Route;\n\nRoute::get('/demo', [\\App\\Http\\Controllers\\DemoController::class, 'index']);\n");
+    file_put_contents($dir.'/app/Services/DemoService.php', "<?php\n\nnamespace App\\Services;\n\nclass DemoService\n{\n    public function run(): void {}\n}\n");
+    file_put_contents($dir.'/app/Jobs/DemoJob.php', "<?php\n\nnamespace App\\Jobs;\n\nclass DemoJob\n{\n    public function handle(): void {}\n}\n");
+    file_put_contents($dir.'/app/Http/Controllers/DemoController.php', <<<PHP
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\DemoService;
+
+class DemoController
+{
+    public function __construct(private DemoService \$svc) {}
+
+    public function index()
+    {
+$controllerIndexBody
+    }
+}
+PHP);
+}
+
+function buildMergeGraph(string $dir): Graph
+{
+    PhpFileParser::clearSharedCache();
+    $routes = (new RouteAnalyzer(['routes/*.php']))->analyze($dir);
+    $controllers = (new ControllerAnalyzer)->analyze($dir, $routes);
+    $traces = (new MethodTracer)->trace($controllers, $controllers === [] ? [] : ['App' => [$dir.'/app']], $dir);
+    $modelFqcns = array_map(fn ($t) => $t->calleeFqcn, array_filter($traces, fn ($t) => $t->type === 'model'));
+    $models = (new ModelAnalyzer)->analyze($dir, $modelFqcns);
+
+    return (new GraphBuilder)->build('test', $routes, new MiddlewareRegistry([], [], []), $controllers, $traces, $models, $dir);
+}
+
+function rmrfDir(string $dir): void
+{
+    if (! is_dir($dir)) {
+        return;
+    }
+    $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS), RecursiveIteratorIterator::CHILD_FIRST);
+    foreach ($it as $f) {
+        $f->isDir() ? rmdir($f->getPathname()) : unlink($f->getPathname());
+    }
+    rmdir($dir);
+}
+
+it('reconstructs a full rebuild from cached graph + one changed file — incl. a cross-file job dispatch (the escaping case)', function () {
+    $dir = sys_get_temp_dir().'/brain-merge-'.bin2hex(random_bytes(6));
+    $controllerFile = $dir.'/app/Http/Controllers/DemoController.php';
+
+    // OLD: index() only calls the injected service.
+    writeMergeProject($dir, '        $this->svc->run();');
+    $old = buildMergeGraph($dir);
+
+    // EDIT: add a cross-file job dispatch — creates a controller->job edge whose TARGET node
+    // (DemoJob::handle) is owned by app/Jobs/DemoJob.php, NOT the edited controller file.
+    writeMergeProject($dir, "        \$this->svc->run();\n        \\App\\Jobs\\DemoJob::dispatch();");
+    $new = buildMergeGraph($dir);
+
+    // Sanity: the edit actually grew the graph (new job node + edge exist), else the test is vacuous.
+    expect($new->nodeCount())->toBeGreaterThan($old->nodeCount());
+
+    $merged = IncrementalMerge::reconstruct($old, $new, [$controllerFile]);
+
+    // The reconstructed graph is byte-identical (element-wise) to a full rebuild.
+    expect(IncrementalMerge::signature($merged))->toEqual(IncrementalMerge::signature($new));
+
+    // And it is genuinely INCREMENTAL: the dirty set is a small fraction of the graph
+    // (unchanged elements were reused from the old build, not recomputed).
+    $dirty = IncrementalMerge::dirtyIds($old, $new, [$controllerFile]);
+    expect(count($dirty['nodes']))->toBeLessThan($new->nodeCount());
+
+    rmrfDir($dir);
+});
+
+it('reconstructs correctly for a method-body edit that changes only the caller node data', function () {
+    $dir = sys_get_temp_dir().'/brain-merge-'.bin2hex(random_bytes(6));
+    $controllerFile = $dir.'/app/Http/Controllers/DemoController.php';
+
+    writeMergeProject($dir, '        $this->svc->run();');
+    $old = buildMergeGraph($dir);
+
+    // Body-only edit: same calls, extra local work → the action node's flow/metrics data changes.
+    writeMergeProject($dir, "        \$x = 1 + 1;\n        \$this->svc->run();");
+    $new = buildMergeGraph($dir);
+
+    $merged = IncrementalMerge::reconstruct($old, $new, [$controllerFile]);
+
+    expect(IncrementalMerge::signature($merged))->toEqual(IncrementalMerge::signature($new));
+
+    rmrfDir($dir);
+});


### PR DESCRIPTION
## What

Watch mode ran a full scan on every save. It now traces only the controllers declared in the
changed files and merges the result into the graph the previous run produced.

| application | full rescan (today) | scoped rescan | |
|---|---:|---:|---|
| B — 1,885 files | 769 ms | 244 ms | **2.9×** |
| C — 4,152 files | 938 ms | 574 ms | **1.6×** |

Measured in a warm process, because that is what watch is. Measuring it as a fresh CLI run
flatters it by counting parse work watch never repeats — that framing showed 1.7× and 1.1×, and
it is the wrong one.

It is not more than this, and the ceiling is worth stating plainly: the win is bounded by how
much of a scan is controller tracing, which is **21% on B and 7% on C**. Facade scanning is 24%
and 60%. Anything beyond these numbers has to come from there, not from here.

## The result is the same graph

A rescan that is fast and subtly different is worse than no rescan. The scoped result is
byte-identical to a full scan of the same tree on both applications — every node, every edge,
their payloads and their order, and all 358 and 406 tabs.

## When it refuses

Reusing the previous graph's edges is only sound while the changed files' own call graph is
intact. An edit that adds or removes a call invalidates it, and that is not knowable until the
scoped build has run and can be compared.

So it is compared, and a mismatch raises `ScopedRebuildNotApplicable` — an exception rather than
a returned flag, so a partial graph cannot be mistaken for a whole one by a caller that forgot to
check. Watch catches it and rescans in full.

It also rescans in full when a file appears or disappears, or when anything outside `app/`
changes: both can move the route table or reachability wholesale, and neither is worth reasoning
about incrementally.

## One change to full scans

The ERD tab is now ordered by model name. It was laid out in the order tracing happened to reach
each model, so it reshuffled whenever an unrelated controller changed which model it touched
first — the diagram churned for reasons that had nothing to do with the models.

Against three applications that is the **only** difference a full scan shows: node order, edge
set and every other tab are unchanged. It is also what makes the scoped path produce an identical
ERD, since a scoped run traces fewer controllers and would otherwise reach the models in a
different order every time.

## What is in here

`BuildFingerprint` hashes the tree by content and reports what changed. `GraphProvenance`
partitions a graph by the source file each node came from. `IncrementalMerge` computes the dirty
set and reconstructs a whole graph from a previous one plus a scoped rebuild.
`IncrementalAnalyzer` orchestrates those, and `ProjectAnalyzer::scopedTo()` is the seam the scan
command drives.

Two bugs found by measuring against real applications rather than fixtures, both fixed here:

- `applyPartial` added untouched nodes in one pass and rebuilt ones in a second, which moved every
  rebuilt node to the end. The merged graph held the right nodes in the wrong sequence.
  `IncrementalMerge::signature()` normalises order, so the existing tests could not see it.
- The ERD ordering above.

## Tests

`198 passed (710 assertions)` · PHPStan level 5 + larastan **No errors** · Pint clean.

Fourteen new across the four units, including a merge test that asserts the node *sequence*
rather than the normalised signature, and a splitter test pinning that the ERD is laid out in the
order it is given — which is why the caller sorts.
