### PR TITLE
Refuse a scoped rebuild that cannot name what it claims to rebuild

### DIFF
--- a/src/Analysis/Incremental/GraphProvenance.php
+++ b/src/Analysis/Incremental/GraphProvenance.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LaraMint\LaravelBrain\Analysis\Incremental;
 
+use LaraMint\LaravelBrain\Analysis\ProjectAnalyzer;
 use LaraMint\LaravelBrain\Graph\Graph;
 
 /**
@@ -34,6 +35,13 @@ use LaraMint\LaravelBrain\Graph\Graph;
  */
 final class GraphProvenance
 {
+    /**
+     * realpath() of each key in {@see $byFile} => that key, built on the first lookup that misses.
+     *
+     * @var array<string, string>|null
+     */
+    private ?array $resolvedKeys = null;
+
     /**
      * @param  array<string, array{nodes: string[], edges: string[]}>  $byFile
      * @param  array<string, string>  $nodeFile  nodeId => owning file
@@ -75,7 +83,7 @@ final class GraphProvenance
     {
         $ids = [];
         foreach ($files as $f) {
-            foreach ($this->byFile[$f]['nodes'] ?? [] as $id) {
+            foreach ($this->byFile[$this->recordedKey($f)]['nodes'] ?? [] as $id) {
                 $ids[] = $id;
             }
         }
@@ -88,11 +96,51 @@ final class GraphProvenance
     {
         $ids = [];
         foreach ($files as $f) {
-            foreach ($this->byFile[$f]['edges'] ?? [] as $id) {
+            foreach ($this->byFile[$this->recordedKey($f)]['edges'] ?? [] as $id) {
                 $ids[] = $id;
             }
         }
 
         return array_values(array_unique($ids));
+    }
+
+    /**
+     * The key the build recorded for this file, or the path unchanged when nothing matches it.
+     *
+     * `byFile` is keyed on `data.file` exactly as the analysis wrote it: the project root the
+     * caller passed, with a relative path appended. A caller that normalises its own paths first
+     * — `realpath()` is the obvious thing to reach for, and on macOS it rewrites `/var` to
+     * `/private/var` — would otherwise name the right file in a form nothing here recognises and
+     * silently own nothing at all. The controller filter in {@see ProjectAnalyzer::analyze()}
+     * already resolves both sides of its match; this makes the ownership lookup agree with it.
+     *
+     * Resolved lazily, and only after a verbatim lookup misses, so the case that always hits —
+     * the paths a build produced itself, which is every path watch mode passes — costs nothing.
+     */
+    private function recordedKey(string $file): string
+    {
+        if (isset($this->byFile[$file])) {
+            return $file;
+        }
+
+        $real = realpath($file);
+        if ($real === false) {
+            return $file;
+        }
+
+        if ($this->resolvedKeys === null) {
+            $this->resolvedKeys = [];
+            foreach (array_keys($this->byFile) as $known) {
+                if ($known === '') {
+                    continue;
+                }
+                $knownReal = realpath($known);
+                if ($knownReal !== false) {
+                    $this->resolvedKeys[$knownReal] = $known;
+                }
+            }
+        }
+
+        return $this->resolvedKeys[$real] ?? $file;
     }
 }

--- a/src/Analysis/ProjectAnalyzer.php
+++ b/src/Analysis/ProjectAnalyzer.php
@@ -161,6 +161,49 @@ class ProjectAnalyzer
         return $this;
     }
 
