### PR TITLE
Show the work a callback does in the method flow

### DIFF
--- a/src/Analysis/FlowExtractor.php
+++ b/src/Analysis/FlowExtractor.php
@@ -366,21 +366,43 @@ class FlowExtractor
      * @param  Node\Arg[]|Node\VariadicPlaceholder[]  $args
      * @return array<string, mixed>
      */
+    /**
+     * How deep this will follow callbacks into each other before it stops.
+     *
+     * Measured over three production applications: the deepest chart nests 5 levels, out of
+     * 14,000-odd steps, and only 25 steps anywhere reach level 4 or 5. So this is roughly six
+     * times what real code does, and it exists for source no one wrote by hand — FlowExtractor
+     * runs over whatever is in the project, and generated or pathological files should not be
+     * able to take a scan down.
+     */
+    private const MAX_CALLBACK_DEPTH = 32;
+
+    private int $callbackDepth = 0;
+
     private function withCallbackBody(array $step, array $args): array
     {
+        if ($this->callbackDepth >= self::MAX_CALLBACK_DEPTH) {
+            return $step;
+        }
+
         foreach ($args as $arg) {
             if (! $arg instanceof Node\Arg) {
                 continue;
             }
             $value = $arg->value;
-            if ($value instanceof Node\Expr\Closure) {
-                $body = $this->stmtsToSteps($value->stmts);
-            } elseif ($value instanceof Node\Expr\ArrowFunction) {
-                // An implicit return, matching how extractFromClosure() reads the same shape —
-                // otherwise one arrow function charts two ways depending on which path found it.
-                $body = $this->stmtsToSteps([new Node\Stmt\Return_($value->expr)]);
-            } else {
-                continue;
+            $this->callbackDepth++;
+            try {
+                if ($value instanceof Node\Expr\Closure) {
+                    $body = $this->stmtsToSteps($value->stmts);
+                } elseif ($value instanceof Node\Expr\ArrowFunction) {
+                    // An implicit return, matching how extractFromClosure() reads the same shape —
+                    // otherwise one arrow function charts two ways depending on which path found it.
+                    $body = $this->stmtsToSteps([new Node\Stmt\Return_($value->expr)]);
+                } else {
+                    continue;
+                }
+            } finally {
+                $this->callbackDepth--;
             }
 
             return $body === [] ? $step : ['type' => 'loop'] + $step + ['body' => $body];
@@ -479,12 +501,42 @@ class FlowExtractor
             return '!'.$this->shortExpr($expr->expr);
         }
 
+        // A closure or arrow function used as a value — nearly always the callback a step was
+        // built from. Without a case here it reaches the pretty printer below, which renders the
+        // entire body: for nested callbacks that means re-rendering everything inside this one,
+        // at every level, so the cost of labelling a chain grows with the square of its depth.
+        if ($expr instanceof Node\Expr\Closure) {
+            return 'function ('.$this->paramsLabel($expr->params).') {...}';
+        }
+        if ($expr instanceof Node\Expr\ArrowFunction) {
+            return 'fn ('.$this->paramsLabel($expr->params).') => ...';
+        }
+
         // Fallback: use pretty printer for full expression
         try {
             return $this->printer->prettyPrintExpr($expr);
         } catch (\Throwable) {
             return '...';
         }
+    }
+
+    /**
+     * The parameter names of a closure, which is the part of its signature worth keeping in a
+     * label. The body is what gets dropped: it is either charted underneath the step already, or
+     * it is an assignment whose contents belong in the code rather than in a chart label.
+     *
+     * @param  Node\Param[]  $params
+     */
+    private function paramsLabel(array $params): string
+    {
+        $names = [];
+        foreach ($params as $param) {
+            $names[] = $param->var instanceof Node\Expr\Variable && is_string($param->var->name)
+                ? '$'.$param->var->name
+                : '$?';
+        }
+
+        return implode(', ', $names);
     }
 
     private function argsLabel(array $args): string

--- a/src/Analysis/FlowExtractor.php
+++ b/src/Analysis/FlowExtractor.php
@@ -316,7 +316,7 @@ class FlowExtractor
                 return ['type' => 'dispatch', 'label' => "Bus::{$method}(...)"];
             }
 
-            return ['type' => 'call', 'label' => "{$short}::{$method}(...)"];
+            return $this->withCallbackBody(['type' => 'call', 'label' => "{$short}::{$method}(...)"], $expr->args);
         }
 
         // $this->service->method(...)  /  $var->method(...)
@@ -327,7 +327,7 @@ class FlowExtractor
                 return ['type' => 'dispatch', 'label' => $this->shortExpr($expr)];
             }
 
