### PR TITLE
Stop parsing most of app/ to find facades

### DIFF
--- a/src/Analysis/FacadeAnalyzer.php
+++ b/src/Analysis/FacadeAnalyzer.php
@@ -47,6 +47,7 @@ final class FacadeAnalyzer
     {
         $registry = new FacadeRegistry;
         $this->parseCache = [];
+        $this->facadeChainShortNames = [];
         $this->projectRoot = rtrim($projectRoot, '/');
         $this->appDir = $this->projectRoot.'/app';
 
@@ -58,31 +59,78 @@ final class FacadeAnalyzer
             new \RecursiveDirectoryIterator($this->appDir, \FilesystemIterator::SKIP_DOTS)
         );
 
+        $files = [];
         foreach ($iterator as $file) {
-            if ($file->getExtension() !== 'php') {
-                continue;
+            if ($file->getExtension() === 'php') {
+                $files[] = $file->getPathname();
             }
-            if (! $this->mightDefineFacade($file->getPathname())) {
-                continue;
+        }
+
+        // Round one: only files that name Facade at all. A facade reaches Illuminate's Facade
+        // through `extends`, and naming that class — imported, aliased or fully qualified —
+        // leaves the token behind.
+        $pending = [];
+        foreach ($files as $path) {
+            if ($this->mightDefineFacade($path)) {
+                $this->scanFile($path, $registry);
+            } else {
+                $pending[] = $path;
             }
-            $this->scanFile($file->getPathname(), $registry);
+        }
+
+        // Then close the gap that leaves: a facade may extend an app-level base whose own file
+        // names Facade while the child's does not. Every class confirmed to sit in the chain is
+        // a name a further file might extend, so the unread files are re-offered whenever a new
+        // such name turns up, until a round adds nothing. String work only — a file is parsed
+        // just when it mentions one of them.
+        $seen = [];
+        while ($pending !== []) {
+            $bases = array_diff(array_keys($this->facadeChainShortNames), $seen);
+            if ($bases === []) {
+                break;
+            }
+            $seen = array_merge($seen, $bases);
+
+            $stillPending = [];
+            foreach ($pending as $path) {
+                $code = @file_get_contents($path);
+                if ($code === false) {
+                    continue;
+                }
+                $mentions = false;
+                foreach ($bases as $base) {
+                    if (str_contains($code, $base)) {
+                        $mentions = true;
+                        break;
+                    }
+                }
+                if ($mentions) {
+                    $this->scanFile($path, $registry);
+                } else {
+                    $stillPending[] = $path;
+                }
+            }
+            $pending = $stillPending;
         }
 
         return $registry;
     }
 
     /**
-     * A facade reaches Facade through `extends`, so a file without the keyword cannot define
-     * one. Crude in the safe direction: `extends` in a comment or a string only costs a scan
-     * that would have happened anyway.
+     * A file that never names Facade cannot extend it directly. The keyword `extends` used to
+     * stand in for this and admitted most of a codebase — 81% of the files of one application
+     * measured here — where naming the class admits 8%.
+     *
+     * On its own this misses a facade that reaches the base through an app-level intermediate;
+     * {@see analyze()} closes that with a second pass rather than assuming it away.
      */
     private function mightDefineFacade(string $file): bool
     {
         $code = @file_get_contents($file);
 
-        // stripos, not str_contains: PHP keywords are case-insensitive, and `class X EXTENDS Y`
-        // is valid source.
-        return $code !== false && stripos($code, 'extends') !== false;
+        // Case-sensitive, unlike the `extends` keyword this replaced: `Facade` is a class name,
+        // and PHP class names are matched case-sensitively by the autoloader in practice.
+        return $code !== false && str_contains($code, 'Facade');
     }
 
     private function scanFile(string $file, FacadeRegistry $registry): void
@@ -101,8 +149,15 @@ final class FacadeAnalyzer
                 continue;
             }
 
-            // Skip abstract classes — they cannot be injected directly.
+            // Abstract classes cannot be injected, so they are never facades themselves — but an
+            // abstract base extending Facade is exactly the intermediate a child reaches it
+            // through, so its name is still worth remembering.
             if ($stmt->isAbstract()) {
+                $parent = PhpExtendsFqcnResolver::resolveExtends($stmt->extends, $ns, $useMap);
+                if ($parent !== null && $this->isInFacadeChain($parent, 0)) {
+                    $this->facadeChainShortNames[$stmt->name->toString()] = true;
+                }
+
                 break;
             }
 
