### PR TITLE
Feat: modular filament support

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,20 @@ This produces the full edge list used to build the graph.
 
 When Filament is installed, the scanner discovers every panel registered via service providers, then resolves its resources, pages, widgets, and relation managers — both explicitly listed (`->resources([...])`) and auto-discovered (`->discoverResources(for: '...')`). Filament page methods are traced through the same call-chain engine as controller actions, so models and services they touch appear in the graph.
 
+Resources and relation managers are recognised through their whole `extends` chain, so a project base class (`class OrderResource extends AppResource`, `AppResource extends Resource`) does not hide them.
+
+Applications that keep their Filament classes somewhere other than `app/Filament` - a modular monolith with no `app/` directory, for instance — point the scanner at their own layout. An entry is used as-is when it is a directory and expanded as a glob pattern otherwise:
+
+```php
+// config/laravel-brain.php
+'filament' => [
+    'panel_paths' => ['app-modules/*/src/Filament'],
+    'paths' => ['app-modules/*/src/Filament'],
+],
+```
+
+A file named `*PanelProvider.php` is treated as a panel by convention. Any other file counts as a panel only when it actually builds a `Panel::make()` chain, so pointing `panel_paths` at a whole source tree does not turn every class into a panel.
+
 ## Graph Node Types
 
 | Node | Accent Color | Represents |

--- a/config/laravel-brain.php
+++ b/config/laravel-brain.php
@@ -301,6 +301,39 @@ return [
     ],
 
     // -------------------------------------------------------------------------
+    // Filament Search Paths
+    // -------------------------------------------------------------------------
+    // Directories (relative to the project root) scanned for Filament panels and
+    // for the resources, pages, widgets and relation managers they expose.
+    //
+    // An entry is used as-is when it is a directory and expanded as a glob pattern
+    // otherwise, so a modular monolith that keeps no app/ directory can point these
+    // at its packages:
+    //
+    //   'panel_paths' => ['app-modules/*/src/Filament'],
+    //   'paths'       => ['app-modules/*/src/Filament'],
+    //
+    // panel_paths  Where panels are declared. A file named *PanelProvider.php is
+    //              treated as a panel by convention (that is what Filament's own
+    //              installer writes); any other file counts only when it actually
+    //              builds a Panel::make() chain, so pointing this at a whole source
+    //              tree does not turn every class into a panel.
+    //
+    // paths        Roots of the Filament class tree. Resources are recognised by a
+    //              Resources/ path segment, pages by Pages/, widgets by Widgets/ and
+    //              relation managers by RelationManagers/ — the layout Filament's
+    //              generators produce.
+    //
+    'filament' => [
+        'panel_paths' => [
+            'app/Providers/Filament',
+        ],
+        'paths' => [
+            'app/Filament',
+        ],
+    ],
+
+    // -------------------------------------------------------------------------
     // Livewire Component Search Paths
     // -------------------------------------------------------------------------
     // Directories (relative to project root) that are searched when resolving

