### PR TITLE
Stop re-deriving whether a file has a rules() method

### DIFF
--- a/src/Analysis/ValidationRulesExtractor.php
+++ b/src/Analysis/ValidationRulesExtractor.php
@@ -23,6 +23,19 @@ final class ValidationRulesExtractor
 
     private PrettyPrinter $printer;
 
+    /**
+     * Whether a file declares a non-abstract rules(), keyed by path + mtime + size.
+     *
+     * The answer is asked once per graph edge that could reach a Form Request, and the same file
+     * is reached from many edges: measured over three applications, 1,116 / 604 / 3,936 calls
+     * concerned 345 / 142 / 370 distinct files. The parse itself is already shared, but the
+     * traversal that looks for rules() was repeated every time — and when the answer is "no", as
+     * it usually is, nothing stops it early and it walks the whole file.
+     *
+     * @var array<string, bool>
+     */
+    private array $hasRulesMemo = [];
+
     public function __construct(?PhpFileParser $parser = null)
     {
         $this->parser = $parser ?? new PhpFileParser;
@@ -31,10 +44,27 @@ final class ValidationRulesExtractor
 
     public function hasNonAbstractRulesMethod(string $file): bool
     {
-        if (! is_file($file)) {
+        $stat = @stat($file);
+        if ($stat === false || ! is_file($file)) {
             return false;
         }
 
+        // Mirrors PhpFileParser's key and its rule for files being edited this very second: a
+        // file whose mtime is not yet in the past can change again without changing its key, so
+        // it is answered from source and not remembered.
+        $settled = $stat['mtime'] < time();
+        $key = $file.':'.$stat['mtime'].':'.$stat['size'];
+        if ($settled && isset($this->hasRulesMemo[$key])) {
+            return $this->hasRulesMemo[$key];
+        }
+
+        $verdict = $this->computeHasNonAbstractRulesMethod($file);
+
+        return $settled ? $this->hasRulesMemo[$key] = $verdict : $verdict;
+    }
+
+    private function computeHasNonAbstractRulesMethod(string $file): bool
+    {
         $parsed = $this->parser->parse($file);
         if ($parsed['ast'] === null) {
             return false;

--- a/src/Analysis/ValidationRulesExtractor.php
+++ b/src/Analysis/ValidationRulesExtractor.php
@@ -36,6 +36,15 @@ final class ValidationRulesExtractor
      */
     private array $hasRulesMemo = [];
 
+    /**
+     * Entry cap, enforced the way {@see PhpFileParser} enforces its own: insertion-ordered
+     * eviction of the oldest quarter. A single build cannot come near it — the most any of the
+     * three applications measured asks about is 370 distinct files. It bounds an extractor that
+     * outlives one build, where every edit mints a key and the superseded entry would otherwise
+     * stay for the life of the process.
+     */
+    private const MEMO_MAX = 8000;
+
     public function __construct(?PhpFileParser $parser = null)
     {
         $this->parser = $parser ?? new PhpFileParser;
@@ -59,8 +68,29 @@ final class ValidationRulesExtractor
         }
 
         $verdict = $this->computeHasNonAbstractRulesMethod($file);
+        if (! $settled) {
+            return $verdict;
+        }
 
-        return $settled ? $this->hasRulesMemo[$key] = $verdict : $verdict;
+        $this->evictIfFull();
+
+        return $this->hasRulesMemo[$key] = $verdict;
+    }
+
+    /** Drop the oldest quarter in one pass, rather than one entry per insert from here on. */
+    private function evictIfFull(): void
+    {
+        if (count($this->hasRulesMemo) < self::MEMO_MAX) {
+            return;
+        }
+
+        $evict = intdiv(self::MEMO_MAX, 4);
+        foreach (array_keys($this->hasRulesMemo) as $key) {
+            unset($this->hasRulesMemo[$key]);
+            if (--$evict <= 0) {
+                return;
+            }
+        }
     }
 
     private function computeHasNonAbstractRulesMethod(string $file): bool

--- a/tests/Unit/ValidationRulesExtractorTest.php
+++ b/tests/Unit/ValidationRulesExtractorTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use LaraMint\LaravelBrain\Analysis\ValidationRulesExtractor;
+use LaraMint\LaravelBrain\Parser\PhpFileParser;
 
 it('detects a concrete rules() method', function () {
     $extractor = new ValidationRulesExtractor;
@@ -59,6 +60,32 @@ it('does not remember a file that is still being written', function () {
     file_put_contents($file, "<?php\n\nclass Draft\n{\n    public function rules() { return []; }\n}\n");
     touch($file, time() + 5);
     expect($extractor->hasNonAbstractRulesMethod($file))->toBeTrue();
+
+    unlink($file);
+});
+
+it('remembers that a file has no rules(), not just that it has one', function () {
+    // The memo stores booleans, and the usual answer is false — so a membership test that treats
+    // a stored false as absent would still look correct (it would just re-derive everything) and
+    // quietly give back the whole saving. This pins that a false is remembered.
+    //
+    // The second version of the file is written at the same byte length and with the same mtime
+    // restored, so path + mtime + size is unchanged. That is the contract of this key, the same
+    // one the shared parse cache keeps: same key, same answer. The parse cache is cleared in
+    // between so that only the memo can produce the earlier answer.
+    $file = sys_get_temp_dir().'/brain-rules-memo-'.uniqid().'.php';
+    $extractor = new ValidationRulesExtractor;
+
+    file_put_contents($file, "<?php\n\nclass Kept\n{\n    public function ruled() { return []; }\n}\n");
+    $mtime = time() - 60;
+    touch($file, $mtime);
+    expect($extractor->hasNonAbstractRulesMethod($file))->toBeFalse();
+
+    file_put_contents($file, "<?php\n\nclass Kept\n{\n    public function rules() { return []; }\n}\n");
+    touch($file, $mtime);
+    PhpFileParser::clearSharedCache();
+
+    expect($extractor->hasNonAbstractRulesMethod($file))->toBeFalse();
 
     unlink($file);
 });

--- a/tests/Unit/ValidationRulesExtractorTest.php
+++ b/tests/Unit/ValidationRulesExtractorTest.php
@@ -24,20 +24,38 @@ it('extracts validation rows from rules() return arrays', function () {
     ]);
 });
 
+/**
+ * Write $code to a temp file and pin its mtime, clearing PHP's per-process stat cache so a test
+ * reads what it just wrote rather than what it last stat'd. The same discipline, and the same
+ * reason, as writeSource() in PhpFileParserSharedCacheTest.
+ */
+function writeRulesSource(string $path, string $code, int $mtime): void
+{
+    file_put_contents($path, $code);
+    touch($path, $mtime);
+    clearstatcache(true, $path);
+}
+
+/** A class with a rules() method, and one without, written to the same byte length. */
+function rulesSource(bool $withRules): string
+{
+    $method = $withRules ? 'rules' : 'ruled';
+
+    return "<?php\n\nclass Subject\n{\n    public function {$method}() { return []; }\n}\n";
+}
+
 it('answers again once the file has changed', function () {
     // The verdict is remembered per file, so the thing worth pinning is that it stops being
-    // remembered when the file it describes is no longer the same file.
+    // remembered when the file it describes is no longer the same file. Both versions are the
+    // same length on purpose: the key is path + mtime + size, so a size that moved with the
+    // content would hide a broken mtime component.
     $file = sys_get_temp_dir().'/brain-rules-'.uniqid().'.php';
     $extractor = new ValidationRulesExtractor;
 
-    // The two versions are the same length on purpose: the key is path + mtime + size, so a
-    // size that changes with the content would hide a broken mtime component.
-    file_put_contents($file, "<?php\n\nclass Plain\n{\n    public function ruled() { return []; }\n}\n");
-    touch($file, time() - 60);
+    writeRulesSource($file, rulesSource(false), time() - 60);
     expect($extractor->hasNonAbstractRulesMethod($file))->toBeFalse();
 
-    file_put_contents($file, "<?php\n\nclass Plain\n{\n    public function rules() { return []; }\n}\n");
-    touch($file, time() - 30);
+    writeRulesSource($file, rulesSource(true), time() - 30);
     expect($extractor->hasNonAbstractRulesMethod($file))->toBeTrue();
 
     unlink($file);
@@ -45,20 +63,18 @@ it('answers again once the file has changed', function () {
 
 it('does not remember a file that is still being written', function () {
     // A file whose mtime is not yet in the past can change again without changing its key, so
-    // caching its verdict would let the old answer stand. The mtime is set ahead explicitly
-    // rather than relying on the write landing in the same second as the read, which would make
-    // this pass or fail on where the clock happens to be.
+    // caching its verdict would let the old answer stand. The mtime is pinned ahead rather than
+    // left to the write landing in the same second as the read, which would make this pass or
+    // fail on where the clock happens to be. Path, mtime and size are all unchanged across the
+    // edit, so only the refusal to remember an unsettled file can give the right answer.
     $file = sys_get_temp_dir().'/brain-rules-unsettled-'.uniqid().'.php';
     $extractor = new ValidationRulesExtractor;
+    $unsettled = time() + 2;
 
-    // Same length again, and the same mtime — so path, mtime and size all match across the
-    // edit and only the refusal to remember an unsettled file can give the right answer.
-    file_put_contents($file, "<?php\n\nclass Draft\n{\n    public function ruled() { return []; }\n}\n");
-    touch($file, time() + 5);
+    writeRulesSource($file, rulesSource(false), $unsettled);
     expect($extractor->hasNonAbstractRulesMethod($file))->toBeFalse();
 
-    file_put_contents($file, "<?php\n\nclass Draft\n{\n    public function rules() { return []; }\n}\n");
-    touch($file, time() + 5);
+    writeRulesSource($file, rulesSource(true), $unsettled);
     expect($extractor->hasNonAbstractRulesMethod($file))->toBeTrue();
 
     unlink($file);
@@ -69,20 +85,17 @@ it('remembers that a file has no rules(), not just that it has one', function ()
     // a stored false as absent would still look correct (it would just re-derive everything) and
     // quietly give back the whole saving. This pins that a false is remembered.
     //
-    // The second version of the file is written at the same byte length and with the same mtime
-    // restored, so path + mtime + size is unchanged. That is the contract of this key, the same
-    // one the shared parse cache keeps: same key, same answer. The parse cache is cleared in
-    // between so that only the memo can produce the earlier answer.
+    // The second version keeps the same path, mtime and size, which is the contract of this key
+    // and of the shared parse cache it mirrors: same key, same answer. The parse cache is cleared
+    // in between so that only the memo can produce the earlier answer.
     $file = sys_get_temp_dir().'/brain-rules-memo-'.uniqid().'.php';
     $extractor = new ValidationRulesExtractor;
-
-    file_put_contents($file, "<?php\n\nclass Kept\n{\n    public function ruled() { return []; }\n}\n");
     $mtime = time() - 60;
-    touch($file, $mtime);
+
+    writeRulesSource($file, rulesSource(false), $mtime);
     expect($extractor->hasNonAbstractRulesMethod($file))->toBeFalse();
 
-    file_put_contents($file, "<?php\n\nclass Kept\n{\n    public function rules() { return []; }\n}\n");
-    touch($file, $mtime);
+    writeRulesSource($file, rulesSource(true), $mtime);
     PhpFileParser::clearSharedCache();
 
     expect($extractor->hasNonAbstractRulesMethod($file))->toBeFalse();

--- a/tests/Unit/ValidationRulesExtractorTest.php
+++ b/tests/Unit/ValidationRulesExtractorTest.php
@@ -22,3 +22,43 @@ it('extracts validation rows from rules() return arrays', function () {
         "'required|email'",
     ]);
 });
+
+it('answers again once the file has changed', function () {
+    // The verdict is remembered per file, so the thing worth pinning is that it stops being
+    // remembered when the file it describes is no longer the same file.
+    $file = sys_get_temp_dir().'/brain-rules-'.uniqid().'.php';
+    $extractor = new ValidationRulesExtractor;
+
+    // The two versions are the same length on purpose: the key is path + mtime + size, so a
+    // size that changes with the content would hide a broken mtime component.
+    file_put_contents($file, "<?php\n\nclass Plain\n{\n    public function ruled() { return []; }\n}\n");
+    touch($file, time() - 60);
+    expect($extractor->hasNonAbstractRulesMethod($file))->toBeFalse();
+
+    file_put_contents($file, "<?php\n\nclass Plain\n{\n    public function rules() { return []; }\n}\n");
+    touch($file, time() - 30);
+    expect($extractor->hasNonAbstractRulesMethod($file))->toBeTrue();
+
+    unlink($file);
+});
+
+it('does not remember a file that is still being written', function () {
+    // A file whose mtime is not yet in the past can change again without changing its key, so
+    // caching its verdict would let the old answer stand. The mtime is set ahead explicitly
+    // rather than relying on the write landing in the same second as the read, which would make
+    // this pass or fail on where the clock happens to be.
+    $file = sys_get_temp_dir().'/brain-rules-unsettled-'.uniqid().'.php';
+    $extractor = new ValidationRulesExtractor;
+
+    // Same length again, and the same mtime — so path, mtime and size all match across the
+    // edit and only the refusal to remember an unsettled file can give the right answer.
+    file_put_contents($file, "<?php\n\nclass Draft\n{\n    public function ruled() { return []; }\n}\n");
+    touch($file, time() + 5);
+    expect($extractor->hasNonAbstractRulesMethod($file))->toBeFalse();
+
+    file_put_contents($file, "<?php\n\nclass Draft\n{\n    public function rules() { return []; }\n}\n");
+    touch($file, time() + 5);
+    expect($extractor->hasNonAbstractRulesMethod($file))->toBeTrue();
+
+    unlink($file);
+});


### PR DESCRIPTION
## What

`hasNonAbstractRulesMethod()` answers one question about one file: does it declare a concrete
`rules()`. The graph builder asks it while classifying call-chain edges and while wiring Form
Requests onto route actions, so the same file is asked about once per edge that reaches it.

The parse is already shared, but the traversal that looks for `rules()` was not. Worse, it is a
traversal with no early exit in the common case: `STOP_TRAVERSAL` fires only when a method named
`rules` is found, so for the great majority of files, which have none, it descends through every
method body, every expression and every argument before returning nothing.

Measured over three applications:

| application | calls | distinct files asked about | repeats | time inside it |
|---|---:|---:|---:|---:|
| A | 3,936 | 370 | 3,566 | 538 ms |
| B | 1,116 | 345 | 771 | 246 ms |
| C | 604 | 142 | 462 | 183 ms |

Between 76% and 91% of the calls re-derive an answer already derived for that exact file.

This remembers the verdict, keyed on path + mtime + size — the same identity `PhpFileParser` keys
its shared cache on, including its rule for a file whose mtime is not yet in the past. Such a file
can change again without changing its key, so it is answered from source and not remembered.

## Cost

| application | scan before | scan after | |
|---|---:|---:|---|
| A | 2,694 ms | 2,173 ms | **−19%** |
| B | 1,775 ms | 1,557 ms | −12% |
| C | 3,278 ms | 3,175 ms | −3% |

Medians of four runs with both arms interleaved in one session, each arm a separate checkout.
Nothing else about a scan changes: parse counts are identical, since the parses were already
shared and it is the walking that stops.

C is the honest disappointment. 183 ms of its scan is spent in this method and about three
quarters of that is recoverable, but its scan is 3.3 s — the gain is small enough that one of the
four reps had the patched arm come out slower. Take the instrumented 183 ms as the real figure
there and the −3% as being at the edge of what this machine can resolve. Most of C's scan is
still facade scanning; on a branch with #80 applied, where that is gone, the same change is worth
−13%. The two are independent and compose.

## Where this came from

Profiling a scan by phase, with the nested `views` step subtracted from `graph` and the work that
falls outside every step reported separately, `graph` is 25–47% of a scan while accounting for 39
to 93 parses. A phase that expensive doing almost no file reading is doing something repeatedly in
memory, and this was it.

## Gate

Full build output — graph, all subgraphs, manifest, totals, the tracer's edge list — is
**byte-identical on all three applications**. A memo that returns a stale answer would change the
graph, so byte-identical output on 7,169 files is the evidence that matters here.

## Tests

`213 passed (754 assertions)` · PHPStan level 5 + larastan **No errors** · Pint clean.

Three new, mirroring `PhpFileParserSharedCacheTest` one for one, and all about what caching can
get wrong rather than what it speeds up:

- the verdict changes once the file changes
- a file whose mtime is still in the future is not remembered at all
- a *false* verdict is remembered, not only a true one

The third is the one worth explaining. The memo stores booleans and the usual answer is false, so
a membership test that read a stored false as absent would still be correct — it would just
re-derive everything and hand back the entire saving without failing anything.

Both versions of the file in each test are written to the same byte length on purpose. The key is
path + mtime + size, so a size that moved with the content would let a broken key still pass. Each
test was checked by breaking the thing it guards: the first fails if the key drops mtime, the
second if the unsettled-file check goes, the third if the membership test treats false as absent.

## Bounds

The memo is capped at 8,000 entries with the oldest quarter evicted in one pass, which is how
`PhpFileParser` bounds the cache this one is keyed like. No build comes close — the most any of
these applications asks about is 370 distinct files, and an extractor lives exactly one build,
since `ScanCommand` constructs a `ProjectAnalyzer` per rescan. The cap is for the design
`IncrementalAnalyzer` describes, where a builder is kept across rescans and every edit mints a key
whose superseded entry would otherwise stay for the life of the process.