-            return ['type' => 'call', 'label' => $this->shortExpr($expr)];
+            return $this->withCallbackBody(['type' => 'call', 'label' => $this->shortExpr($expr)], $expr->args);
         }
 
         // event(new SomeEvent)  /  dispatch(new SomeJob)  /  dispatch_sync(new SomeJob)
@@ -340,10 +340,51 @@ class FlowExtractor
                 return ['type' => 'dispatch', 'label' => $this->shortExpr($expr)];
             }
 
-            return ['type' => 'call', 'label' => $this->shortExpr($expr)];
+            return $this->withCallbackBody(['type' => 'call', 'label' => $this->shortExpr($expr)], $expr->args);
         }
 
         return null;
+    }
+
+    /**
+     * Give a call the steps of the callback it was passed, so the work inside is part of the flow.
+     *
+     * `DB::transaction(function () { ... })` is one statement holding a whole block of work, and
+     * without this the flow chart shows the wrapper and stops — the body simply vanishes. The same
+     * is true of `Cache::remember`, `retry`, a collection `each`, and anything else taking a
+     * closure.
+     *
+     * The step becomes a `loop`, which is what the viewer calls a block with a body — both its
+     * mermaid and React renderers descend into `body` for that type and for no other, so a `call`
+     * carrying one would be dropped on the floor. A `try` block is already emitted this way for
+     * the same reason.
+     *
+     * Only the first callback is descended into: a call taking two is rare, and showing one body
+     * under one label is clearer than merging them.
+     *
+     * @param  array{type: string, label: string}  $step
+     * @param  Node\Arg[]|Node\VariadicPlaceholder[]  $args
+     * @return array<string, mixed>
+     */
+    private function withCallbackBody(array $step, array $args): array
+    {
+        foreach ($args as $arg) {
+            if (! $arg instanceof Node\Arg) {
+                continue;
+            }
+            $value = $arg->value;
+            if ($value instanceof Node\Expr\Closure) {
+                $body = $this->stmtsToSteps($value->stmts);
+            } elseif ($value instanceof Node\Expr\ArrowFunction) {
+                $body = $this->stmtsToSteps([new Node\Stmt\Expression($value->expr)]);
+            } else {
+                continue;
+            }
+
+            return $body === [] ? $step : ['type' => 'loop'] + $step + ['body' => $body];
+        }
+
+        return $step;
     }
 
     // ── Expression prettifier ─────────────────────────────────────────────────

--- a/src/Analysis/FlowExtractor.php
+++ b/src/Analysis/FlowExtractor.php
@@ -376,7 +376,9 @@ class FlowExtractor
             if ($value instanceof Node\Expr\Closure) {
                 $body = $this->stmtsToSteps($value->stmts);
             } elseif ($value instanceof Node\Expr\ArrowFunction) {
-                $body = $this->stmtsToSteps([new Node\Stmt\Expression($value->expr)]);
+                // An implicit return, matching how extractFromClosure() reads the same shape —
+                // otherwise one arrow function charts two ways depending on which path found it.
+                $body = $this->stmtsToSteps([new Node\Stmt\Return_($value->expr)]);
             } else {
                 continue;
             }

--- a/tests/Unit/FlowExtractorTest.php
+++ b/tests/Unit/FlowExtractorTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use LaraMint\LaravelBrain\Analysis\FlowExtractor;
+use LaraMint\LaravelBrain\Parser\PhpFileParser;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+
+/** Flow steps for the first method of a class written inline. */
+function flowFor(string $body): array
+{
+    $parsed = (new PhpFileParser)->parseCode(<<<PHP
+        <?php
+
+        namespace App;
+
+        class Subject
+        {
+            public function handle()
+            {
+        {$body}
+            }
+        }
+        PHP);
+
+    $found = null;
+    $traverser = new NodeTraverser;
+    $traverser->addVisitor(new class($found) extends NodeVisitorAbstract
+    {
+        public function __construct(private mixed &$found) {}
+
+        public function enterNode(Node $node): ?int
+        {
+            if ($node instanceof Node\Stmt\ClassMethod && $this->found === null) {
+                $this->found = $node;
+            }
+
+            return null;
+        }
+    });
+    $traverser->traverse($parsed['ast'] ?? []);
+
+    return $found === null ? [] : (new FlowExtractor)->extract($found, $parsed['useMap'] ?? []);
+}
+
+it('shows the work inside a DB::transaction, not just the wrapper', function () {
+    // The reported bug: a method whose body is wrapped in a transaction charted as one step and
+    // nothing else, so everything the transaction actually did was invisible.
+    $steps = flowFor('        \DB::transaction(function () {
+            $this->payer->charge();
+            $this->ledger->record();
+        });');
+
+    expect($steps)->toHaveCount(1)
+        ->and($steps[0]['label'])->toContain('transaction')
+        ->and($steps[0]['body'] ?? [])->toHaveCount(2);
+
+    $labels = array_column($steps[0]['body'], 'label');
+    expect($labels[0])->toContain('charge')
+        ->and($labels[1])->toContain('record');
+});
+
+it('marks a step carrying a body as the type the viewer descends into', function () {
+    // Both viewer renderers read `body` only for the `loop` type — a `call` carrying one is
+    // dropped silently, which is the difference between fixing this and appearing to.
+    $steps = flowFor('        \DB::transaction(function () {
+            $this->payer->charge();
+        });');
+
+    expect($steps[0]['type'])->toBe('loop');
+});
+
+it('descends into an arrow function too', function () {
+    $steps = flowFor('        \Cache::remember("k", 60, fn () => $this->repo->load());');
+
+    expect($steps[0]['body'] ?? [])->toHaveCount(1)
+        ->and($steps[0]['body'][0]['label'])->toContain('load');
+});
+
+it('leaves a call without a callback exactly as it was', function () {
+    $steps = flowFor('        $this->payer->charge();');
+
+    expect($steps)->toHaveCount(1)
+        ->and($steps[0]['type'])->toBe('call')
+        ->and($steps[0])->not->toHaveKey('body');
+});
+
+it('keeps the calls a closure makes visible to the flow, nested one level', function () {
+    // A collection callback is the same shape and just as invisible before this.
+    $steps = flowFor('        collect($rows)->each(function ($row) {
+            $this->importer->import($row);
+        });');
+
+    expect($steps[0]['body'] ?? [])->toHaveCount(1)
+        ->and($steps[0]['body'][0]['label'])->toContain('import');
+});

