### PR TITLE
Let the rules extractor read source, not only a path

### DIFF
--- a/src/Analysis/ValidationRulesExtractor.php
+++ b/src/Analysis/ValidationRulesExtractor.php
@@ -51,6 +51,13 @@ final class ValidationRulesExtractor
         $this->printer = new PrettyPrinter;
     }
 
+    /**
+     * Asking about a path goes through the memo above and, under it,
+     * {@see PhpFileParser::parse()} and the parse cache it shares with every other analyzer. Do
+     * not reroute this through the code variant below: `parseCode()` has neither, so a path
+     * handed to it is re-read and re-parsed on every call, and this question is asked thousands
+     * of times in a build.
+     */
     public function hasNonAbstractRulesMethod(string $file): bool
     {
         $stat = @stat($file);
@@ -95,17 +102,42 @@ final class ValidationRulesExtractor
 
     private function computeHasNonAbstractRulesMethod(string $file): bool
     {
-        $parsed = $this->parser->parse($file);
-        if ($parsed['ast'] === null) {
+        return $this->hasRulesMethodInAst($this->parser->parse($file)['ast']);
+    }
+
+    /**
+     * The same question, asked about source held in memory: a git blob, an unsaved editor buffer,
+     * or a file the caller has already read.
+     *
+     * Source is parsed on each call, with no cache or memo behind it, so asking this and then
+     * {@see extractFromCode()} about the same string parses it twice.
+     *
+     * They are not interchangeable, which is the reason to pay for both when you need both: a
+     * `rules()` that exists but yields nothing readable — one with no `return`, say — answers
+     * true here and `[]` there. Empty rows mean "nothing enumerable", not "no rules() method".
+     */
+    public function hasNonAbstractRulesMethodInCode(string $code): bool
+    {
+        return $this->hasRulesMethodInAst($this->parser->parseCode($code)['ast']);
+    }
+
+    /**
+     * @param  Stmt[]|null  $ast
+     */
+    private function hasRulesMethodInAst(?array $ast): bool
+    {
+        if ($ast === null) {
             return false;
         }
 
-        $method = $this->findRulesMethod($parsed['ast']);
+        $method = $this->findRulesMethod($ast);
 
         return $method !== null && ! $method->isAbstract();
     }
 
     /**
+     * Parses through the shared cache, for the reason given on {@see hasNonAbstractRulesMethod()}.
+     *
      * @return list<RuleRow>
      */
     public function extractFromFile(string $file): array
@@ -114,12 +146,28 @@ final class ValidationRulesExtractor
             return [];
         }
 
-        $parsed = $this->parser->parse($file);
-        if ($parsed['ast'] === null) {
+        return $this->extractFromAst($this->parser->parse($file)['ast']);
+    }
+
+    /**
+     * @return list<RuleRow>
+     */
+    public function extractFromCode(string $code): array
+    {
+        return $this->extractFromAst($this->parser->parseCode($code)['ast']);
+    }
+
+    /**
+     * @param  Stmt[]|null  $ast
+     * @return list<RuleRow>
+     */
+    private function extractFromAst(?array $ast): array
+    {
+        if ($ast === null) {
             return [];
         }
 
-        $method = $this->findRulesMethod($parsed['ast']);
+        $method = $this->findRulesMethod($ast);
         if ($method === null || $method->isAbstract()) {
             return [];
         }

--- a/tests/Unit/ValidationRulesExtractorTest.php
+++ b/tests/Unit/ValidationRulesExtractorTest.php
@@ -102,3 +102,81 @@ it('remembers that a file has no rules(), not just that it has one', function ()
 
     unlink($file);
 });
+
+it('answers identically for source handed over and for the file it came from', function () {
+    // Driving both variants from one fixture is what stops them drifting: a change that reaches
+    // only one of them fails here. The rows themselves are pinned by the file-variant test above,
+    // so this asserts equality rather than restating them.
+    $file = fixture('/laravel-project/app/Http/Requests/ProfileStoreRequest.php');
+    $code = (string) file_get_contents($file);
+    $extractor = new ValidationRulesExtractor;
+
+    expect($extractor->hasNonAbstractRulesMethodInCode($code))
+        ->toBe($extractor->hasNonAbstractRulesMethod($file))
+        ->toBeTrue()
+        ->and($extractor->extractFromCode($code))->toBe($extractor->extractFromFile($file))
+        ->toBeNonEmptyArray();
+});
+
+it('reads source that never was a file', function () {
+    // The point of the entry point: a caller holding source with no path to hand over.
+    $extractor = new ValidationRulesExtractor;
+
+    $rows = $extractor->extractFromCode(<<<'PHP'
+        <?php
+
+        namespace App\Http\Requests;
+
+        class InMemoryRequest extends FormRequest
+        {
+            public function rules()
+            {
+                return ['title' => 'required|string'];
+            }
+        }
+        PHP);
+
+    expect($rows)->toBe([['field' => "'title'", 'rules' => "'required|string'"]]);
+});
+
+it('says no rather than throwing when the source does not parse', function () {
+    $extractor = new ValidationRulesExtractor;
+
+    expect($extractor->hasNonAbstractRulesMethodInCode('<?php class Broken {'))->toBeFalse()
+        ->and($extractor->extractFromCode('<?php class Broken {'))->toBe([])
+        ->and($extractor->hasNonAbstractRulesMethodInCode(''))->toBeFalse()
+        ->and($extractor->extractFromCode(''))->toBe([]);
+});
+
+it('does not mistake an abstract rules() for one it can read', function () {
+    // The file variant has always drawn this line; the code variant has to draw it in the same
+    // place, and it is the one branch of the shared path a happy-path test never reaches.
+    $extractor = new ValidationRulesExtractor;
+
+    $code = <<<'PHP'
+        <?php
+
+        abstract class BaseRequest
+        {
+            abstract public function rules();
+        }
+        PHP;
+
+    expect($extractor->hasNonAbstractRulesMethodInCode($code))->toBeFalse()
+        ->and($extractor->extractFromCode($code))->toBe([]);
+});
+
+it('separates a rules() it cannot read from no rules() at all', function () {
+    // Empty rows are not absence. A rules() with nothing readable in it answers true to the one
+    // question and [] to the other, and a caller that collapses the two loses the distinction
+    // between "no validation here" and "validation this cannot enumerate".
+    $extractor = new ValidationRulesExtractor;
+
+    $unreadable = '<?php class Unreadable { public function rules() { $rules = []; } }';
+    $absent = '<?php class Absent { public function other() { return []; } }';
+
+    expect($extractor->hasNonAbstractRulesMethodInCode($unreadable))->toBeTrue()
+        ->and($extractor->extractFromCode($unreadable))->toBe([])
+        ->and($extractor->hasNonAbstractRulesMethodInCode($absent))->toBeFalse()
+        ->and($extractor->extractFromCode($absent))->toBe([]);
+});


### PR DESCRIPTION
## What

`ValidationRulesExtractor` can only be reached with a path on disk. A caller that already holds
the source has to write a temp file to ask it anything.

The parser layer below it already offers both forms — `PhpFileParser::parseCode()` sits beside
`parse()` and returns the same shape. This adds the matching pair to the extractor:

```php
$extractor->hasNonAbstractRulesMethodInCode($source);
$extractor->extractFromCode($source);
```

Three kinds of caller are shut out today: something reading a git blob, which never has a path;
an editor or language-server integration looking at an unsaved buffer; and anything that has
already read the file and would otherwise pay for a second read and a second parse.

## The file variant does not go through the code variant

The obvious refactor is to have `extractFromFile()` read the file and hand the string to
`extractFromCode()`. That would be wrong here. `PhpFileParser::parse()` is what consults the
shared parse cache; `parseCode()` always parses. `hasNonAbstractRulesMethod()` is asked thousands
of times in a build, so routing paths through the code variant re-reads and re-parses every file
on every call.

That is not a guess. Built both ways and measured a full scan:

| application | meeting after the parse | file variant delegating to the code variant |
|---|---:|---:|
| B | 1,818 ms | 5,381 ms — **3.0×** |
| A | 2,667 ms | 13,067 ms — **4.9×** |

Medians with the arms interleaved back to back, three reps on B and two on A. The spread within
each arm is under 10%, so nothing here rests on the rep count.

So the two entry points meet *after* parsing instead, at a private method taking the AST. There
is still exactly one implementation of the analysis, which is the part worth not duplicating.

Two things are worth knowing about that measurement, because both would let this regression ship
unnoticed. The test suite passes either way — a parity test compares the two variants to each
other, and both are equally correct when one is four times slower. And the parse counter reads
1,582 either way, because `PhpFileParser::$parseCount` is incremented in `parseFile()`, not in
`parseCode()`, so parses driven through the code path are invisible to it. Wall clock is the only
instrument that sees this.

## What this is not

It does not make the extractor usable for comparing two revisions of a form request. That needs
something this return shape cannot express: the ability to say *"this side cannot be
enumerated"* and stay silent. An unkeyed item or a spread can hide any number of fields, a
class-constant key resolves against whichever codebase is loaded, and a `rules()` that builds its
array up before returning it is not readable at all. `list<RuleRow>` has no way to report that —
a keyless item comes back as the field `'*'`, which is a value, not a signal. Field names also
arrive as pretty-printed source, quotes included.

Serving that would mean a second, stricter contract, which is a different change and arguably a
different package's job. This one enumerates one present-tense file for a graph.

## Nothing else moves

Full build output — graph, all subgraphs, manifest, totals, the tracer's edge list — is
byte-identical to `main` on three applications. Scan time and parse counts are unchanged against
`main` with the arms interleaved, which is what "additive" should mean.

## Tests

`230 passed (794 assertions)` · PHPStan level 5 + larastan **No errors** · Pint clean.

Five new. One asks the same fixture both ways and asserts the answers are equal, so a change that
reaches only one variant fails here. The rest cover what only the new entry point can reach:
source that never was a file, source that does not parse, an abstract `rules()` — the one branch
of the shared path a happy-path test never touches — and the difference between a `rules()` this
cannot read and no `rules()` at all, since both return no rows and only one of them means there
is no validation.