@@ -118,6 +173,9 @@ final class FacadeAnalyzer
 
             $short = $stmt->name->toString();
             $facadeFqcn = $ns !== '' ? $ns.'\\'.$short : $short;
+
+            // This class is itself a name a further file may extend to become a facade.
+            $this->facadeChainShortNames[$short] = true;
 
             // Find getFacadeAccessor() in this class or an ancestor.
             $accessor = $this->findAccessorInChain($stmt, $ns, $useMap, 0);
@@ -137,6 +195,9 @@ final class FacadeAnalyzer
      * Return true when $fqcn is Illuminate\Support\Facades\Facade or extends it
      * (directly or through intermediate app-level classes).
      */
+    /** @var array<string, true> short names of classes confirmed to sit in the facade chain */
+    private array $facadeChainShortNames = [];
+
     private function isInFacadeChain(string $fqcn, int $depth): bool
     {
         if ($fqcn === self::FACADE_BASE) {

--- a/src/Analysis/FacadeAnalyzer.php
+++ b/src/Analysis/FacadeAnalyzer.php
@@ -119,7 +119,14 @@ final class FacadeAnalyzer
     /**
      * A file that never names Facade cannot extend it directly. The keyword `extends` used to
      * stand in for this and admitted most of a codebase — 81% of the files of one application
-     * measured here — where naming the class admits 8%.
+     * measured here.
+     *
+     * Naming the class is the real test, but `Facade` on its own is not that test: the import
+     * `use Illuminate\Support\Facades\Log;` contains it, and most files in a Laravel application
+     * carry a line like that. Dropping the framework's `Facades\` path segment first leaves the
+     * bare mention that only a file defining or extending a facade has — 22% of one application
+     * admitted down to 1%, and the base class itself survives, since
+     * `Illuminate\Support\Facades\Facade` still reads `Illuminate\Support\Facade` afterwards.
      *
      * On its own this misses a facade that reaches the base through an app-level intermediate;
      * {@see analyze()} closes that with a second pass rather than assuming it away.
@@ -130,7 +137,7 @@ final class FacadeAnalyzer
 
         // Case-sensitive, unlike the `extends` keyword this replaced: `Facade` is a class name,
         // and PHP class names are matched case-sensitively by the autoloader in practice.
-        return $code !== false && str_contains($code, 'Facade');
+        return $code !== false && str_contains(str_replace('Facades\\', '', $code), 'Facade');
     }
 
     private function scanFile(string $file, FacadeRegistry $registry): void

--- a/tests/Unit/FacadeAnalyzerTest.php
+++ b/tests/Unit/FacadeAnalyzerTest.php
@@ -100,8 +100,8 @@ it('discovers a facade whose files open with declare(strict_types=1)', function 
 });
 
 it('still discovers a facade whose source spells the keyword EXTENDS', function () {
-    // Files with no `extends` keyword are skipped before parsing, since they cannot define a
-    // facade. PHP keywords are case-insensitive, so that test has to be too.
+    // The `extends` keyword no longer decides which files are read, but this class is still the
+    // ordinary shape a facade takes, and PHP keywords are case-insensitive.
     $root = sys_get_temp_dir().'/brain-facade-case-'.uniqid();
     mkdir($root.'/app/Support', 0o777, true);
 
@@ -126,6 +126,56 @@ it('still discovers a facade whose source spells the keyword EXTENDS', function 
     expect($registry->get('App\Support\ShoutFacade'))
         ->toBeInstanceOf(FacadeRecord::class)
         ->accessor->toBe('shout');
+
+    exec('rm -rf '.escapeshellarg($root));
+});
+
+it('discovers a facade whose own file never mentions Facade', function () {
+    // The narrow case the prefilter cannot see and the second pass exists for. The child extends
+    // an app-level base that is *not* named `…Facade`, and imports it from a namespace segment
+    // the filter discounts — so the child's source, read as text, offers nothing at all. Only the
+    // base is admitted on the first pass; the child is reached because the base turned out to sit
+    // in the chain and the child names it.
+    $root = sys_get_temp_dir().'/brain-facade-indirect-'.uniqid();
+    mkdir($root.'/app/Support/Facades', 0o777, true);
+
+    file_put_contents($root.'/app/Support/Facades/Base.php', <<<'PHP'
+        <?php
+
+        namespace App\Support\Facades;
+
+        use Illuminate\Support\Facades\Facade;
+
+        abstract class Base extends Facade
+        {
+            protected static function getFacadeAccessor()
+            {
+                return 'reporting';
+            }
+        }
+        PHP);
+
+    file_put_contents($root.'/app/Support/Reporting.php', <<<'PHP'
+        <?php
+
+        namespace App\Support;
+
+        use App\Support\Facades\Base;
+
+        class Reporting extends Base
+        {
+        }
+        PHP);
+
+    // Guard the premise: if this file ever gains a bare `Facade` the test proves nothing.
+    $source = (string) file_get_contents($root.'/app/Support/Reporting.php');
+    expect(str_contains(str_replace('Facades\\', '', $source), 'Facade'))->toBeFalse();
+
+    $registry = (new FacadeAnalyzer)->analyze($root);
+
+    expect($registry->get('App\Support\Reporting'))
+        ->toBeInstanceOf(FacadeRecord::class)
+        ->accessor->toBe('reporting');
 
     exec('rm -rf '.escapeshellarg($root));
 });


### PR DESCRIPTION
## What

The facade scan reads every PHP file under `app/` and parses the ones containing `extends`. On a
large codebase that is most of them, so this one analyzer accounted for the majority of all
parsing in a scan — every other analyzer only parses code a route can reach.

A facade reaches Illuminate's `Facade` through `extends`, and naming that class leaves the token
behind, so the filter can ask for the name instead of the keyword. On its own that is still far
too loose: `use Illuminate\Support\Facades\Log;` contains `Facade`, and most files in a Laravel
application carry a line like it — the filter ends up admitting anything that *uses* a facade
rather than anything that *defines* one. Dropping the framework's `Facades\` path segment before
the match leaves the bare mention that only a definition has, and leaves the base class itself
intact, since `Illuminate\Support\Facades\Facade` still reads `Illuminate\Support\Facade`
afterwards.

| application | php files in app/ | admitted by `extends` | admitted now |
|---|---:|---:|---:|
| A | 1,089 | 758 (70%) | **2** |
| B | 1,899 | 1,036 (55%) | **15** |
| C | 4,181 | 3,369 (81%) | **7** |

C has no application facades at all. It was parsing 3,369 files to find that out.

## Cost

| application | scan before | scan after | | facade phase | parses |
|---|---:|---:|---|---:|---|
| A | 2,511 ms | 2,375 ms | −5% | 180 → 30 ms | 950 → 717 |
| B | 1,717 ms | 1,476 ms | −14% | 383 → 124 ms | 1,582 → 1,035 |
| C | 3,196 ms | 1,398 ms | **−56%** | 1,926 → 195 ms | 3,704 → 690 |

Medians of four interleaved runs in one session, warm. The phase drops from 7%, 22% and 60% of a
scan to 1%, 8% and 14%.

What is left is close to the floor of this design. The phase now parses 4, 54 and 7 files; almost
everything it still spends goes on walking `app/` and reading each file to apply the filter, which
no filter can be cheaper than.

> An earlier revision of this description reported B as 2,029 → 1,550 ms. That pair was measured
> in two sittings and the baseline was contaminated; the parse counts were right but the wall
> clock was not. Every number above comes from a single interleaved run of all arms.

## The hole it would leave, and how it is closed

A facade can extend an app-level base whose file names `Facade` while the child's does not:

```php
namespace App\Support\Facades;
abstract class Base extends \Illuminate\Support\Facades\Facade {}  // admitted

namespace App\Support;
use App\Support\Facades\Base;
class Reporting extends Base {}                                    // nothing to match on
```

`isInFacadeChain()` resolves transitively, so `Reporting` is a facade — and the filter alone would
drop it silently, which is the worst kind of wrong here: a missing facade is invisible unless you
diff two graphs.

So the filter is a first pass. Every class confirmed to sit in the chain is recorded, including an
abstract intermediate that can never be a facade itself but is exactly what a child reaches the
base through. Files not read in round one are re-offered whenever a new such name appears, until a
round adds nothing. It is string work — a held-back file is parsed only once it mentions one of
those names.

Across 7,169 files in three applications the second pass finds nothing, because none of them use
that shape. It is here so the ones that do keep working, and it has a test that fails when the
pass is removed.

## Gate

Full build output — graph, all subgraphs, manifest, totals, the tracer's edge list — is
**byte-identical on all three applications**, 14.7 MB, 19.2 MB and 40.0 MB of dump apiece. That is
the check that matters: the registry could shrink without a single test failing.

The filter was also judged against ground truth computed independently of it: parse every file
under `app/`, index every class by FQCN, walk each `extends` chain, and collect the files defining
a class that reaches `Illuminate\Support\Facades\Facade`. Every one of those files is admitted
directly, without leaning on the second pass.

## Tests

`211 passed (751 assertions)` · PHPStan level 5 + larastan **No errors** · Pint clean.