--- a/tests/Unit/FlowExtractorTest.php
+++ b/tests/Unit/FlowExtractorTest.php
@@ -74,7 +74,9 @@ it('descends into an arrow function too', function () {
     $steps = flowFor('        \Cache::remember("k", 60, fn () => $this->repo->load());');
 
     expect($steps[0]['body'] ?? [])->toHaveCount(1)
-        ->and($steps[0]['body'][0]['label'])->toContain('load');
+        ->and($steps[0]['body'][0]['label'])->toContain('load')
+        // An implicit return, as extractFromClosure() reads the same shape.
+        ->and($steps[0]['body'][0]['type'])->toBe('return');
 });
 
 it('leaves a call without a callback exactly as it was', function () {
@@ -93,4 +95,29 @@ it('keeps the calls a closure makes visible to the flow, nested one level', func
 
     expect($steps[0]['body'] ?? [])->toHaveCount(1)
         ->and($steps[0]['body'][0]['label'])->toContain('import');
+});
+
+it('surfaces an N+1 that was hidden inside a callback', function () {
+    // A query in a foreach inside a callback was invisible, so the N+1 marker never reached it.
+    // Callback bodies are walked as not-in-a-loop, so the flag can only come from the real
+    // foreach nested within — a transaction is not itself a loop and is not counted as one.
+    $steps = flowFor('        \DB::transaction(function () {
+            foreach ($this->rows as $row) {
+                \App\Models\Thing::find($row->id);
+            }
+        });');
+
+    $inner = $steps[0]['body'][0] ?? [];
+    expect($inner['type'])->toBe('loop')
+        ->and($inner['label'])->toContain('foreach')
+        ->and($inner['body'][0]['n1'] ?? false)->toBeTrue();
+});
+
+it('does not call a callback that merely contains a query an N+1', function () {
+    $steps = flowFor('        \DB::transaction(function () {
+            \App\Models\Thing::find(1);
+        });');
+
+    expect($steps[0]['n1'] ?? false)->toBeFalse()
+        ->and($steps[0]['body'][0]['n1'] ?? false)->toBeFalse();
 });

--- a/tests/Unit/FlowExtractorTest.php
+++ b/tests/Unit/FlowExtractorTest.php
@@ -121,3 +121,48 @@ it('does not call a callback that merely contains a query an N+1', function () {
     expect($steps[0]['n1'] ?? false)->toBeFalse()
         ->and($steps[0]['body'][0]['n1'] ?? false)->toBeFalse();
 });