+    /**
+     * Refuse a scope that cannot name anything the previous graph owns, before any work is done.
+     *
+     * The soundness check below compares what the scope owns in the previous graph against what
+     * it owns in the fresh one. A scope naming nothing owns nothing in both, and two empty sets
+     * compare equal — so the check approves it, the merge substitutes nothing, and the previous
+     * graph is returned as though it were current. The less such a scope matches, the more
+     * confidently it passes.
+     *
+     * Path *form* is no longer a way into that: {@see GraphProvenance} resolves a caller's paths
+     * against the ones a build recorded. What is left is a path that names no file in this
+     * project at all — deleted since the previous run, from another checkout, or simply a typo —
+     * and there is no reading of that a previous graph can answer, so it is refused.
+     *
+     * A file that exists here but owns nothing is a different case and stays on the fast path.
+     * It is most of `app/` — 45% to 86% of it across the applications measured — because the
+     * graph only holds what an entry point reaches, and an edit to a file nothing reaches cannot
+     * change it without an edit to its caller, which would be in the scope and does own
+     * provenance.
+     *
+     * @param  string[]|null  $scopeToFiles
+     *
+     * @throws ScopedRebuildNotApplicable
+     */
+    private function assertScopeIsUsable(?array $scopeToFiles, string $projectRoot): void
+    {
+        if ($scopeToFiles === null) {
+            return;
+        }
+
+        $root = realpath($projectRoot);
+        if ($root === false || $scopeToFiles === []) {
+            throw new ScopedRebuildNotApplicable;
+        }
+
+        foreach ($scopeToFiles as $file) {
+            $real = realpath($file);
+            if ($real === false || ! is_file($real) || ! str_starts_with($real, $root.DIRECTORY_SEPARATOR)) {
+                throw new ScopedRebuildNotApplicable;
+            }
+        }
+    }
+
     public function analyze(string $projectRoot, ?callable $onProgress = null): AnalysisResult
     {
         if ($onProgress !== null) {
@@ -183,6 +226,7 @@ class ProjectAnalyzer
         $scopeToFiles = $this->scopeToFiles;
         $mergeInto = $this->mergeInto;
         $this->scopeToFiles = null;
+        $this->assertScopeIsUsable($scopeToFiles, $projectRoot);
         $this->mergeInto = null;
 
         $this->emit('step:start', ['step' => 'routes', 'label' => 'Scanning routes', 'message' => '  → Scanning routes...']);

--- a/tests/Unit/ScopedRebuildTest.php
+++ b/tests/Unit/ScopedRebuildTest.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Config\Repository;
+use Illuminate\Container\Container;
+use LaraMint\LaravelBrain\Analysis\Incremental\GraphProvenance;
+use LaraMint\LaravelBrain\Analysis\Incremental\ScopedRebuildNotApplicable;
+use LaraMint\LaravelBrain\Analysis\ProjectAnalyzer;
+use LaraMint\LaravelBrain\Graph\Graph;
+use LaraMint\LaravelBrain\Parser\PhpFileParser;
+
+/**
+ * The seam ProjectAnalyzer::scopedTo() exposes, which the classes under Incremental/ compose.
+ *
+ * These exist because those classes were each covered and the seam was not, and the gap hid a
+ * scope that matched nothing passing the soundness check: the check compares what the scope owns
+ * in the previous graph against what it owns in the fresh one, two empty sets compare equal, so a
+ * scope naming nothing approved itself and the previous graph came back as though it were current.
+ *
+ * Graphs are compared by their edges' endpoints, type and label rather than by counting them. The
+ * stale graph in the reported case has exactly as many nodes and edges as a correct one; what it
+ * has is the edge the edit removed and not the one the edit added. A count is blind to that.
+ */
+beforeEach(function () {
+    PhpFileParser::clearSharedCache();
+
+    $container = new Container;
+    Container::setInstance($container);
+    $container->instance('config', new Repository(['app' => ['name' => 'ScopedRebuildTest']]));
+
+    $this->root = sys_get_temp_dir().'/brain-scoped-'.uniqid();
+    mkdir($this->root.'/app/Http/Controllers', 0o777, true);
+    mkdir($this->root.'/app/Services', 0o777, true);
+    mkdir($this->root.'/routes', 0o777, true);
+
+    writeScopedSource($this->root.'/routes/web.php', <<<'PHP'
+        <?php
+
+        use App\Http\Controllers\PublishController;
+        use Illuminate\Support\Facades\Route;
+
+        Route::get('/publish', [PublishController::class, 'index']);
+        PHP);
+
+    writeScopedSource($this->root.'/app/Services/Publisher.php', <<<'PHP'
+        <?php
+
+        namespace App\Services;
+
+        class Publisher
+        {
+            public function run()
+            {
+                return 'ran';
+            }
+
+            public function log()
+            {
+                return 'logged';
+            }
+        }
+        PHP);
+
+    $this->controller = $this->root.'/app/Http/Controllers/PublishController.php';
+    writeScopedSource($this->controller, controllerCalling('run'));
+});
+
+afterEach(function () {
+    exec('rm -rf '.escapeshellarg($this->root));
+    PhpFileParser::clearSharedCache();
+    Container::setInstance(null);
+});
+
+/**
+ * Write source and pin its mtime in the past, clearing PHP's per-process stat cache so the next
+ * read sees what was just written. Same discipline as writeSource() in
+ * PhpFileParserSharedCacheTest and for the same reason: without it a second build in the same
+ * process can be answered from the first version's cached parse.
+ */
+function writeScopedSource(string $path, string $code): void
+{
+    static $age = 900;
+
+    file_put_contents($path, $code);
+    touch($path, time() - $age);
+    $age = max(10, $age - 30);
+    clearstatcache(true, $path);
+}
+
+/** The controller's action, calling one named method on the service. */
+function controllerCalling(string $method, string $extra = ''): string
+{
+    return <<<PHP
+        <?php
+
+        namespace App\Http\Controllers;
+
+        use App\Services\Publisher;
+
+        class PublishController
+        {
+            public function index(Publisher \$publisher)
+            {
+                {$extra}
+
+                return \$publisher->{$method}();
+            }
+        }
+        PHP;
+}
+
+function buildFull(string $root): Graph
+{
+    return (new ProjectAnalyzer)->analyze($root, quietly(...))->fullGraph;
+}
+
+/** @param string[] $scope */
+function buildScoped(string $root, array $scope, Graph $previous): Graph
+{
+    return (new ProjectAnalyzer)->scopedTo($scope, $previous)->analyze($root, quietly(...))->fullGraph;
+}
+
+/** Swallow the progress events, which are otherwise printed straight through the test run. */
+function quietly(string $event, array $data): void {}
+
+/**
+ * Every edge as endpoints + type + label, sorted. Two graphs agreeing here agree on what they
+ * describe, which counting nodes and edges does not establish.
+ *
+ * @return string[]
+ */
+function edgeSignature(Graph $graph): array
+{
+    $edges = [];
+    foreach ($graph->edges() as $edge) {
+        $edges[] = $edge->source.' -['.$edge->type.':'.($edge->label ?? '').']-> '.$edge->target;
+    }
+    sort($edges);
+
+    return $edges;
+}
+
+it('reproduces a full build when the edit left the call graph alone', function () {
+    $previous = buildFull($this->root);
+
+    // Same call, extra statement in front of it: the previous graph's edges still hold.
+    writeScopedSource($this->controller, controllerCalling('run', '$noop = 1;'));
+
+    $scoped = buildScoped($this->root, [$this->controller], $previous);
+
+    expect(edgeSignature($scoped))->toBe(edgeSignature(buildFull($this->root)));
+});
+
+it('refuses an edit that moved a call', function () {
+    $previous = buildFull($this->root);
+    writeScopedSource($this->controller, controllerCalling('log'));
+
+    expect(fn () => buildScoped($this->root, [$this->controller], $previous))
+        ->toThrow(ScopedRebuildNotApplicable::class);
+});
+
+it('refuses that same edit when the caller normalised the path', function () {
+    // The reported bug. Provenance keys each file as the build recorded it, and a caller that
+    // runs realpath() over its own paths names the same file in a form nothing recognises — so
+    // the scope owned nothing, the check compared two empty sets and approved, and the merge
+    // substituted nothing. What came back still carried the call that had just moved, with the
+    // same node and edge counts as a correct graph.
+    //
+    // The project is reached through a symlink made here rather than relying on the platform's
+    // temp directory being one. It is on macOS, where /var resolves to /private/var, and is not
+    // on Linux — so without this the test would quietly assert nothing there.
+    $link = sys_get_temp_dir().'/brain-scoped-link-'.uniqid();
+    if (! @symlink($this->root, $link)) {
+        $this->markTestSkipped('this platform will not make a symlink');
+    }
+
+    try {
+        $viaLink = $link.'/app/Http/Controllers/PublishController.php';
+        $previous = buildFull($link);
+        expect(array_keys(GraphProvenance::of($previous)->byFile))->toContain($viaLink);
+
+        $normalised = realpath($viaLink);
+        expect($normalised)->not->toBeFalse()
+            ->and($normalised)->not->toBe($viaLink);  // the premise: the forms really do differ
+
+        writeScopedSource($this->controller, controllerCalling('log'));
+
+        expect(fn () => buildScoped($link, [(string) $normalised], $previous))
+            ->toThrow(ScopedRebuildNotApplicable::class);
+    } finally {
+        unlink($link);
+    }
+});
+
+it('refuses a scope naming a file that is not there', function () {
+    $previous = buildFull($this->root);
+    writeScopedSource($this->controller, controllerCalling('log'));
+
+    expect(fn () => buildScoped($this->root, [$this->root.'/app/Services/Gone.php'], $previous))
+        ->toThrow(ScopedRebuildNotApplicable::class);
+});
+
+it('refuses a scope naming a file outside the project', function () {
+    $previous = buildFull($this->root);
+    $outside = sys_get_temp_dir().'/brain-scoped-outside-'.uniqid().'.php';
+    writeScopedSource($outside, "<?php\n\nclass Outside {}\n");
+
+    try {
+        expect(fn () => buildScoped($this->root, [$outside], $previous))
+            ->toThrow(ScopedRebuildNotApplicable::class);
+    } finally {
+        unlink($outside);
+    }
+});
+
+it('refuses an empty scope', function () {
+    // Nothing to substitute, so the merge would hand back the previous graph whatever had changed.
+    $previous = buildFull($this->root);
+
+    expect(fn () => buildScoped($this->root, [], $previous))
+        ->toThrow(ScopedRebuildNotApplicable::class);
+});
+
+it('still rebuilds scoped for a file the graph attributes nothing to', function () {
+    // Most of app/ is in this state — 45% to 86% across three applications — because the graph
+    // only holds what an entry point reaches. Refusing every scope that owns nothing would be
+    // sound but would send most single-file edits down the full path, so this pins that the fix
+    // did not go that far.
+    $unreached = $this->root.'/app/Services/Unreached.php';
+    writeScopedSource($unreached, "<?php\n\nnamespace App\Services;\n\nclass Unreached\n{\n    public \$name;\n}\n");
+
+    $previous = buildFull($this->root);
+    expect(GraphProvenance::of($previous)->byFile)->not->toHaveKey($unreached);
+
+    writeScopedSource($unreached, "<?php\n\nnamespace App\Services;\n\nclass Unreached\n{\n    public \$title;\n}\n");
+
+    $scoped = buildScoped($this->root, [$unreached], $previous);
+
+    expect(edgeSignature($scoped))->toBe(edgeSignature(buildFull($this->root)));
+});


### PR DESCRIPTION
Closes #83.

## What

A scoped rebuild could hand back the previous graph as though it were current.

`scopedTo($files, $previous)` matched `$files` against the project two different ways. The
controller filter resolves both sides with `realpath()`; the soundness check matched them verbatim
against the path each node recorded. Any path form only one of them accepted fell between the two.

The check compares what the scope owns in the previous graph against what it owns in the fresh
one. A scope that matches nothing owns nothing in **both**, two empty sets compare equal, the
check approves, and the merge substitutes nothing. The less a scope matched, the more confidently
it was accepted.

Reproduced with a route → controller → service fixture, editing the controller so its call moves
from `Publisher::run()` to `Publisher::log()` — the edit the check exists to refuse:

```
scope as the build recorded it   ScopedRebuildNotApplicable   correct
scope through realpath()         accepted, and the graph still says index → Publisher::run
```

Both graphs have four nodes and three edges. The stale one is not smaller, it is wrong — so a
check that counts sees nothing, which is why the tests here compare edges by endpoint, type and
label.

## Two changes

**`GraphProvenance` resolves a caller's path form.** `byFile` is keyed on `data.file` as the
analysis wrote it. A lookup that misses verbatim is retried against the recorded keys resolved
through `realpath()`, so the ownership lookup agrees with the controller filter that already
worked this way. It is lazy and only runs after a miss, so the case that always hits — every path
watch mode passes, which a build produced itself — costs nothing.

**A scope that cannot name anything is refused up front.** Path form was the common way in, not
the only one: a path naming no file at all was accepted too, with the same result. Every scoped
path now has to be an existing file inside the project, checked before any work happens. A file
deleted since the previous run, a path from another checkout, a typo, and an empty scope are all
`ScopedRebuildNotApplicable` rather than a stale graph.

## What it deliberately does not do

The issue's second suggestion was to refuse any scope matching no provenance. That is sound, and
it is too blunt: a file the graph attributes nothing to is the common case, not the exception,
because the graph only holds what an entry point reaches.

| application | php files in app/ | graph attributes something | attributes nothing |
|---|---:|---:|---:|
| A | 1,089 | 596 (55%) | 493 (45%) |
| B | 1,899 | 840 (44%) | 1,059 (56%) |
| C | 4,181 | 597 (14%) | **3,584 (86%)** |

That rule would send 45–86% of single-file edits down the full-rebuild path, which is most of what
watch mode exists to avoid, and it buys little: an edit to a file nothing reaches cannot change
the graph without an edit to its caller, and that caller is a changed file too, is therefore in
the scope, and does own provenance. A test pins that this case still takes the scoped path.

## Scope of the bug

Watch mode was never affected. `ScanCommand` passes `base_path()` unmodified into both the mtime
walk and `analyze()`, and the directory iterator preserves that form, so its scope paths and the
recorded paths agree by construction. This reached consumers calling `scopedTo()` directly, which
is how it was found.

## Tests

`217 passed (759 assertions)` · PHPStan level 5 + larastan **No errors** · Pint clean.

Seven new, and the first tests `scopedTo()` has had — the classes it composes were each covered,
the seam that composes them was not, which is why this shipped. Four fail on `main`: the
normalised path, a path naming nothing, a path outside the project, and an empty scope.

The other three pass on `main` and are there to fence the change in: a scoped rebuild still
reproduces a full build when the edit left the call graph alone, still refuses an edit that moved
a call, and still takes the scoped path for a file the graph attributes nothing to.

The normalised-path test builds through a symlink it creates rather than relying on the platform's
temp directory being one — it is on macOS, where `/var` resolves to `/private/var`, and is not on
Linux, so without that the test would quietly assert nothing on CI. It asserts the two path forms
really do differ before relying on them.

## Gate

Full build output — graph, all subgraphs, manifest, totals, the tracer's edge list — is
byte-identical to `main` on three applications, and scan time and parse counts are unchanged with
the arms interleaved.