--- a/src/Analysis/FilamentAnalyzer.php
+++ b/src/Analysis/FilamentAnalyzer.php
@@ -94,11 +94,122 @@ class FilamentRelationManagerDefinition
 
 class FilamentAnalyzer
 {
+    /**
+     * Where panels are declared in a default Laravel skeleton.
+     *
+     * @var string[]
+     */
+    public const DEFAULT_PANEL_PATHS = ['app/Providers/Filament'];
+
+    /**
+     * Where resources, pages, widgets and relation managers live in a default
+     * Laravel skeleton.
+     *
+     * @var string[]
+     */
+    public const DEFAULT_PATHS = ['app/Filament'];
+
     private PhpFileParser $parser;
 
-    public function __construct()
-    {
+    /** @var string[] */
+    private array $panelPaths;
+
+    /** @var string[] */
+    private array $paths;
+
+    /**
+     * class FQCN => parent FQCN, collected from the scanned Filament trees so a
+     * resource or relation manager that extends a project base class is still
+     * recognised.
+     *
+     * @var array<string, string>
+     */
+    private array $classParents = [];
+
+    /**
+     * @param  string[]  $panelPaths  directories holding panel definitions, relative to the
+     *                                project root; glob patterns are expanded
+     * @param  string[]  $paths  directories holding resources, pages, widgets and relation
+     *                           managers, relative to the project root; glob patterns are
+     *                           expanded
+     */
+    public function __construct(
+        array $panelPaths = self::DEFAULT_PANEL_PATHS,
+        array $paths = self::DEFAULT_PATHS,
+    ) {
         $this->parser = new PhpFileParser;
+        $this->panelPaths = $panelPaths;
+        $this->paths = $paths;
+    }
+
+    /**
+     * Expand the configured relative paths into absolute directories that exist.
+     * An entry is used verbatim when it is a directory and treated as a glob
+     * pattern otherwise, so a pattern such as `app-modules/*` + `/src/Filament`
+     * works for a modular monolith that keeps no `app/` directory at all.
+     *
+     * @param  string[]  $relativePaths
+     * @return string[] absolute directories
+     */
+    private function resolveDirs(string $projectRoot, array $relativePaths): array
+    {
+        $dirs = [];
+
+        foreach ($relativePaths as $relativePath) {
+            $relativePath = trim((string) $relativePath);
+            if ($relativePath === '') {
+                continue;
+            }
+
+            $absolute = rtrim($projectRoot, '/').'/'.ltrim($relativePath, '/');
+            if (is_dir($absolute)) {
+                $dirs[] = $absolute;
+
+                continue;
+            }
+
+            foreach (glob($absolute, GLOB_ONLYDIR | GLOB_BRACE) ?: [] as $match) {
+                $dirs[] = $match;
+            }
+        }
+
+        return array_values(array_unique($dirs));
+    }
+
+    /**
+     * Every PHP file below the given absolute directories, each file yielded once
+     * even when the directories overlap.
+     *
+     * @param  string[]  $dirs  absolute directories
+     * @return iterable<\SplFileInfo>
+     */
+    private function phpFilesIn(array $dirs): iterable
+    {
+        $seen = [];
+
+        foreach ($dirs as $dir) {
+            if (! is_dir($dir)) {
+                continue;
+            }
+
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS)
+            );
+
+            foreach ($iterator as $entry) {
+                if (! $entry->isFile() || $entry->getExtension() !== 'php') {
+                    continue;
+                }
+
+                $realPath = $entry->getRealPath() ?: $entry->getPathname();
+                if (isset($seen[$realPath])) {
+                    continue;
+                }
+                $seen[$realPath] = true;
+
+                yield $entry;
+            }
+        }
     }
 
     /**
@@ -126,11 +237,14 @@ class FilamentAnalyzer
             return $empty;
         }
 
+        $dirs = $this->resolveDirs($projectRoot, $this->paths);
+        $this->classParents = $this->collectClassParents($dirs);
+
         $panels = $this->scanPanels($projectRoot);
-        $resources = $this->scanResources($projectRoot, $panels);
-        $pages = $this->scanPages($projectRoot, $panels);
-        $widgets = $this->scanWidgets($projectRoot, $panels);
-        $relationManagers = $this->scanRelationManagers($projectRoot);
+        $resources = $this->scanResources($dirs, $panels);
+        $pages = $this->scanPages($dirs, $panels);
+        $widgets = $this->scanWidgets($dirs, $panels);
+        $relationManagers = $this->scanRelationManagers($dirs);
 
         return [
             'detected' => true,
@@ -142,35 +256,108 @@ class FilamentAnalyzer
         ];
     }
 
-    // ── Panel scanning ────────────────────────────────────────────────────────
-
-    /** @return FilamentPanelDefinition[] */
-    private function scanPanels(string $projectRoot): array
+    /**
+     * Map every class declared in the scanned trees to the class it extends, with the
+     * parent resolved through the declaring file's use map.
+     *
+     * @param  string[]  $dirs  absolute directories
+     * @return array<string, string>
+     */
+    private function collectClassParents(array $dirs): array
     {
-        $panelsDir = $projectRoot.'/app/Providers/Filament';
-        if (! is_dir($panelsDir)) {
-            return [];
-        }
+        $parents = [];
 
-        $panels = [];
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($panelsDir, \FilesystemIterator::SKIP_DOTS)
-        );
-
-        foreach ($iterator as $entry) {
-            if (! $entry->isFile() || $entry->getExtension() !== 'php') {
-                continue;
-            }
-            if (! str_ends_with($entry->getBasename(), 'PanelProvider.php')) {
-                continue;
-            }
-
+        foreach ($this->phpFilesIn($dirs) as $entry) {
             $parsed = $this->parser->parse($entry->getPathname());
             if (! $parsed || ! $parsed['ast']) {
                 continue;
             }
 
-            $def = $this->extractPanel($parsed['ast'], $parsed['useMap'], $entry->getPathname());
+            $traverser = new NodeTraverser;
+            $visitor = new class($parsed['useMap']) extends NodeVisitorAbstract
+            {
+                /** @var array<string, string> */
+                public array $found = [];
+
+                private string $namespace = '';
+
+                public function __construct(private array $useMap) {}
+
+                public function enterNode(Node $node): ?int
+                {
+                    if ($node instanceof Node\Stmt\Namespace_) {
+                        $this->namespace = $node->name ? $node->name->toString() : '';
+                    }
+
+                    if ($node instanceof Node\Stmt\Class_ && $node->name !== null && $node->extends instanceof Node\Name) {
+                        $fqcn = $this->namespace !== ''
+                            ? $this->namespace.'\\'.$node->name->toString()
+                            : $node->name->toString();
+                        $parent = $node->extends->toString();
+                        $this->found[$fqcn] = ltrim($this->useMap[$parent] ?? $parent, '\\');
+                    }
+
+                    return null;
+                }
+            };
+
+            $traverser->addVisitor($visitor);
+            $traverser->traverse($parsed['ast']);
+
+            $parents += $visitor->found;
+        }
+
+        return $parents;
+    }
+
+    /**
+     * Whether an `extends` chain reaches a Filament base class of the given short name.
+     * Only the chain recorded from the scanned files is walked — a base class living in
+     * vendor/ is never parsed, so the walk ends there and the short name decides, exactly
+     * as the direct parent check always did. The chain is what lets a project's own
+     * `AppResource extends Resource` sit between Filament and every real resource.
+     */
+    private function descendsFrom(string $parentFqcn, string $baseShortName, int $depth = 0): bool
+    {
+        if ($parentFqcn === '' || $depth > 20) {
+            return false;
+        }
+
+        $position = strrpos($parentFqcn, '\\');
+        $shortName = $position === false ? $parentFqcn : substr($parentFqcn, $position + 1);
+
+        if ($shortName === $baseShortName) {
+            return true;
+        }
+
+        return $this->descendsFrom($this->classParents[$parentFqcn] ?? '', $baseShortName, $depth + 1);
+    }
+
+    // ── Panel scanning ────────────────────────────────────────────────────────
+
+    /** @return FilamentPanelDefinition[] */
+    private function scanPanels(string $projectRoot): array
+    {
+        $panels = [];
+
+        foreach ($this->phpFilesIn($this->resolveDirs($projectRoot, $this->panelPaths)) as $entry) {
+            $parsed = $this->parser->parse($entry->getPathname());
+            if (! $parsed || ! $parsed['ast']) {
+                continue;
+            }
+
+            // A `*PanelProvider.php` is a panel by convention — that is the file Filament's own
+            // installer writes, and it configures the injected $panel rather than building one.
+            // Any other file counts only when it actually builds a `Panel::make()` chain, so
+            // pointing panel_paths at a whole source tree cannot turn every class into a panel.
+            $byConvention = str_ends_with($entry->getBasename(), 'PanelProvider.php');
+
+            $def = $this->extractPanel(
+                $parsed['ast'],
+                $parsed['useMap'],
+                $entry->getPathname(),
+                requiresPanelBuilder: ! $byConvention,
+            );
             if ($def !== null) {
                 $panels[] = $def;
             }
@@ -179,10 +366,14 @@ class FilamentAnalyzer
         return $panels;
     }
 
-    private function extractPanel(array $ast, array $useMap, string $file): ?FilamentPanelDefinition
-    {
+    private function extractPanel(
+        array $ast,
+        array $useMap,
+        string $file,
+        bool $requiresPanelBuilder = false,
+    ): ?FilamentPanelDefinition {
         $traverser = new NodeTraverser;
-        $visitor = new class($file, $useMap) extends NodeVisitorAbstract
+        $visitor = new class($file, $useMap, $requiresPanelBuilder) extends NodeVisitorAbstract
         {
             public ?FilamentPanelDefinition $result = null;
 
@@ -212,9 +403,12 @@ class FilamentAnalyzer
             /** @var string[] */
             private array $discoverWidgetsFor = [];
 
+            private bool $sawPanelBuilder = false;
+
             public function __construct(
                 private string $file,
                 private array $useMap,
+                private bool $requiresPanelBuilder,
             ) {}
 
             public function enterNode(Node $node): ?int
@@ -225,6 +419,17 @@ class FilamentAnalyzer
 
                 if ($node instanceof Node\Stmt\Class_) {
                     $this->className = $node->name ? $node->name->toString() : '';
+                }
+
+                // Detect `Panel::make()` — the shape a panel registered outside the
+                // *PanelProvider convention takes (a plugin class, a factory, a provider
+                // that builds its own panel).
+                if ($node instanceof Node\Expr\StaticCall
+                    && $node->name instanceof Node\Identifier
+                    && $node->name->toString() === 'make'
+                    && $node->class instanceof Node\Name
+                    && $this->resolvesToPanel($node->class->toString())) {
+                    $this->sawPanelBuilder = true;
                 }
 
                 // Detect ->id('admin') method chains
@@ -284,6 +489,9 @@ class FilamentAnalyzer
                 if ($this->className === '') {
                     return null;
                 }
+                if ($this->requiresPanelBuilder && ! $this->sawPanelBuilder) {
+                    return null;
+                }
                 $fqcn = $this->namespace !== ''
                     ? $this->namespace.'\\'.$this->className
                     : $this->className;
@@ -302,6 +510,17 @@ class FilamentAnalyzer
                 );
 
                 return null;
+            }
+
+            /**
+             * Whether a class name written in the source refers to Filament's Panel,
+             * resolved through the file's use map so an aliased import still matches.
+             */
+            private function resolvesToPanel(string $name): bool
+            {
+                $resolved = $this->useMap[$name] ?? $name;
+
+                return ltrim($resolved, '\\') === 'Filament\\Panel';
             }
 
             /**
@@ -362,13 +581,8 @@ class FilamentAnalyzer
      * @param  FilamentPanelDefinition[]  $panels
      * @return FilamentResourceDefinition[]
      */
-    private function scanResources(string $projectRoot, array &$panels): array
+    private function scanResources(array $dirs, array &$panels): array
     {
-        $filamentDir = $projectRoot.'/app/Filament';
-        if (! is_dir($filamentDir)) {
-            return [];
-        }
-
         // Build reverse map: explicit resource FQCN => panelId
         $resourceToPanelId = [];
         foreach ($panels as $panel) {
@@ -379,18 +593,12 @@ class FilamentAnalyzer
 
         $resources = [];
 
-        // Scan all PHP files under app/Filament/ recursively.
+        // Scan all PHP files under the configured Filament directories recursively.
         // Only process files inside a Resources/ directory; skip files that live in
         // known non-resource sub-directories (Pages, RelationManagers, Schemas, Tables, Widgets).
         // This supports both flat layouts (Resources/PostResource.php) and grouped layouts
         // (Resources/Shop/Products/ProductResource.php).
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($filamentDir, \FilesystemIterator::SKIP_DOTS)
-        );
-        foreach ($iterator as $entry) {
-            if (! $entry->isFile() || $entry->getExtension() !== 'php') {
-                continue;
-            }
+        foreach ($this->phpFilesIn($dirs) as $entry) {
             $normalizedPath = str_replace('\\', '/', $entry->getPathname());
             if (! str_contains($normalizedPath, '/Resources/')) {
                 continue;
@@ -513,7 +721,7 @@ class FilamentAnalyzer
 
             private string $slug = '';
 
-            private bool $isResource = false;
+            public string $parentFqcn = '';
 
             /** @var array<string, string> */
             private array $pages = [];
@@ -534,10 +742,9 @@ class FilamentAnalyzer
 
                 if ($node instanceof Node\Stmt\Class_) {
                     $this->className = $node->name ? $node->name->toString() : '';
-                    // Check if extends Resource
                     if ($node->extends instanceof Node\Name) {
-                        $parent = $node->extends->getLast();
-                        $this->isResource = $parent === 'Resource';
+                        $parent = $node->extends->toString();
+                        $this->parentFqcn = ltrim($this->useMap[$parent] ?? $parent, '\\');
                     }
                 }
 
@@ -585,7 +792,7 @@ class FilamentAnalyzer
 
             public function afterTraverse(array $nodes): ?array
             {
-                if ($this->className === '' || ! $this->isResource) {
+                if ($this->className === '') {
                     return null;
                 }
                 $fqcn = $this->namespace !== ''
@@ -683,6 +890,10 @@ class FilamentAnalyzer
         $traverser->addVisitor($visitor);
         $traverser->traverse($ast);
 
+        if (! $this->descendsFrom($visitor->parentFqcn, 'Resource')) {
+            return null;
+        }
+
         return $visitor->result;
     }
 
@@ -692,32 +903,23 @@ class FilamentAnalyzer
      * @param  FilamentPanelDefinition[]  $panels
      * @return FilamentPageDefinition[]
      */
-    private function scanPages(string $projectRoot, array &$panels): array
+    private function scanPages(array $dirs, array &$panels): array
     {
         $pages = [];
 
-        // Scan the entire app/Filament/ tree once and categorise pages by path.
+        // Scan the configured Filament directories once and categorise pages by path.
         // - Resource pages: live inside a Resources/ directory AND inside a Pages/ sub-directory.
         // - Custom pages:   live inside a Pages/ directory but NOT inside a Resources/ directory.
         //   This covers both the standard app/Filament/Pages/ location and non-standard
         //   panel layouts such as app/Filament/App/Pages/ (common in Filament v3+ multi-panel apps).
-        $filamentDir = $projectRoot.'/app/Filament';
-        if (is_dir($filamentDir)) {
-            $iterator = new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator($filamentDir, \FilesystemIterator::SKIP_DOTS)
-            );
-            foreach ($iterator as $entry) {
-                if (! $entry->isFile() || $entry->getExtension() !== 'php') {
-                    continue;
-                }
-                $normalizedPath = str_replace('\\', '/', $entry->getPathname());
-                if (! str_contains($normalizedPath, '/Pages/')) {
-                    continue;
-                }
-                $def = $this->extractPage($entry->getPathname());
-                if ($def !== null) {
-                    $pages[] = $def;
-                }
+        foreach ($this->phpFilesIn($dirs) as $entry) {
+            $normalizedPath = str_replace('\\', '/', $entry->getPathname());
+            if (! str_contains($normalizedPath, '/Pages/')) {
+                continue;
+            }
+            $def = $this->extractPage($entry->getPathname());
+            if ($def !== null) {
+                $pages[] = $def;
             }
         }
 
@@ -901,61 +1103,20 @@ class FilamentAnalyzer
      * @param  FilamentPanelDefinition[]  $panels
      * @return FilamentWidgetDefinition[]
      */
-    private function scanWidgets(string $projectRoot, array &$panels): array
+    private function scanWidgets(array $dirs, array &$panels): array
     {
         $widgets = [];
-        $seenFiles = [];
 
-        // Helper closure to scan a directory recursively for widget PHP files.
-        $scanDir = function (string $dir) use (&$widgets, &$seenFiles): void {
-            if (! is_dir($dir)) {
-                return;
+        // Every file below a Widgets/ directory anywhere in the configured Filament trees:
+        // the panel-level app/Filament/Widgets/ as well as widgets co-located with a resource
+        // (app/Filament/Resources/**/Widgets/, the Filament v3+ grouped-resource pattern).
+        foreach ($this->phpFilesIn($dirs) as $entry) {
+            if (! str_contains(str_replace('\\', '/', $entry->getPathname()), '/Widgets/')) {
+                continue;
             }
-            $iterator = new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS)
-            );
-            foreach ($iterator as $entry) {
-                if (! $entry->isFile() || $entry->getExtension() !== 'php') {
-                    continue;
-                }
-                $realPath = $entry->getRealPath();
-                if (isset($seenFiles[$realPath])) {
-                    continue;
-                }
-                $seenFiles[$realPath] = true;
-                $def = $this->extractWidget($entry->getPathname());
-                if ($def !== null) {
-                    $widgets[] = $def;
-                }
-            }
-        };
-
-        // Standard panel-level widgets: app/Filament/Widgets/
-        $scanDir($projectRoot.'/app/Filament/Widgets');
-
-        // Widgets co-located with resources (Filament v3+ grouped-resource pattern):
-        // app/Filament/Resources/**/Widgets/
-        $resourcesDir = $projectRoot.'/app/Filament/Resources';
-        if (is_dir($resourcesDir)) {
-            $iterator = new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator($resourcesDir, \FilesystemIterator::SKIP_DOTS)
-            );
-            foreach ($iterator as $entry) {
-                if (! $entry->isFile() || $entry->getExtension() !== 'php') {
-                    continue;
-                }
-                if (! str_contains(str_replace('\\', '/', $entry->getPathname()), '/Widgets/')) {
-                    continue;
-                }
-                $realPath = $entry->getRealPath();
-                if (isset($seenFiles[$realPath])) {
-                    continue;
-                }
-                $seenFiles[$realPath] = true;
-                $def = $this->extractWidget($entry->getPathname());
-                if ($def !== null) {
-                    $widgets[] = $def;
-                }
+            $def = $this->extractWidget($entry->getPathname());
+            if ($def !== null) {
+                $widgets[] = $def;
             }
         }
 
@@ -1066,22 +1227,11 @@ class FilamentAnalyzer
     // ── Relation Manager scanning ─────────────────────────────────────────────
 
     /** @return FilamentRelationManagerDefinition[] */
-    private function scanRelationManagers(string $projectRoot): array
+    private function scanRelationManagers(array $dirs): array
     {
-        $filamentDir = $projectRoot.'/app/Filament';
-        if (! is_dir($filamentDir)) {
-            return [];
-        }
-
         $managers = [];
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($filamentDir, \FilesystemIterator::SKIP_DOTS)
-        );
 
-        foreach ($iterator as $entry) {
-            if (! $entry->isFile() || $entry->getExtension() !== 'php') {
-                continue;
-            }
+        foreach ($this->phpFilesIn($dirs) as $entry) {
             if (! str_contains(str_replace('\\', '/', $entry->getPathname()), '/RelationManagers/')) {
                 continue;
             }
@@ -1103,7 +1253,7 @@ class FilamentAnalyzer
         }
 
         $traverser = new NodeTraverser;
-        $visitor = new class($file) extends NodeVisitorAbstract
+        $visitor = new class($file, $parsed['useMap']) extends NodeVisitorAbstract
         {
             public ?FilamentRelationManagerDefinition $result = null;
 
@@ -1111,11 +1261,11 @@ class FilamentAnalyzer
 
             private string $className = '';
 
-            private string $parentClass = '';
+            public string $parentFqcn = '';
 
             private string $relationship = '';
 
-            public function __construct(private string $file) {}
+            public function __construct(private string $file, private array $useMap) {}
 
             public function enterNode(Node $node): ?int
             {
@@ -1126,7 +1276,8 @@ class FilamentAnalyzer
                 if ($node instanceof Node\Stmt\Class_) {
                     $this->className = $node->name ? $node->name->toString() : '';
                     if ($node->extends instanceof Node\Name) {
-                        $this->parentClass = $node->extends->getLast();
+                        $parent = $node->extends->toString();
+                        $this->parentFqcn = ltrim($this->useMap[$parent] ?? $parent, '\\');
                     }
                 }
 
@@ -1147,7 +1298,7 @@ class FilamentAnalyzer
 
             public function afterTraverse(array $nodes): ?array
             {
-                if ($this->className === '' || $this->parentClass !== 'RelationManager') {
+                if ($this->className === '') {
                     return null;
                 }
 
@@ -1176,6 +1327,10 @@ class FilamentAnalyzer
 
         $traverser->addVisitor($visitor);
         $traverser->traverse($parsed['ast']);
+
+        if (! $this->descendsFrom($visitor->parentFqcn, 'RelationManager')) {
+            return null;
+        }
 
         return $visitor->result;
     }

--- a/src/Analysis/FilamentAnalyzer.php
+++ b/src/Analysis/FilamentAnalyzer.php
@@ -143,6 +143,27 @@ class FilamentAnalyzer
     }
 
     /**
+     * The fully-qualified name of the class an `extends` clause points at.
+     *
+     * The use map alone is not enough: a base class in the same namespace as its children needs
+     * no import, so nobody writes one, and the clause is a bare short name that matches nothing
+     * in a map keyed by FQCN. The parser's resolved name covers that — it is the namespace
+     * resolution PHP itself would do — and the use map stays as the fallback for a file the
+     * resolver could not annotate.
+     *
+     * Every site that reads an `extends` clause has to agree on this, or one of them hands a
+     * short name to a chain walk keyed by FQCN and the class silently stops being recognised.
+     *
+     * @param  array<string, string>  $useMap
+     */
+    public static function parentFqcn(Node\Name $extends, array $useMap): string
+    {
+        $written = $extends->toString();
+
+        return ltrim(PhpFileParser::resolvedName($extends) ?? ($useMap[$written] ?? $written), '\\');
+    }
+
+    /**
      * Expand the configured relative paths into absolute directories that exist.
      * An entry is used verbatim when it is a directory and treated as a glob
      * pattern otherwise, so a pattern such as `app-modules/*` + `/src/Filament`
@@ -293,8 +314,8 @@ class FilamentAnalyzer
                         $fqcn = $this->namespace !== ''
                             ? $this->namespace.'\\'.$node->name->toString()
                             : $node->name->toString();
-                        $parent = $node->extends->toString();
-                        $this->found[$fqcn] = ltrim($this->useMap[$parent] ?? $parent, '\\');
+                        // `self::` inside an anonymous class is the anonymous class, not this one.
+                        $this->found[$fqcn] = FilamentAnalyzer::parentFqcn($node->extends, $this->useMap);
                     }
 
                     return null;
@@ -743,8 +764,7 @@ class FilamentAnalyzer
                 if ($node instanceof Node\Stmt\Class_) {
                     $this->className = $node->name ? $node->name->toString() : '';
                     if ($node->extends instanceof Node\Name) {
-                        $parent = $node->extends->toString();
-                        $this->parentFqcn = ltrim($this->useMap[$parent] ?? $parent, '\\');
+                        $this->parentFqcn = FilamentAnalyzer::parentFqcn($node->extends, $this->useMap);
                     }
                 }
 
@@ -1276,8 +1296,7 @@ class FilamentAnalyzer
                 if ($node instanceof Node\Stmt\Class_) {
                     $this->className = $node->name ? $node->name->toString() : '';
                     if ($node->extends instanceof Node\Name) {
-                        $parent = $node->extends->toString();
-                        $this->parentFqcn = ltrim($this->useMap[$parent] ?? $parent, '\\');
+                        $this->parentFqcn = FilamentAnalyzer::parentFqcn($node->extends, $this->useMap);
                     }
                 }
 

--- a/src/Analysis/ProjectAnalyzer.php
+++ b/src/Analysis/ProjectAnalyzer.php
@@ -112,7 +112,12 @@ class ProjectAnalyzer
         $this->methodTracer = new MethodTracer(is_array($dispatchHelpers) ? $dispatchHelpers : []);
         $modelPaths = config('laravel-brain.models.paths', ['app/Models']);
         $this->modelAnalyzer = new ModelAnalyzer(is_array($modelPaths) ? $modelPaths : []);
-        $this->filamentAnalyzer = new FilamentAnalyzer;
+        $filamentPanelPaths = config('laravel-brain.filament.panel_paths', FilamentAnalyzer::DEFAULT_PANEL_PATHS);
+        $filamentPaths = config('laravel-brain.filament.paths', FilamentAnalyzer::DEFAULT_PATHS);
+        $this->filamentAnalyzer = new FilamentAnalyzer(
+            is_array($filamentPanelPaths) ? $filamentPanelPaths : FilamentAnalyzer::DEFAULT_PANEL_PATHS,
+            is_array($filamentPaths) ? $filamentPaths : FilamentAnalyzer::DEFAULT_PATHS,
+        );
         $this->queryTracer = new QueryTracer;
         $this->securityAnalyzer = new SecurityAnalyzer(
             extraAuthPatterns: $this->stringList(config('laravel-brain.security.auth_middleware', [])),

--- a/tests/Unit/FilamentAnalyzerTest.php
+++ b/tests/Unit/FilamentAnalyzerTest.php
@@ -288,3 +288,36 @@ function modularAnalyzer(): FilamentAnalyzer
         paths: ['app-modules/*/src/Filament'],
     );
 }
+
+// ── A base class in the same namespace needs no import ───────────────────────
+
+function sameNamespaceAnalyzer(): FilamentAnalyzer
+{
+    return new FilamentAnalyzer(
+        panelPaths: ['app-modules/*/src/Filament'],
+        paths: ['app-modules/*/src/Filament'],
+    );
+}
+
+it('recognises a resource whose base class sits in its own namespace', function () {
+    // PHP needs no `use` for a class in the same namespace, so nobody writes one and the
+    // parent is a bare short name. Resolving it through the use map alone finds nothing.
+    $result = sameNamespaceAnalyzer()->analyze(fixture('filament-same-namespace-project'));
+
+    $fqcns = array_map(fn (FilamentResourceDefinition $r): string => $r->fqcn, $result['resources']);
+
+    expect($fqcns)->toContain('Modules\\Catalog\\Filament\\Resources\\ProductResource');
+});
+
+it('recognises a relation manager whose base class sits in its own namespace', function () {
+    $result = sameNamespaceAnalyzer()->analyze(fixture('filament-same-namespace-project'));
+
+    $fqcns = array_map(
+        fn (FilamentRelationManagerDefinition $m): string => $m->fqcn,
+        $result['relationManagers'],
+    );
+
+    expect($fqcns)->toContain(
+        'Modules\\Catalog\\Filament\\Resources\\ProductResource\\RelationManagers\\PricesRelationManager',
+    );
+});

--- a/tests/Unit/FilamentAnalyzerTest.php
+++ b/tests/Unit/FilamentAnalyzerTest.php
@@ -184,3 +184,107 @@ it('attaches the panel ID to discovered resources', function () {
         ->ToBeInstanceOf(FilamentResourceDefinition::class)
         ->panelId->toBe('admin');
 });
+
+// ── Configurable search paths (modular monolith, no app/ directory) ───────────
+
+it('finds nothing in a modular project while the default app/ paths are used', function () {
+    $result = (new FilamentAnalyzer)->analyze(fixture('filament-modular-project'));
+
+    expect($result['detected'])->toBeTrue()
+        ->and($result['panels'])->toBe([])
+        ->and($result['resources'])->toBe([])
+        ->and($result['pages'])->toBe([])
+        ->and($result['widgets'])->toBe([])
+        ->and($result['relationManagers'])->toBe([]);
+});
+
+it('expands glob patterns in the configured paths', function () {
+    $result = modularAnalyzer()->analyze(fixture('filament-modular-project'));
+
+    expect($result['resources'])
+        ->toHaveCount(1)
+        ->andArrayFirstElement()
+        ->ToBeInstanceOf(FilamentResourceDefinition::class)
+        ->fqcn->toBe('Modules\\Shop\\Filament\\Resources\\OrderResource')
+        ->modelFqcn->toBe('Modules\\Shop\\Models\\Order');
+});
+
+it('extracts a panel that is not named *PanelProvider', function () {
+    $result = modularAnalyzer()->analyze(fixture('filament-modular-project'));
+
+    expect($result['panels'])
+        ->toHaveCount(1)
+        ->andArrayFirstElement()
+        ->ToBeInstanceOf(FilamentPanelDefinition::class)
+        ->id->toBe('shop')
+        ->path->toBe('shop')
+        ->fqcn->toBe('Modules\\Shop\\Filament\\ShopPanel')
+        ->resources->toBe(['Modules\\Shop\\Filament\\Resources\\OrderResource']);
+});
+
+it('does not treat every class under a panel path as a panel', function () {
+    $result = modularAnalyzer()->analyze(fixture('filament-modular-project'));
+
+    $fqcns = array_map(fn (FilamentPanelDefinition $panel): string => $panel->fqcn, $result['panels']);
+
+    expect($fqcns)->not->toContain('Modules\\Shop\\Filament\\ShopTheme');
+});
+
+it('collects pages, widgets and relation managers across modules', function () {
+    $result = modularAnalyzer()->analyze(fixture('filament-modular-project'));
+
+    $pages = array_map(fn (FilamentPageDefinition $page): string => $page->fqcn, $result['pages']);
+    $widgets = array_map(fn (FilamentWidgetDefinition $widget): string => $widget->fqcn, $result['widgets']);
+    $managers = array_map(
+        fn (FilamentRelationManagerDefinition $manager): string => $manager->fqcn,
+        $result['relationManagers'],
+    );
+
+    expect($pages)->toContain('Modules\\Shop\\Filament\\Resources\\OrderResource\\Pages\\ListOrders')
+        ->and($pages)->toContain('Modules\\Blog\\Filament\\Pages\\BlogSettings')
+        ->and($widgets)->toBe(['Modules\\Shop\\Filament\\Widgets\\OrderStatsWidget'])
+        ->and($managers)->toBe([
+            'Modules\\Shop\\Filament\\Resources\\OrderResource\\RelationManagers\\ItemsRelationManager',
+        ]);
+});
+
+it('scans nothing when the configured paths are empty', function () {
+    $result = (new FilamentAnalyzer([], []))->analyze(fixture('filament-project'));
+
+    expect($result['detected'])->toBeTrue()
+        ->and($result['panels'])->toBe([])
+        ->and($result['resources'])->toBe([]);
+});
+
+it('recognises a resource and a relation manager that extend a project base class', function () {
+    $result = modularAnalyzer()->analyze(fixture('filament-modular-project'));
+
+    // OrderResource extends ShopResource extends Resource, and ItemsRelationManager
+    // extends ShopRelationManager extends RelationManager — a single-level `extends`
+    // check finds neither.
+    expect($result['resources'])
+        ->toHaveCount(1)
+        ->andArrayFirstElement()
+        ->fqcn->toBe('Modules\\Shop\\Filament\\Resources\\OrderResource');
+
+    expect($result['relationManagers'])
+        ->toHaveCount(1)
+        ->andArrayFirstElement()
+        ->fqcn->toBe('Modules\\Shop\\Filament\\Resources\\OrderResource\\RelationManagers\\ItemsRelationManager');
+});
+
+it('does not treat a plain class inside Resources/ as a resource', function () {
+    $result = modularAnalyzer()->analyze(fixture('filament-modular-project'));
+
+    $fqcns = array_map(fn (FilamentResourceDefinition $resource): string => $resource->fqcn, $result['resources']);
+
+    expect($fqcns)->not->toContain('Modules\\Shop\\Filament\\Resources\\OrderResourceHelper');
+});
+
+function modularAnalyzer(): FilamentAnalyzer
+{
+    return new FilamentAnalyzer(
+        panelPaths: ['app-modules/*/src/Filament'],
+        paths: ['app-modules/*/src/Filament'],
+    );
+}

--- a/tests/fixtures/filament-modular-project/app-modules/blog/src/Filament/Pages/BlogSettings.php
+++ b/tests/fixtures/filament-modular-project/app-modules/blog/src/Filament/Pages/BlogSettings.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Modules\Blog\Filament\Pages;
+
+use Filament\Pages\Page;
+
+class BlogSettings extends Page
+{
+    protected static string $view = 'blog.filament.pages.settings';
+}

--- a/tests/fixtures/filament-modular-project/app-modules/shop/src/Filament/Resources/OrderResource.php
+++ b/tests/fixtures/filament-modular-project/app-modules/shop/src/Filament/Resources/OrderResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Modules\Shop\Filament\Resources;
+
+use Modules\Shop\Filament\Resources\OrderResource\Pages;
+use Modules\Shop\Filament\Resources\OrderResource\RelationManagers\ItemsRelationManager;
+use Modules\Shop\Filament\Support\ShopResource;
+use Modules\Shop\Models\Order;
+
+class OrderResource extends ShopResource
+{
+    protected static ?string $model = Order::class;
+
+    public static function getRelations(): array
+    {
+        return [
+            ItemsRelationManager::class,
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListOrders::route('/'),
+        ];
+    }
+}

--- a/tests/fixtures/filament-modular-project/app-modules/shop/src/Filament/Resources/OrderResource/Pages/ListOrders.php
+++ b/tests/fixtures/filament-modular-project/app-modules/shop/src/Filament/Resources/OrderResource/Pages/ListOrders.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Modules\Shop\Filament\Resources\OrderResource\Pages;
+
+use Filament\Resources\Pages\ListRecords;
+use Modules\Shop\Filament\Resources\OrderResource;
+
+class ListOrders extends ListRecords
+{
+    protected static string $resource = OrderResource::class;
+}

--- a/tests/fixtures/filament-modular-project/app-modules/shop/src/Filament/Resources/OrderResource/RelationManagers/ItemsRelationManager.php
+++ b/tests/fixtures/filament-modular-project/app-modules/shop/src/Filament/Resources/OrderResource/RelationManagers/ItemsRelationManager.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Modules\Shop\Filament\Resources\OrderResource\RelationManagers;
+
+use Modules\Shop\Filament\Support\ShopRelationManager;
+
+class ItemsRelationManager extends ShopRelationManager
+{
+    protected static string $relationship = 'items';
+}

--- a/tests/fixtures/filament-modular-project/app-modules/shop/src/Filament/Resources/OrderResourceHelper.php
+++ b/tests/fixtures/filament-modular-project/app-modules/shop/src/Filament/Resources/OrderResourceHelper.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Modules\Shop\Filament\Resources;
+
+/**
+ * Negative control: a plain class inside Resources/ that is not a resource.
+ */
+class OrderResourceHelper
+{
+    public function label(): string
+    {
+        return 'Orders';
+    }
+}

--- a/tests/fixtures/filament-modular-project/app-modules/shop/src/Filament/ShopPanel.php
+++ b/tests/fixtures/filament-modular-project/app-modules/shop/src/Filament/ShopPanel.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Modules\Shop\Filament;
+
+use Filament\Facades\Filament;
+use Filament\Panel;
+
+/**
+ * A panel built outside the *PanelProvider convention: the module registers it
+ * itself, so the file is named after the panel rather than after a provider.
+ */
+class ShopPanel
+{
+    public function register(): void
+    {
+        Filament::registerPanel($this->panel());
+    }
+
+    private function panel(): Panel
+    {
+        return Panel::make()
+            ->id('shop')
+            ->path('shop')
+            ->discoverResources(in: __DIR__.'/Resources', for: 'Modules\\Shop\\Filament\\Resources')
+            ->discoverPages(in: __DIR__.'/Pages', for: 'Modules\\Shop\\Filament\\Pages');
+    }
+}

--- a/tests/fixtures/filament-modular-project/app-modules/shop/src/Filament/ShopTheme.php
+++ b/tests/fixtures/filament-modular-project/app-modules/shop/src/Filament/ShopTheme.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Modules\Shop\Filament;
+
+/**
+ * Negative control: a plain class living in the very directory panel_paths points
+ * at. It never builds a panel, so it must not be reported as one — otherwise every
+ * class under a source tree would become a panel.
+ */
+class ShopTheme
+{
+    public function id(): string
+    {
+        return 'shop-theme';
+    }
+
+    public function path(): string
+    {
+        return 'theme';
+    }
+}

--- a/tests/fixtures/filament-modular-project/app-modules/shop/src/Filament/Support/ShopRelationManager.php
+++ b/tests/fixtures/filament-modular-project/app-modules/shop/src/Filament/Support/ShopRelationManager.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Modules\Shop\Filament\Support;
+
+use Filament\Resources\RelationManagers\RelationManager;
+
+abstract class ShopRelationManager extends RelationManager {}

--- a/tests/fixtures/filament-modular-project/app-modules/shop/src/Filament/Support/ShopResource.php
+++ b/tests/fixtures/filament-modular-project/app-modules/shop/src/Filament/Support/ShopResource.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Modules\Shop\Filament\Support;
+
+use Filament\Resources\Resource;
+
+/**
+ * A project base class sitting between Filament and every real resource — the
+ * shape that makes a single-level `extends Resource` check find nothing.
+ */
+abstract class ShopResource extends Resource {}

--- a/tests/fixtures/filament-modular-project/app-modules/shop/src/Filament/Widgets/OrderStatsWidget.php
+++ b/tests/fixtures/filament-modular-project/app-modules/shop/src/Filament/Widgets/OrderStatsWidget.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Modules\Shop\Filament\Widgets;
+
+use Filament\Widgets\StatsOverviewWidget;
+
+class OrderStatsWidget extends StatsOverviewWidget
+{
+    protected function getStats(): array
+    {
+        return [];
+    }
+}

--- a/tests/fixtures/filament-modular-project/app-modules/shop/src/Models/Order.php
+++ b/tests/fixtures/filament-modular-project/app-modules/shop/src/Models/Order.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Modules\Shop\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Order extends Model
+{
+    protected $table = 'orders';
+}

--- a/tests/fixtures/filament-same-namespace-project/app-modules/catalog/src/Filament/Resources/CatalogResource.php
+++ b/tests/fixtures/filament-same-namespace-project/app-modules/catalog/src/Filament/Resources/CatalogResource.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Modules\Catalog\Filament\Resources;
+
+use Filament\Resources\Resource;
+
+/** A module base class sitting beside the resources that extend it. */
+abstract class CatalogResource extends Resource {}

--- a/tests/fixtures/filament-same-namespace-project/app-modules/catalog/src/Filament/Resources/ProductResource.php
+++ b/tests/fixtures/filament-same-namespace-project/app-modules/catalog/src/Filament/Resources/ProductResource.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Modules\Catalog\Filament\Resources;
+
+use Modules\Catalog\Models\Product;
+
+/**
+ * Extends a base class in its own namespace, so PHP needs no `use` for it and nobody
+ * writes one. The parent is written as a bare short name.
+ */
+class ProductResource extends CatalogResource
+{
+    protected static ?string $model = Product::class;
+}

--- a/tests/fixtures/filament-same-namespace-project/app-modules/catalog/src/Filament/Resources/ProductResource/RelationManagers/PricesRelationManager.php
+++ b/tests/fixtures/filament-same-namespace-project/app-modules/catalog/src/Filament/Resources/ProductResource/RelationManagers/PricesRelationManager.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Modules\Catalog\Filament\Resources\ProductResource\RelationManagers;
+
+/** Same shape as ProductResource: base class in the same namespace, no import. */
+class PricesRelationManager extends CatalogRelationManager
+{
+    protected static string $relationship = 'prices';
+}

--- a/tests/fixtures/filament-same-namespace-project/app-modules/catalog/src/Filament/Resources/ProductResource/RelationManagers/VariantsRelationManager.php
+++ b/tests/fixtures/filament-same-namespace-project/app-modules/catalog/src/Filament/Resources/ProductResource/RelationManagers/VariantsRelationManager.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Modules\Catalog\Filament\Resources\ProductResource\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+
+abstract class CatalogRelationManager extends RelationManager {}


### PR DESCRIPTION
## Filament: configurable search paths, panels outside the `*PanelProvider` convention, and base-class subclasses

`FilamentAnalyzer` currently hardcodes the default Laravel skeleton: panels are read from `app/Providers/Filament` and everything else from `app/Filament`, with no configuration surface at all. Two consequences:

1. **An application that keeps its Filament classes anywhere else gets a silently empty Filament graph.** The `vendor/filament/filament` check still reports `detected: true`, every scan then hits `is_dir()` on a path that does not exist, and the scan summary prints `0 resources` with no indication that nothing was even looked at. A modular monolith - local Composer packages under `app-modules/*`, no `app/` directory whatsoever - is the case I hit, but the same applies to any non-default layout.
2. **A project base class hides every resource.** `extractResource()` accepted only a direct `extends` whose last segment is `Resource`, and `extractRelationManager()` only a direct `extends RelationManager`. An `AppResource extends Resource` sitting between Filament and the real resources is an extremely common pattern, and it drops all of them.

### What this changes

**`filament.panel_paths` / `filament.paths` config keys.** Both default to today's values, so existing installs behave identically. An entry is used as-is when it is a directory and expanded as a glob pattern otherwise:

```php
// config/laravel-brain.php
'filament' => [
    'panel_paths' => ['app-modules/*/src/Filament'],
    'paths' => ['app-modules/*/src/Filament'],
],
```

**Panels are no longer required to be named `*PanelProvider.php`.** That filename still counts as a panel by convention - it is what Filament's own installer writes, and it configures the injected `$panel` rather than building one. Any other file counts only when it actually builds a `Panel::make()` chain (resolved through the file's use map, so an aliased import still matches). Without that guard, pointing `panel_paths` at a whole source tree would turn every class into a panel; with it, a panel registered from a plugin class or a factory is found.

**Resources and relation managers are recognised through their whole `extends` chain.** A `class FQCN => parent FQCN` map is collected once from the configured trees and walked when deciding what a class is. The walk terminates at a parent that was never parsed (a base class in `vendor/`), where the short name decides - exactly what the single-level check did before, so this is strictly additive.

Pages and widgets were already ungated and are untouched. Panel linking (`->resources([...])`, `->discoverResources(for: '...')`), slug/route computation and everything downstream are unchanged.

### Incidental simplifications

- `scanWidgets()` had two hand-rolled passes with a shared `$seenFiles` guard (one for `app/Filament/Widgets`, one for `app/Filament/Resources/**/Widgets/`). Both are now one pass filtered on a `/Widgets/` path segment, which covers the same two locations plus page-level widget directories. De-duplication moved into the shared file iterator.
- The four scan methods used to re-walk the tree independently; `analyze()` now resolves the directories once and passes them down.

### Tests

8 new tests in `tests/Unit/FilamentAnalyzerTest.php` against a new `tests/fixtures/filament-modular-project` fixture - two modules, a panel built by `Panel::make()` outside the naming convention, a resource and a relation manager behind project base classes, and two negative controls (a plain class inside a panel path, a plain class inside `Resources/`). They assert, among others, that the same fixture yields nothing under the default `app/` paths and everything under the configured ones.

Existing Filament tests are unchanged and still pass. Full suite: `262 passed (890 assertions)`, `pint` clean, `phpstan` 0 errors.

### Verified against a real application

A ~90-module monolith with no `app/` directory, before → after:

| | before | after |
|---|---|---|
| panels | 0 | 1 |
| resources | 0 | 55 |
| pages | 0 | 217 |
| widgets | 0 | 87 |
| relation managers | 0 | 22 |

(0.8 s for the Filament pass over ~830 files.) With only the config keys and not the `extends`-chain fix, resources came out at 4 of 55 - the 51 behind the project base class.

### Compatibility

The defaults are the previous hardcoded paths, `*PanelProvider.php` still short-circuits panel detection, and the chain walk can only match more than the direct-parent check did. `FilamentAnalyzer::__construct()` gains two optional arguments.

**Two things do change on a default layout, both in the direction of finding more.** The single `/Widgets/` pass replaces two hand-rolled ones and picks up a widget under `app/Filament/<PanelName>/Widgets/`, which neither of the old passes looked in. And the `extends` chain now recognises a base class in the same namespace as its children — three relation managers on the application this was developed against were invisible before it.