+
+it('labels a closure by its signature rather than its whole body', function () {
+    // The body used to be pretty-printed into the label. For a callback the body is charted
+    // underneath the step anyway, so the label repeated it; and for a chain of callbacks each
+    // level re-rendered everything inside it, which is what made deep nesting quadratic.
+    $steps = flowFor('        $constraint = function ($query, $user) {
+            $query->whereBelongsTo($user);
+        };');
+
+    expect($steps[0]['label'])->toBe('$constraint = function ($query, $user) {...}')
+        ->and($steps[0]['label'])->not->toContain('whereBelongsTo');
+});
+
+it('labels an arrow function by its signature too', function () {
+    $steps = flowFor('        $ids = $items->filter(fn ($item) => $item->id > 10);');
+
+    expect($steps[0]['label'])->toContain('fn ($item) => ...')
+        ->and($steps[0]['label'])->not->toContain('> 10');
+});
+
+it('stops descending into callbacks nested past any depth real code reaches', function () {
+    // FlowExtractor runs over whatever is in the project, and a generated or pathological file
+    // should not be able to take a scan down. Before the limit, 640 levels exhausted a 128 MB
+    // memory limit inside the pretty printer; 320 took half a second for one file.
+    $depth = 200;
+    $inner = '$this->svc->leaf();';
+    for ($i = 0; $i < $depth; $i++) {
+        $inner = "\$this->svc->wrap(function () { {$inner} });";
+    }
+
+    $started = microtime(true);
+    $steps = flowFor('        '.$inner);
+    $elapsed = (microtime(true) - $started) * 1000;
+
+    // It still charts, and it charts quickly — the guard truncates rather than throwing.
+    expect($steps)->toHaveCount(1)->and($elapsed)->toBeLessThan(500);
+
+    $levels = 0;
+    $cursor = $steps;
+    while (! empty($cursor[0]['body'])) {
+        $levels++;
+        $cursor = $cursor[0]['body'];
+    }
+    expect($levels)->toBeLessThanOrEqual(32)->and($levels)->toBeGreaterThan(1);
+});


### PR DESCRIPTION
Closes #21.

## What

A method whose body sits inside `DB::transaction(function () { ... })` charted as a single step —
the wrapper — and nothing else. Everything the transaction did was missing from the one view you
open to see what a method does.

`FlowExtractor` turned every call into a leaf and never looked at its arguments, so a closure
passed to one was never entered. Nothing about that is specific to transactions:
`Cache::remember`, `retry`, a collection `each`, anything taking a callback lost its contents the
same way.

```
before   DB::transaction(...)

after    DB::transaction(...)
           └─ $this->payer->charge()
              $this->ledger->record()
```

## The type matters more than the body

A call given a callback now carries that body, in the shape a `try` block already uses. It is also
retyped `loop`, which is what the viewer calls a block with a body — and that part is not cosmetic.
Both renderers in the shipped bundle read `body` for the `loop` type and for no other:

```js
else if (t.type === `loop`) { … t.body && t.body.length > 0 && walk(t.body, e) … }
```

A `call` carrying a `body` is dropped without a word. The fix would have looked correct in the
JSON, passed a test written against the JSON, and changed nothing on screen — which is the bug
being reported, not the fix for it. One of the tests pins the type for that reason.

Only the first callback of a call is entered. A call taking two is rare, and one body under one
label reads better than two merged.

## What it costs

Flow charts get bigger, so the question is whether they get unreadable. Measured over every action
node of two production applications:

| application | total flow steps | largest single chart | actions gaining a nested body |
|---|---|---|---|
| B — 1,885 files | 4,698 → 4,834 (+2.9%) | 65 → 65 | +38 |
| C — 4,152 files | 5,090 → 5,512 (+8.3%) | 50 → 54 | +81 |

The growth lands where work was hidden rather than spread across every chart, and the worst case
barely moves. Nothing else about a scan changes.

## Tests

`235 passed (806 assertions)` · PHPStan level 5 + larastan **No errors** · Pint clean.

Ten new, and the first tests `FlowExtractor` has had. Five fail on `main`: the transaction body,
the step type the viewer needs, an arrow function, a collection callback, and the N+1 that was
hidden inside one.

The other two pass on `main` and are there to fence the change in rather than to demonstrate it:
one asserts a call *without* a callback is untouched — no type change, no `body` key — and the
other that a callback merely containing a query is not itself an N+1. That second one exists
because I first read the new warnings this produces as false positives and drafted the PR saying
so. They are real: callback bodies are walked with `inLoop = false`, so a step can only be marked
by a loop genuinely nested inside.




## Bounded, after review

@mrmarchone found that following callbacks into each other had no depth limit, and that it
compounded with the pretty-print fallback in `shortExpr`: a call with one closure argument
rendered the whole closure into its label, so a chain re-rendered everything inside it at every
level. Reproduced — 4 ms at depth 40, 56 ms at 160, 514 ms at 320, and a fatal at 640 from
exhausting a 128 MB limit inside the pretty printer, which takes the scan with it.

A closure is now labelled by its signature (`function ($query, $user) {...}`), keeping the
parameters and dropping the body — which for a callback is charted underneath the step anyway.
And the descent stops at 32 levels, truncating rather than throwing: measured across three
production applications the deepest chart nests 5, out of ~14,000 steps, so that is about six
times real code. Depth 320 is now 2 ms and 640 is 1 ms.

That label change is visible in output: 452 labels change on one application and 414 on another,
and every changed line in a full dump is a `"label"` — no node, edge or step type moves.
