### PR TITLE
Run a build with the cycle collector off

### DIFF
--- a/src/Analysis/ProjectAnalyzer.php
+++ b/src/Analysis/ProjectAnalyzer.php
@@ -204,7 +204,37 @@ class ProjectAnalyzer
         }
     }
 
+    /**
+     * Runs the analysis with PHP's cycle collector switched off.
+     *
+     * That collector exists to reclaim objects which reference each other in a loop, and a build
+     * makes none. Measured across three applications it ran 15 to 37 times per build and
+     * collected **zero** objects every time, including at the deliberate `gc_collect_cycles()`
+     * further down: ASTs are trees, nothing here links a child back to its parent, and neither
+     * Node nor Edge holds a reference to the Graph — so every one of those passes walks the root
+     * buffer and finds nothing to free. Switching it off for the build is worth 3-10%, and peak
+     * memory does not move: 268 MB and 276 MB on two applications either way, and still unchanged
+     * after five builds in one process, which is what watch mode does.
+     *
+     * The caller's setting is restored afterwards, including when the analysis throws: a scoped
+     * run raises {@see ScopedRebuildNotApplicable} from the middle of a build, and the process
+     * belongs to whoever called this.
+     */
     public function analyze(string $projectRoot, ?callable $onProgress = null): AnalysisResult
+    {
+        $collectorWasEnabled = gc_enabled();
+        gc_disable();
+
+        try {
+            return $this->runAnalysis($projectRoot, $onProgress);
+        } finally {
+            if ($collectorWasEnabled) {
+                gc_enable();
+            }
+        }
+    }
+
+    private function runAnalysis(string $projectRoot, ?callable $onProgress = null): AnalysisResult
     {
         if ($onProgress !== null) {
             $this->onProgress = $onProgress;

--- a/tests/Unit/ProjectAnalyzerGcTest.php
+++ b/tests/Unit/ProjectAnalyzerGcTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Config\Repository;
+use Illuminate\Container\Container;
+use LaraMint\LaravelBrain\Analysis\ProjectAnalyzer;
+
+/**
+ * A build runs with PHP's cycle collector off, which is a global setting on someone else's
+ * process. What is worth pinning is not the speed but the borrowing: whatever the caller had, it
+ * gets back.
+ */
+beforeEach(function () {
+    $container = new Container;
+    Container::setInstance($container);
+    $container->instance('config', new Repository(['app' => ['name' => 'GcTest']]));
+
+    $this->root = sys_get_temp_dir().'/brain-gc-'.uniqid();
+    mkdir($this->root.'/app', 0o777, true);
+    mkdir($this->root.'/routes', 0o777, true);
+    file_put_contents($this->root.'/routes/web.php', "<?php\n");
+
+    $this->collectorWasEnabled = gc_enabled();
+});
+
+afterEach(function () {
+    exec('rm -rf '.escapeshellarg($this->root));
+    Container::setInstance(null);
+    $this->collectorWasEnabled ? gc_enable() : gc_disable();
+});
+
+it('gives the cycle collector back to the caller it borrowed it from', function () {
+    gc_enable();
+
+    (new ProjectAnalyzer)->analyze($this->root, function () {});
+
+    expect(gc_enabled())->toBeTrue();
+});
+
+it('gives it back even when the analysis throws', function () {
+    // A scoped run raises ScopedRebuildNotApplicable from the middle of a build, so the restore
+    // cannot sit at the end of the happy path. Thrown from the progress callback here, which
+    // needs no fixture and reaches the same finally.
+    gc_enable();
+
+    expect(fn () => (new ProjectAnalyzer)->analyze($this->root, function (): void {
+        throw new RuntimeException('from the progress callback');
+    }))->toThrow(RuntimeException::class);
+
+    expect(gc_enabled())->toBeTrue();
+});
+
+it('leaves it off for a caller that had already turned it off', function () {
+    gc_disable();
+
+    (new ProjectAnalyzer)->analyze($this->root, function () {});
+
+    expect(gc_enabled())->toBeFalse();
+});


### PR DESCRIPTION
## What

A build runs with PHP's cycle collector switched off, and the caller's setting is restored
afterwards.

That collector exists to reclaim objects which reference each other in a loop. A build makes none:
ASTs are trees, and nothing here links a child back to its parent. Measured across three
applications, the collector ran 15 to 37 times per build and collected **zero** objects every
time — including at the deliberate `gc_collect_cycles()` the analyzer already calls after
releasing the tracer's class cache. Every one of those passes walks the root buffer and finds
nothing to free.

## Cost

| application | scan before | scan after | |
|---|---:|---:|---|
| A | 1,954 ms | 1,841 ms | **−6%** |
| B | 1,263 ms | 1,211 ms | −4% |
| C | 1,156 ms | 1,134 ms | −2% |

Re-measured against `main` after #80, #81 and #84 landed — those made a scan substantially faster,
so these are smaller in absolute terms than the numbers this description carried before, and the
share is what moved. Medians of three runs with the arms interleaved in one session, each arm its
own checkout. Every individual rep favours the branch, and parse counts are identical on all
three, since nothing about what gets analysed changes.

Repeated builds in one process — what watch mode does — gain more, because the collector would
otherwise run on every one of them:

| application | five builds before | five builds after | |
|---|---:|---:|---|
| B | 4,436 ms | 3,992 ms | **−10%** |

## What it costs in memory: nothing

This is the question that decides whether the change is worth making, so it was measured rather
than argued:

| application | arm | peak | at the end | collector runs | **collected** |
|---|---|---:|---:|---:|---:|
| B, one build | before | 198 MB | 196 MB | 15 | **0** |
| B, one build | after | 196 MB | 196 MB | 1 | **0** |
| B, five builds | before | 198 MB | 196 MB | 30 | **0** |
| B, five builds | after | 198 MB | 196 MB | 5 | **0** |
| A, one build | before | 250 MB | 250 MB | 19 | **0** |
| A, one build | after | 250 MB | 250 MB | 1 | **0** |
| A, five builds | before | 252 MB | 250 MB | 37 | **0** |
| A, five builds | after | 252 MB | 250 MB | 5 | **0** |

Peak memory does not move, and does not drift across five builds in one process. The runs that
remain on the right-hand side are the explicit `gc_collect_cycles()`, one per build, which still
happens and still collects nothing.

The honest limit of that evidence: it says the collector finds no cycles in *these* applications.
An application whose graph did contain some would hold that garbage for the length of a build
rather than the length of a collection cycle.

## Giving it back

The collector is a global setting on someone else's process, so the change borrows it rather than
takes it. `gc_enabled()` is read first and restored in a `finally`, which matters because a scoped
run raises `ScopedRebuildNotApplicable` from the middle of a build — a restore at the end of the
happy path would leak the disabled state out of a rescan that watch mode then carries on with.

A caller that had already turned the collector off gets it left off.

The body of `analyze()` is unchanged; it moved into a private `runAnalysis()` so the wrapper can
be read at a glance.

## Gate

Full build output — graph, all subgraphs, manifest, totals, the tracer's edge list — is
byte-identical to `main` on three applications.

## Tests

`228 passed (782 assertions)` · PHPStan level 5 + larastan **No errors** · Pint clean.

Three new, all about the borrowing rather than the speed: the collector is given back, it is
given back when the analysis throws, and a caller who had it off keeps it off. Each was checked by
breaking what it guards — dropping the `finally` kills the second, restoring unconditionally kills
the third.

