### PR TITLE
Feat: modular psr4 and command attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,29 @@ php artisan brain:scan --auto-discover
 
 > **Heads up:** in auto-discover mode the source file and line number of each route are not available, so the sidebar will not group routes by their declaring file (everything falls under a single group). Use the default AST mode if file/line grouping matters to you.
 
+### Modular applications
+
+Class names are resolved through the PSR-4 map built from the root `composer.json` **and** from every local package: packages installed from a `path` repository, and nwidart/laravel-modules under `Modules/`. An application whose code lives in packages rather than in `app/` therefore resolves normally — without it, classes are discovered and then dropped, because no file can be found for them.
+
+Regular vendor dependencies are deliberately left out of that map, so the call-chain tracer never walks into framework or library internals.
+
+### Artisan commands
+
+A command is recognised however it names itself: a `$signature` (or the older `$name`) property, Laravel's `#[Signature]` / `#[Description]` attributes, or Symfony's `#[AsCommand]`. A property wins over an attribute, matching Laravel's own precedence.
+
+Scheduled tasks are read from `routes/console.php` and from a schedule split into its own `routes/schedule.php`, in both the `Schedule::command()` and `$schedule->command()` spellings, along with `job()` and `call()` entries and the cadence each one is chained with.
+
+### Broadcast channels
+
+Channels registered through the `Broadcast` facade are found out of the box. If your application registers them through a wrapper of its own — one that scopes every channel to a tenant, for instance — name that class in `channel_registrars` and its `::channel()` calls are read the same way:
+
+```php
+// config/laravel-brain.php
+'channel_registrars' => [
+    App\Broadcasting\TenantChannel::class,
+],
+```
+
 ### Call chain tracing
 
 From each controller action (and Filament page method), the tracer follows:

--- a/config/laravel-brain.php
+++ b/config/laravel-brain.php
@@ -180,6 +180,23 @@ return [
     ],
 
     // -------------------------------------------------------------------------
+    // Channel Registrars
+    // -------------------------------------------------------------------------
+    // Classes whose static channel() call registers a broadcast channel, on top of
+    // the Broadcast facade, which is always recognised.
+    //
+    // Add your own wrapper here if channels are not registered through the facade
+    // directly — a class that scopes every channel to a tenant, for example. Entries
+    // are matched by short class name, so either spelling works:
+    //
+    //   'channel_registrars' => [
+    //       'TenantChannel',
+    //       App\Broadcasting\TenantChannel::class,
+    //   ],
+    //
+    'channel_registrars' => [],
+
+    // -------------------------------------------------------------------------
     // Job Dispatch
     // -------------------------------------------------------------------------
     // Brain resolves the built-in dispatch verbs (dispatch(), dispatch_sync(),

--- a/src/Analysis/ChannelAnalyzer.php
+++ b/src/Analysis/ChannelAnalyzer.php
@@ -25,14 +25,35 @@ class ChannelAnalyzer
     /** @var string[] */
     private array $channelPaths;
 
+    /** @var string[] class names, short or fully qualified */
+    private array $registrars;
+
     /**
      * @param  string[]  $channelPaths  Glob patterns relative to the project root.
      *                                  Only files whose basename contains "channel" are parsed.
+     * @param  string[]  $registrars  Additional classes whose static channel() call registers
+     *                                a channel, on top of Broadcast. An application that wraps
+     *                                the facade — to scope channels to a tenant, say — registers
+     *                                every one of its channels through its own class, and none
+     *                                of them are Broadcast::channel() calls.
      */
-    public function __construct(array $channelPaths = ['routes/*/*.php'])
+    public function __construct(array $channelPaths = ['routes/*/*.php'], array $registrars = [])
     {
         $this->parser = new PhpFileParser;
         $this->channelPaths = $channelPaths ?: ['routes/*/*.php'];
+        $this->registrars = array_values(array_unique(array_merge(
+            ['Broadcast'],
+            array_map(static fn (string $registrar): string => self::shortName($registrar), $registrars),
+        )));
+    }
+
+    /** Compare registrars by short name: an import may be aliased, a call may be qualified. */
+    private static function shortName(string $class): string
+    {
+        $class = trim($class, '\\');
+        $position = strrpos($class, '\\');
+
+        return $position === false ? $class : substr($class, $position + 1);
     }
 
     /**
@@ -100,13 +121,17 @@ class ChannelAnalyzer
     private function extractChannels(array $ast, array $useMap, string $file): array
     {
         $traverser = new NodeTraverser;
-        $visitor = new class($file, $useMap) extends NodeVisitorAbstract
+        $visitor = new class($file, $useMap, $this->registrars) extends NodeVisitorAbstract
         {
             public array $channels = [];
 
+            /**
+             * @param  string[]  $registrars
+             */
             public function __construct(
                 private string $file,
                 private array $useMap,
+                private array $registrars,
             ) {}
 
             public function enterNode(Node $node): ?int
@@ -119,7 +144,7 @@ class ChannelAnalyzer
                 if (! $node->class instanceof Node\Name) {
                     return null;
                 }
-                if ($node->class->getLast() !== 'Broadcast') {
+                if (! in_array($node->class->getLast(), $this->registrars, true)) {
                     return null;
                 }
 

--- a/src/Analysis/ComposerPsr4Map.php
+++ b/src/Analysis/ComposerPsr4Map.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaraMint\LaravelBrain\Analysis;
+
+/**
+ * The namespace => source-root map every FQCN is resolved through.
+ *
+ * Reading only the root composer.json is enough for an application that keeps its
+ * code in `app/`. It is not enough for the two layouts that put source in packages:
+ * a modular monolith wiring local packages through a `path` repository, and
+ * nwidart/laravel-modules. In both, the root composer.json declares `App\ => app/`
+ * and nothing else, so every class in a module is unresolvable — analyzers still
+ * discover the classes, then drop them because no file can be found for them.
+ *
+ * Only LOCAL packages are added. Regular vendor dependencies stay out on purpose:
+ * making their classes resolvable would let the call-chain tracer walk into
+ * framework and library internals, which is not what the graph is about.
+ */
+class ComposerPsr4Map
+{
+    /**
+     * @return array<string, string[]> namespace prefix (no trailing separator) => base paths
+     */
+    public static function build(string $projectRoot): array
+    {
+        $root = rtrim($projectRoot, '/');
+        $map = [];
+
+        self::mergeComposerFile($map, $root.'/composer.json', $root);
+        self::mergeInstalledPathPackages($map, $root);
+        self::mergePathRepositories($map, $root);
+        self::mergeNwidartModules($map, $root);
+
+        foreach ($map as $namespace => $paths) {
+            $map[$namespace] = array_values(array_unique($paths));
+        }
+
+        return $map;
+    }
+
+    /**
+     * Packages Composer installed from a `path` repository. This is the authoritative
+     * source: it lists what is actually wired up, including packages whose directory
+     * name does not match their namespace.
+     *
+     * @param  array<string, string[]>  $map
+     */
+    private static function mergeInstalledPathPackages(array &$map, string $root): void
+    {
+        $installed = $root.'/vendor/composer/installed.json';
+        if (! file_exists($installed)) {
+            return;
+        }
+
+        $data = json_decode((string) file_get_contents($installed), true);
+        if (! is_array($data)) {
+            return;
+        }
+
+        /** @var array<int, array<string, mixed>> $packages */
+        $packages = $data['packages'] ?? $data;
+
+        foreach ($packages as $package) {
+            if (! is_array($package) || ($package['dist']['type'] ?? null) !== 'path') {
+                continue;
+            }
+
+            $packageRoot = self::localPackageRoot($package, $root);
+            if ($packageRoot === null) {
+                continue;
+            }
+
+            self::mergeAutoloadSections($map, $package, $packageRoot);
+        }
+    }
+
+    /**
+     * A `path` package is symlinked into vendor/, so its install-path leads back into
+     * vendor/. The dist url is the real location; resolving the symlink covers the
+     * copy install (`--no-symlink`), where the url may be a glob that no longer applies.
+     *
+     * @param  array<string, mixed>  $package
+     */
+    private static function localPackageRoot(array $package, string $root): ?string
+    {
+        $url = $package['dist']['url'] ?? null;
+        if (is_string($url) && $url !== '') {
+            $candidate = str_starts_with($url, '/') ? $url : $root.'/'.$url;
+            if (is_dir($candidate)) {
+                return rtrim($candidate, '/');
+            }
+        }
+
+        $installPath = $package['install-path'] ?? null;
+        if (is_string($installPath) && $installPath !== '') {
+            $resolved = realpath($root.'/vendor/composer/'.$installPath);
+            if ($resolved !== false) {
+                return rtrim($resolved, '/');
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * `path` repositories declared in the root composer.json, read straight from each
+     * package's own composer.json. Covers a checkout where `composer install` has not
+     * run yet, and a package that is declared but not required.
+     *
+     * @param  array<string, string[]>  $map
+     */
+    private static function mergePathRepositories(array &$map, string $root): void
+    {
+        $composerJson = $root.'/composer.json';
+        if (! file_exists($composerJson)) {
+            return;
+        }
+
+        $data = json_decode((string) file_get_contents($composerJson), true);
+        if (! is_array($data)) {
+            return;
+        }
+
+        foreach ($data['repositories'] ?? [] as $repository) {
+            if (! is_array($repository) || ($repository['type'] ?? null) !== 'path') {
+                continue;
+            }
+
+            $url = $repository['url'] ?? null;
+            if (! is_string($url) || $url === '') {
+                continue;
+            }
+
+            $absolute = str_starts_with($url, '/') ? $url : $root.'/'.$url;
+            $directories = is_dir($absolute) ? [$absolute] : (glob($absolute, GLOB_ONLYDIR | GLOB_BRACE) ?: []);
+
+            foreach ($directories as $directory) {
+                self::mergeComposerFile($map, rtrim($directory, '/').'/composer.json', rtrim($directory, '/'));
+            }
+        }
+    }
+
+    /**
+     * nwidart/laravel-modules: each Modules/{Name}/composer.json may declare its own
+     * PSR-4 map, and older module structures rely on the conventional mapping.
+     *
+     * @param  array<string, string[]>  $map
+     */
+    private static function mergeNwidartModules(array &$map, string $root): void
+    {
+        $modulesDir = $root.'/Modules';
+        if (! is_dir($modulesDir)) {
+            return;
+        }
+
+        foreach (scandir($modulesDir) ?: [] as $moduleName) {
+            if ($moduleName === '.' || $moduleName === '..') {
+                continue;
+            }
+
+            $modulePath = $modulesDir.'/'.$moduleName;
+            if (! is_dir($modulePath)) {
+                continue;
+            }
+
+            self::mergeComposerFile($map, $modulePath.'/composer.json', $modulePath);
+
+            // Conventional fallback: Modules\{Name} => Modules/{Name}/, covering both the
+            // old structure (Http/ directly) and the new one (app/).
+            $namespace = 'Modules\\'.$moduleName;
+            if (! isset($map[$namespace])) {
+                $map[$namespace] = [is_dir($modulePath.'/app') ? $modulePath.'/app' : $modulePath];
+            }
+        }
+    }
+
+    /**
+     * @param  array<string, string[]>  $map
+     */
+    private static function mergeComposerFile(array &$map, string $composerJson, string $packageRoot): void
+    {
+        if (! file_exists($composerJson)) {
+            return;
+        }
+
+        $data = json_decode((string) file_get_contents($composerJson), true);
+        if (! is_array($data)) {
+            return;
+        }
+
+        self::mergeAutoloadSections($map, $data, $packageRoot);
+    }
+
+    /**
+     * @param  array<string, string[]>  $map
+     * @param  array<string, mixed>  $data
+     */
+    private static function mergeAutoloadSections(array &$map, array $data, string $packageRoot): void
+    {
+        foreach (['autoload', 'autoload-dev'] as $section) {
+            $psr4 = $data[$section]['psr-4'] ?? [];
+            if (! is_array($psr4)) {
+                continue;
+            }
+
+            foreach ($psr4 as $namespace => $paths) {
+                $key = rtrim((string) $namespace, '\\');
+                foreach ((array) $paths as $path) {
+                    $map[$key][] = rtrim($packageRoot.'/'.ltrim((string) $path, '/'), '/');
+                }
+            }
+        }
+    }
+}

--- a/src/Analysis/ConsoleAnalyzer.php
+++ b/src/Analysis/ConsoleAnalyzer.php
@@ -32,6 +32,15 @@ class ScheduleEntry
 
 class ConsoleAnalyzer
 {
+    /** @var string[] Schedule methods that state a cadence. */
+    public const FREQUENCY_METHODS = [
+        'everyMinute', 'everyTwoMinutes', 'everyThreeMinutes', 'everyFiveMinutes',
+        'everyTenMinutes', 'everyFifteenMinutes', 'everyThirtyMinutes', 'hourly',
+        'hourlyAt', 'daily', 'dailyAt', 'twiceDaily', 'weekly', 'weeklyOn',
+        'monthly', 'monthlyOn', 'twiceMonthly', 'lastDayOfMonth', 'quarterly',
+        'yearly', 'cron', 'timezone',
+    ];
+
     private PhpFileParser $parser;
 
     /** @var string[] */
@@ -68,10 +77,12 @@ class ConsoleAnalyzer
         $schedule = [];
         $root = rtrim($projectRoot, '/');
 
-        // 1. Closure-based commands: files containing "console" in their basename
+        // 1. Closure-based commands and schedule entries. Laravel's own skeleton keeps
+        //    both in routes/console.php, but a schedule split out of it is conventionally
+        //    routes/schedule.php — a file the "console" keyword alone never reaches.
         foreach ($this->consoleRoutePaths as $pattern) {
             $baseDir = $this->resolveBaseDir($root, $pattern);
-            foreach ($this->findFilesContaining($baseDir, 'console') as $file) {
+            foreach ($this->findFilesContaining($baseDir, ['console', 'schedule']) as $file) {
                 $result = $this->parseConsoleRouteFile($file);
                 $commands = array_merge($commands, $result['commands']);
                 $schedule = array_merge($schedule, $result['schedule']);
@@ -148,10 +159,21 @@ class ConsoleAnalyzer
 
             public array $schedule = [];
 
+            /** @var array<int, string> spl_object_id of a static call => frequency read off its chain */
+            private array $chainFrequencies = [];
+
             public function __construct(private string $file) {}
 
             public function enterNode(Node $node): ?int
             {
+                // Frequency lives on the calls wrapped AROUND the registration
+                // (`Schedule::command(...)->dailyAt(...)`), and a node cannot see its own
+                // parents. Traversal is top-down, so the chain is read on the way in and
+                // parked for the static call that arrives a few nodes later.
+                if ($node instanceof Node\Expr\MethodCall) {
+                    $this->rememberChainFrequency($node);
+                }
+
                 if (! $node instanceof Node\Expr\StaticCall) {
                     return null;
                 }
@@ -176,15 +198,14 @@ class ConsoleAnalyzer
                     }
                 }
 
-                // Schedule::command('sig')->daily()
-                if ($class === 'Schedule' && $method === 'command') {
-                    $sig = $this->strArg($node->args[0] ?? null);
-                    $freq = $this->walkChainForFrequency($node);
-                    if ($sig !== null) {
+                // Schedule::command('sig')->daily(), and the job/call siblings
+                if ($class === 'Schedule' && in_array($method, ['command', 'job', 'call'], true)) {
+                    $target = $this->scheduleTarget($method, $node->args[0] ?? null);
+                    if ($target !== null) {
                         $this->schedule[] = new ScheduleEntry(
-                            type: 'command',
-                            target: $sig,
-                            frequency: $freq,
+                            type: $method,
+                            target: $target,
+                            frequency: $this->walkChainForFrequency($node),
                             file: $this->file,
                         );
                     }
@@ -193,11 +214,58 @@ class ConsoleAnalyzer
                 return null;
             }
 
+            /** What a scheduled entry points at: a signature, a job class, or a closure. */
+            private function scheduleTarget(string $method, ?Node\Arg $arg): ?string
+            {
+                if ($method === 'call') {
+                    return 'Closure';
+                }
+
+                $signature = $this->strArg($arg);
+                if ($signature !== null) {
+                    return $signature;
+                }
+
+                if ($arg?->value instanceof Node\Expr\ClassConstFetch
+                    && $arg->value->class instanceof Node\Name
+                    && $arg->value->name instanceof Node\Identifier
+                    && $arg->value->name->toString() === 'class') {
+                    // The parser preserves original names, so `Job::class` reads as the short
+                    // name it was written with; the resolved name is on the attribute.
+                    return PhpFileParser::resolvedName($arg->value->class)
+                        ?? $arg->value->class->toString();
+                }
+
+                return null;
+            }
+
             private function walkChainForFrequency(Node $node): string
             {
-                // Walk up the parent chain looking for frequency method names
-                // The AST has the parent as the receiver of subsequent method calls
-                return '';
+                return $this->chainFrequencies[spl_object_id($node)] ?? '';
+            }
+
+            /**
+             * Read the first frequency method off a `Schedule::…()->frequency()->…` chain and
+             * park it under the static call the chain is built on.
+             */
+            private function rememberChainFrequency(Node\Expr\MethodCall $node): void
+            {
+                $frequency = '';
+                $current = $node;
+
+                while ($current instanceof Node\Expr\MethodCall) {
+                    $name = $current->name instanceof Node\Identifier ? $current->name->toString() : '';
+                    if ($frequency === '' && in_array($name, ConsoleAnalyzer::FREQUENCY_METHODS, true)) {
+                        $frequency = $name;
+                    }
+                    $current = $current->var;
+                }
+
+                if ($frequency === '' || ! $current instanceof Node\Expr\StaticCall) {
+                    return;
+                }
+
+                $this->chainFrequencies[spl_object_id($current)] ??= $frequency;
             }
 
             private function strArg(?Node $node): ?string
@@ -260,6 +328,10 @@ class ConsoleAnalyzer
 
             private ?string $description = null;
 
+            private ?string $attributeSignature = null;
+
+            private ?string $attributeDescription = null;
+
             public function __construct(private string $file) {}
 
             public function enterNode(Node $node): ?int
@@ -269,12 +341,14 @@ class ConsoleAnalyzer
                 }
                 if ($node instanceof Node\Stmt\Class_) {
                     $this->className = $node->name?->toString();
+                    $this->readCommandAttributes($node);
                 }
                 if ($node instanceof Node\Stmt\Property) {
                     foreach ($node->props as $prop) {
                         $name = $prop->name->toString();
-                        if ($name === 'signature' && $prop->default instanceof Node\Scalar\String_) {
-                            $this->signature = $prop->default->value;
+                        // $name is the pre-signature spelling; it still names the command.
+                        if (($name === 'signature' || $name === 'name') && $prop->default instanceof Node\Scalar\String_) {
+                            $this->signature ??= $prop->default->value;
                         }
                         if ($name === 'description' && $prop->default instanceof Node\Scalar\String_) {
                             $this->description = $prop->default->value;
@@ -287,18 +361,74 @@ class ConsoleAnalyzer
 
             public function afterTraverse(array $nodes): ?int
             {
-                if ($this->className && $this->signature !== null) {
+                // A property wins over an attribute: that is the precedence Laravel itself
+                // applies when a command declares both.
+                $signature = $this->signature ?? $this->attributeSignature;
+                $description = $this->description ?? $this->attributeDescription;
+
+                if ($this->className && $signature !== null) {
                     $fqcn = $this->namespace
                         ? $this->namespace.'\\'.$this->className
                         : $this->className;
 
                     $this->result = new ConsoleCommandDefinition(
-                        signature: $this->signature,
-                        description: $this->description ?? '',
+                        signature: $signature,
+                        description: $description ?? '',
                         class: $fqcn,
                         file: $this->file,
                         source: 'class',
                     );
+                }
+
+                return null;
+            }
+
+            /**
+             * Laravel 12 declares a command's signature and description as class
+             * attributes rather than properties, and Symfony's #[AsCommand] carries the
+             * same two values. A command written either way has no $signature property
+             * at all, so reading properties alone finds nothing.
+             */
+            private function readCommandAttributes(Node\Stmt\Class_ $node): void
+            {
+                foreach ($node->attrGroups as $group) {
+                    foreach ($group->attrs as $attribute) {
+                        switch ($attribute->name->getLast()) {
+                            case 'Signature':
+                                $this->attributeSignature ??= $this->attributeArg($attribute->args, 'signature', 0);
+                                break;
+                            case 'Description':
+                                $this->attributeDescription ??= $this->attributeArg($attribute->args, 'description', 0);
+                                break;
+                            case 'AsCommand':
+                                $this->attributeSignature ??= $this->attributeArg($attribute->args, 'name', 0);
+                                $this->attributeDescription ??= $this->attributeArg($attribute->args, 'description', 1);
+                                break;
+                        }
+                    }
+                }
+            }
+
+            /**
+             * Read a string attribute argument given either by name or by position.
+             *
+             * @param  Node\Arg[]  $args
+             */
+            private function attributeArg(array $args, string $name, int $position): ?string
+            {
+                $index = 0;
+
+                foreach ($args as $arg) {
+                    $named = $arg->name instanceof Node\Identifier && $arg->name->toString() === $name;
+                    $positional = $arg->name === null && $index === $position;
+
+                    if (($named || $positional) && $arg->value instanceof Node\Scalar\String_) {
+                        return $arg->value->value;
+                    }
+
+                    if ($arg->name === null) {
+                        $index++;
+                    }
                 }
 
                 return null;
@@ -418,13 +548,6 @@ class ConsoleAnalyzer
             /** Walk the method chain to find the first frequency-like method. */
             private function chainFrequency(Node\Expr\MethodCall $node): string
             {
-                $freq = ['everyMinute', 'everyFiveMinutes', 'everyTenMinutes',
-                    'everyFifteenMinutes', 'everyThirtyMinutes', 'hourly',
-                    'daily', 'dailyAt', 'weekly', 'weeklyOn', 'monthly',
-                    'monthlyOn', 'quarterly', 'yearly', 'cron',
-                    'everyTwoMinutes', 'everyThreeMinutes', 'twiceDaily',
-                    'twiceMonthly', 'lastDayOfMonth', 'timezone'];
-
                 // The node itself may be wrapped by frequency calls further up;
                 // we look at the var chain (the receiver of this call)
                 $current = $node;
@@ -432,7 +555,7 @@ class ConsoleAnalyzer
                     $m = $current->name instanceof Node\Identifier
                         ? $current->name->toString()
                         : '';
-                    if (in_array($m, $freq, true)) {
+                    if (in_array($m, ConsoleAnalyzer::FREQUENCY_METHODS, true)) {
                         return $m;
                     }
                     $current = $current->var;
@@ -474,7 +597,11 @@ class ConsoleAnalyzer
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
-    private function findFilesContaining(string $dir, string $keyword): array
+    /**
+     * @param  string[]  $keywords
+     * @return string[]
+     */
+    private function findFilesContaining(string $dir, array $keywords): array
     {
         if (! is_dir($dir)) {
             return [];
@@ -485,10 +612,16 @@ class ConsoleAnalyzer
             new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS)
         );
         foreach ($iterator as $entry) {
-            if ($entry->isFile()
-                && $entry->getExtension() === 'php'
-                && str_contains(strtolower($entry->getBasename()), $keyword)) {
-                $files[] = $entry->getPathname();
+            if (! $entry->isFile() || $entry->getExtension() !== 'php') {
+                continue;
+            }
+
+            $basename = strtolower($entry->getBasename());
+            foreach ($keywords as $keyword) {
+                if (str_contains($basename, $keyword)) {
+                    $files[] = $entry->getPathname();
+                    break;
+                }
             }
         }
 

--- a/src/Analysis/ControllerAnalyzer.php
+++ b/src/Analysis/ControllerAnalyzer.php
@@ -509,67 +509,12 @@ class ControllerAnalyzer
         );
     }
 
+    /**
+     * @return array<string, string[]>
+     */
     private function buildPsr4Map(string $projectRoot): array
     {
-        $composerJson = $projectRoot.'/composer.json';
-        if (! file_exists($composerJson)) {
-            return [];
-        }
-
-        $data = json_decode(file_get_contents($composerJson), true);
-        $map = [];
-
-        foreach (['autoload', 'autoload-dev'] as $section) {
-            foreach ($data[$section]['psr-4'] ?? [] as $namespace => $paths) {
-                $ns = rtrim($namespace, '\\');
-                foreach ((array) $paths as $path) {
-                    $map[$ns][] = rtrim($projectRoot.'/'.$path, '/');
-                }
-            }
-        }
-
-        // Scan nwidart/laravel-modules: each Modules/{Name}/composer.json may declare its own PSR-4 map.
-        // Also infer the conventional mapping Modules\{Name} → Modules/{Name}/ for older module structures.
-        $modulesDir = $projectRoot.'/Modules';
-        if (is_dir($modulesDir)) {
-            foreach (scandir($modulesDir) as $modName) {
-                if ($modName === '.' || $modName === '..') {
-                    continue;
-                }
-                $modPath = $modulesDir.'/'.$modName;
-                if (! is_dir($modPath)) {
-                    continue;
-                }
-
-                // Read module's own composer.json for explicit PSR-4 entries
-                $modComposer = $modPath.'/composer.json';
-                if (file_exists($modComposer)) {
-                    $modData = json_decode(file_get_contents($modComposer), true);
-                    foreach (['autoload', 'autoload-dev'] as $section) {
-                        foreach ($modData[$section]['psr-4'] ?? [] as $namespace => $paths) {
-                            $ns = rtrim($namespace, '\\');
-                            foreach ((array) $paths as $path) {
-                                $map[$ns][] = rtrim($modPath.'/'.$path, '/');
-                            }
-                        }
-                    }
-                }
-
-                // Conventional fallback: Modules\{Name} → Modules/{Name}/
-                // Covers both old structure (Http/ directly) and new structure (app/)
-                $ns = 'Modules\\'.$modName;
-                if (! isset($map[$ns])) {
-                    // New nwidart structure: Modules/{Name}/app/
-                    if (is_dir($modPath.'/app')) {
-                        $map[$ns] = [$modPath.'/app'];
-                    } else {
-                        $map[$ns] = [$modPath];
-                    }
-                }
-            }
-        }
-
-        return $map;
+        return ComposerPsr4Map::build($projectRoot);
     }
 
     private function resolveFile(string $fqcn, string $projectRoot): ?string

--- a/src/Analysis/ModelAnalyzer.php
+++ b/src/Analysis/ModelAnalyzer.php
@@ -513,25 +513,12 @@ class ModelAnalyzer
         return array_values(array_unique($dirs));
     }
 
+    /**
+     * @return array<string, string[]>
+     */
     private function buildPsr4Map(string $projectRoot): array
     {
-        $composerJson = $projectRoot.'/composer.json';
-        if (! file_exists($composerJson)) {
-            return [];
-        }
-
-        $data = json_decode(file_get_contents($composerJson), true);
-        $map = [];
-        foreach (['autoload', 'autoload-dev'] as $section) {
-            foreach ($data[$section]['psr-4'] ?? [] as $ns => $paths) {
-                $key = rtrim($ns, '\\');
-                foreach ((array) $paths as $path) {
-                    $map[$key][] = rtrim($projectRoot.'/'.$path, '/');
-                }
-            }
-        }
-
-        return $map;
+        return ComposerPsr4Map::build($projectRoot);
     }
 
     private function resolveFile(string $fqcn, string $projectRoot, array $psr4Map): ?string

--- a/src/Analysis/ProjectAnalyzer.php
+++ b/src/Analysis/ProjectAnalyzer.php
@@ -76,7 +76,11 @@ class ProjectAnalyzer
         $this->routeAnalyzer = new RouteAnalyzer($routePaths, $autoDiscover, $excludeVendor);
 
         $channelPaths = config('laravel-brain.channel_paths', ['routes/*/*.php']);
-        $this->channelAnalyzer = new ChannelAnalyzer($channelPaths);
+        $channelRegistrars = config('laravel-brain.channel_registrars', []);
+        $this->channelAnalyzer = new ChannelAnalyzer(
+            is_array($channelPaths) ? $channelPaths : [],
+            $this->stringList($channelRegistrars),
+        );
 
         $listenerPaths = config('laravel-brain.listeners.paths', ['app/Listeners']);
         $providerPaths = config('laravel-brain.listeners.provider_paths', ['app/Providers']);

--- a/tests/Unit/ChannelAnalyzerTest.php
+++ b/tests/Unit/ChannelAnalyzerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use LaraMint\LaravelBrain\Analysis\ChannelAnalyzer;
+use LaraMint\LaravelBrain\Analysis\ChannelDefinition;
+
+/** @param string[] $registrars */
+function channelNames(array $registrars = []): array
+{
+    $channels = (new ChannelAnalyzer(['packages/*/routes/channels.php'], $registrars))
+        ->analyze(fixture('modular-project'));
+
+    return array_map(fn (ChannelDefinition $channel): string => $channel->name, $channels);
+}
+
+it('finds channels registered through the Broadcast facade', function () {
+    expect(channelNames())->toContain('orders.{orderId}');
+});
+
+it('ignores a wrapper class that was not configured as a registrar', function () {
+    expect(channelNames())->not->toContain('tenant.orders.{orderId}');
+});
+
+it('finds channels registered through a configured registrar', function () {
+    // An application that wraps the facade — to scope channels to a tenant, say —
+    // registers every channel through its own class and none through Broadcast.
+    expect(channelNames(['TenantChannel']))->toContain('tenant.orders.{orderId}');
+});
+
+it('accepts a registrar written as a fully qualified class name', function () {
+    expect(channelNames(['Acme\\Shop\\Broadcasting\\TenantChannel']))
+        ->toContain('tenant.orders.{orderId}');
+});
+
+it('keeps recognising the Broadcast facade when registrars are configured', function () {
+    expect(channelNames(['TenantChannel']))->toContain('orders.{orderId}');
+});

--- a/tests/Unit/ComposerPsr4MapTest.php
+++ b/tests/Unit/ComposerPsr4MapTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use LaraMint\LaravelBrain\Analysis\ComposerPsr4Map;
+
+it('maps the namespaces declared in the root composer.json', function () {
+    $map = ComposerPsr4Map::build(fixture('modular-project'));
+
+    expect($map)->toHaveKey('App')
+        ->and($map['App'])->toBe([fixture('modular-project').'/app']);
+});
+
+it('maps a local package installed from a path repository', function () {
+    $map = ComposerPsr4Map::build(fixture('modular-project'));
+
+    expect($map)->toHaveKey('Acme\\Shop')
+        ->and($map['Acme\\Shop'])->toBe([fixture('modular-project').'/packages/shop/src']);
+});
+
+it('leaves regular vendor dependencies out of the map', function () {
+    $map = ComposerPsr4Map::build(fixture('modular-project'));
+
+    // Resolving vendor classes would let the call-chain tracer walk into library
+    // internals, which is not what the graph is for.
+    expect($map)->not->toHaveKey('Acme\\VendorLib');
+});
+
+it('reads a path repository package that installed.json does not list', function () {
+    $map = ComposerPsr4Map::build(fixture('modular-project'));
+
+    // acme/blog is declared as a path repository but was never installed — the case of
+    // a fresh checkout, or a package that is present but not required.
+    expect($map)->toHaveKey('Acme\\Blog')
+        ->and($map['Acme\\Blog'])->toBe([fixture('modular-project').'/packages/blog/src']);
+});
+
+it('keeps the conventional nwidart module mapping', function () {
+    $map = ComposerPsr4Map::build(fixture('nwidart-project'));
+
+    expect($map)->toHaveKey('Modules\\Sales')
+        ->and($map['Modules\\Sales'])->toBe([fixture('nwidart-project').'/Modules/Sales/app']);
+});
+
+it('returns an empty map for a directory with no composer.json', function () {
+    expect(ComposerPsr4Map::build(__DIR__.'/does-not-exist'))->toBe([]);
+});

--- a/tests/Unit/ConsoleAnalyzerTest.php
+++ b/tests/Unit/ConsoleAnalyzerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use LaraMint\LaravelBrain\Analysis\ConsoleAnalyzer;
+use LaraMint\LaravelBrain\Analysis\ConsoleCommandDefinition;
+use LaraMint\LaravelBrain\Analysis\ScheduleEntry;
+
+function modularConsoleAnalyzer(): ConsoleAnalyzer
+{
+    return new ConsoleAnalyzer(
+        consoleRoutePaths: ['packages/*/routes/*.php'],
+        classPaths: ['packages/shop/src/Console'],
+        kernelPaths: [],
+    );
+}
+
+/** @return array<string, ConsoleCommandDefinition> */
+function commandsBySignature(): array
+{
+    $result = modularConsoleAnalyzer()->analyze(fixture('modular-project'));
+    $bySignature = [];
+
+    foreach ($result['commands'] as $command) {
+        $bySignature[$command->signature] = $command;
+    }
+
+    return $bySignature;
+}
+
+it('extracts a command declared with the Signature and Description attributes', function () {
+    $commands = commandsBySignature();
+    $signature = 'shop:sync-orders {--since= : Only orders updated after this date}';
+
+    expect($commands)->toHaveKey($signature)
+        ->and($commands[$signature]->description)->toBe('Pull orders from the storefront')
+        ->and($commands[$signature]->class)->toBe('Acme\\Shop\\Console\\SyncOrdersCommand');
+});
+
+it('extracts a command declared with the AsCommand attribute', function () {
+    $commands = commandsBySignature();
+
+    expect($commands)->toHaveKey('shop:import-products')
+        ->and($commands['shop:import-products']->description)->toBe('Import the product feed');
+});
+
+it('extracts a command that names itself through the legacy $name property', function () {
+    $commands = commandsBySignature();
+
+    expect($commands)->toHaveKey('shop:legacy')
+        ->and($commands['shop:legacy']->description)->toBe('The pre-signature spelling');
+});
+
+it('lets a $signature property win over a Signature attribute', function () {
+    $commands = commandsBySignature();
+
+    expect($commands)->toHaveKey('shop:from-property')
+        ->and($commands)->not->toHaveKey('shop:from-attribute');
+});
+
+it('reads schedule entries out of routes/schedule.php', function () {
+    $result = modularConsoleAnalyzer()->analyze(fixture('modular-project'));
+
+    // Laravel's own skeleton keeps the schedule in routes/console.php; a schedule split
+    // into its own file is the layout the "console" keyword alone never reaches.
+    $targets = array_map(fn (ScheduleEntry $entry): string => $entry->target, $result['schedule']);
+
+    expect($targets)->toContain('shop:sync-orders')
+        ->and($targets)->toContain('Acme\\Shop\\Jobs\\ReconcilePayouts');
+});
+
+it('reads the cadence off the scheduling chain', function () {
+    $result = modularConsoleAnalyzer()->analyze(fixture('modular-project'));
+
+    $byTarget = [];
+    foreach ($result['schedule'] as $entry) {
+        $byTarget[$entry->target] = $entry;
+    }
+
+    expect($byTarget['shop:sync-orders']->frequency)->toBe('dailyAt')
+        ->and($byTarget['shop:sync-orders']->type)->toBe('command')
+        ->and($byTarget['Acme\\Shop\\Jobs\\ReconcilePayouts']->frequency)->toBe('hourly')
+        ->and($byTarget['Acme\\Shop\\Jobs\\ReconcilePayouts']->type)->toBe('job');
+});

--- a/tests/fixtures/modular-project/composer.json
+++ b/tests/fixtures/modular-project/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "acme/modular-app",
+    "repositories": [
+        { "type": "path", "url": "packages/*" }
+    ],
+    "require": {
+        "acme/shop": "*",
+        "acme/blog": "*"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    }
+}

--- a/tests/fixtures/modular-project/packages/blog/composer.json
+++ b/tests/fixtures/modular-project/packages/blog/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "acme/blog",
+    "autoload": {
+        "psr-4": {
+            "Acme\\Blog\\": "src/"
+        }
+    }
+}

--- a/tests/fixtures/modular-project/packages/blog/src/Post.php
+++ b/tests/fixtures/modular-project/packages/blog/src/Post.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Acme\Blog;
+
+class Post {}

--- a/tests/fixtures/modular-project/packages/shop/composer.json
+++ b/tests/fixtures/modular-project/packages/shop/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "acme/shop",
+    "autoload": {
+        "psr-4": {
+            "Acme\\Shop\\": "src/"
+        }
+    }
+}

--- a/tests/fixtures/modular-project/packages/shop/routes/channels.php
+++ b/tests/fixtures/modular-project/packages/shop/routes/channels.php
@@ -1,0 +1,8 @@
+<?php
+
+use Acme\Shop\Broadcasting\TenantChannel;
+use Illuminate\Support\Facades\Broadcast;
+
+Broadcast::channel('orders.{orderId}', fn ($user, $orderId) => true);
+
+TenantChannel::channel('tenant.orders.{orderId}', fn ($user, $orderId) => true);

--- a/tests/fixtures/modular-project/packages/shop/routes/schedule.php
+++ b/tests/fixtures/modular-project/packages/shop/routes/schedule.php
@@ -1,0 +1,8 @@
+<?php
+
+use Acme\Shop\Jobs\ReconcilePayouts;
+use Illuminate\Support\Facades\Schedule;
+
+Schedule::command('shop:sync-orders')->dailyAt('05:30')->withoutOverlapping();
+
+Schedule::job(ReconcilePayouts::class)->hourly();

--- a/tests/fixtures/modular-project/packages/shop/src/Console/ImportProductsCommand.php
+++ b/tests/fixtures/modular-project/packages/shop/src/Console/ImportProductsCommand.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Acme\Shop\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'shop:import-products', description: 'Import the product feed')]
+class ImportProductsCommand extends Command
+{
+    public function handle(): int
+    {
+        return self::SUCCESS;
+    }
+}

--- a/tests/fixtures/modular-project/packages/shop/src/Console/LegacyCommand.php
+++ b/tests/fixtures/modular-project/packages/shop/src/Console/LegacyCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Acme\Shop\Console;
+
+use Illuminate\Console\Command;
+
+class LegacyCommand extends Command
+{
+    protected $name = 'shop:legacy';
+
+    protected $description = 'The pre-signature spelling';
+}

--- a/tests/fixtures/modular-project/packages/shop/src/Console/OverriddenCommand.php
+++ b/tests/fixtures/modular-project/packages/shop/src/Console/OverriddenCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Acme\Shop\Console;
+
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+
+#[Signature('shop:from-attribute')]
+class OverriddenCommand extends Command
+{
+    protected $signature = 'shop:from-property';
+}

--- a/tests/fixtures/modular-project/packages/shop/src/Console/SyncOrdersCommand.php
+++ b/tests/fixtures/modular-project/packages/shop/src/Console/SyncOrdersCommand.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Acme\Shop\Console;
+
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+
+#[Signature('shop:sync-orders {--since= : Only orders updated after this date}')]
+#[Description('Pull orders from the storefront')]
+class SyncOrdersCommand extends Command
+{
+    public function handle(): int
+    {
+        return self::SUCCESS;
+    }
+}

--- a/tests/fixtures/modular-project/packages/shop/src/Models/Order.php
+++ b/tests/fixtures/modular-project/packages/shop/src/Models/Order.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Acme\Shop\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Order extends Model
+{
+    protected $table = 'orders';
+}

--- a/tests/fixtures/modular-project/vendor/acme/vendor-lib/composer.json
+++ b/tests/fixtures/modular-project/vendor/acme/vendor-lib/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "acme/vendor-lib",
+    "autoload": {
+        "psr-4": {
+            "Acme\\VendorLib\\": "src/"
+        }
+    }
+}

--- a/tests/fixtures/modular-project/vendor/acme/vendor-lib/src/Client.php
+++ b/tests/fixtures/modular-project/vendor/acme/vendor-lib/src/Client.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Acme\VendorLib;
+
+class Client {}

--- a/tests/fixtures/modular-project/vendor/composer/installed.json
+++ b/tests/fixtures/modular-project/vendor/composer/installed.json
@@ -1,0 +1,19 @@
+{
+    "packages": [
+        {
+            "name": "acme/shop",
+            "type": "library",
+            "install-path": "../acme/shop",
+            "dist": { "type": "path", "url": "packages/shop", "reference": "abc123" },
+            "autoload": { "psr-4": { "Acme\\Shop\\": "src/" } }
+        },
+        {
+            "name": "acme/vendor-lib",
+            "type": "library",
+            "install-path": "../acme/vendor-lib",
+            "dist": { "type": "zip", "url": "https://example.test/vendor-lib.zip" },
+            "autoload": { "psr-4": { "Acme\\VendorLib\\": "src/" } }
+        }
+    ],
+    "dev": true
+}

--- a/tests/fixtures/nwidart-project/Modules/Sales/app/Models/Invoice.php
+++ b/tests/fixtures/nwidart-project/Modules/Sales/app/Models/Invoice.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Modules\Sales\Models;
+
+class Invoice {}

--- a/tests/fixtures/nwidart-project/composer.json
+++ b/tests/fixtures/nwidart-project/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "acme/nwidart-app",
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    }
+}


### PR DESCRIPTION
## Resolve classes in package-based applications, and recognise commands, schedules and channels however they are declared

Four independent places assume the default Laravel skeleton and go quiet - not wrong, quiet - the moment an application does not match it. A scan still succeeds and still prints a summary; the summary just says `0`.

### 1. The PSR-4 map is read from the root composer.json only

`ControllerAnalyzer::buildPsr4Map()` and `ModelAnalyzer::buildPsr4Map()` each read `autoload`/`autoload-dev` out of the project's own `composer.json`. In an application whose code lives in packages, that file declares `App\ => app/` and nothing else, so no class in any package can be mapped to a file.

The failure mode is silent and total. `ModelAnalyzer::discoverModels()` walks the configured directories and finds every model; `analyze()` then drops all of them, because `resolveFile()` has no namespace to match. On a ~90-package monolith that is 174 models discovered and 0 kept - and with them the call chains, jobs, events, listeners and DB queries that hang off models. Nothing in the output suggests a lookup problem.

The first of those two maps is the canonical one: `ProjectAnalyzer` builds it once and hands it to `MethodTracer`, `ListenerAnalyzer`, `PolicyAnalyzer`, `QueryTracer` and the Filament page tracer. So this is one fix, not six.

A new `ComposerPsr4Map` merges four sources and both old builders delegate to it:

- the root `composer.json`, exactly as before;
- packages Composer installed from a `path` repository, read from `vendor/composer/installed.json` - the authoritative list of what is actually wired up;
- `path` repositories declared in the root `composer.json`, read from each package's own `composer.json`, which covers a checkout where `composer install` has not run and a package that is present but not required;
- the nwidart/laravel-modules `Modules/` scan, moved over unchanged from `ControllerAnalyzer`.

**Regular vendor dependencies are deliberately left out.** Reading `vendor/composer/autoload_psr4.php` would have been one line and a complete map, but making vendor classes resolvable lets `MethodTracer` walk into framework and library internals, which is not what the graph is for. Local packages are enough.

### 2. A command is only recognised by its `$signature` property

`ConsoleAnalyzer` reads `protected $signature = '...'` and nothing else. A command that declares itself with Laravel 12's `#[Signature]` / `#[Description]` attributes, or with Symfony's `#[AsCommand]`, has no such property and is skipped entirely - 109 of 111 commands in the application I measured on.

All three forms are now read, along with the pre-signature `protected $name`. A property wins over an attribute, matching Laravel's own precedence.

### 3. Scheduled tasks are only looked for in files named `*console*`

`console_route_paths` is documented as a glob, but the analyzer truncates the pattern at its first wildcard and then keeps only files whose basename contains `console`. Laravel's own skeleton keeps the schedule in `routes/console.php`, so this works - until a schedule is split into `routes/schedule.php`, which nothing ever reaches. That was 40 files and 61 entries in the application I measured on.

`schedule` is now accepted alongside `console`. Two things follow from finally reading those files:

- `Schedule::job()` and `Schedule::call()` are recorded next to `Schedule::command()`; a job target is resolved to its FQCN through the parser's resolved-name attribute rather than the short name it was written with.
- `walkChainForFrequency()` was a stub returning `''`, so every statically-registered entry carried an empty cadence. Frequency lives on the calls wrapped *around* the registration and a node cannot see its own parents, so the chain is now read on the way in - traversal is top-down - and parked for the static call that arrives a few nodes later. `Schedule::command('x')->dailyAt('05:30')->withoutOverlapping()` now reports `dailyAt`.

### 4. Channels are only recognised as `Broadcast::channel()`

An application that wraps the facade - to scope every channel to a tenant, for instance - registers all of its channels through its own class and none through `Broadcast`, so none are found.

A `channel_registrars` config key names additional classes whose static `channel()` call registers a channel. `Broadcast` is always recognised, so the default is unchanged. Entries are matched by short class name, so both `'TenantChannel'` and `App\Broadcasting\TenantChannel::class` work.

### Tests

17 new tests across `ComposerPsr4MapTest`, `ConsoleAnalyzerTest` and `ChannelAnalyzerTest` - the latter two did not exist - against two new fixtures:

- `modular-project`: a package installed from a `path` repository, a package declared as a `path` repository but never installed, a regular vendor dependency as a negative control, four spellings of a command declaration (`#[Signature]`+`#[Description]`, `#[AsCommand]`, legacy `$name`, and one declaring both a property and an attribute to pin the precedence), a `routes/schedule.php` and a `routes/channels.php` registering through both the facade and a wrapper;
- `nwidart-project`: pins the conventional `Modules\{Name}` mapping that moved out of `ControllerAnalyzer`.

Full suite: `271 passed (883 assertions)`, up from 254 with no existing test changed. `pint` clean, `phpstan` 0 errors.

### Verified against a real application

A ~90-package monolith with no `app/` directory, same scan before and after:

| | before | after |
|---|---|---|
| controllers | 0 | 223 |
| lifecycle call edges | 145 | 1370 |
| models | 0 | 177 |
| commands | 2 | 109 |
| scheduled tasks | 0 | 58 |
| broadcast channels | 0 | 6 |
| command call chains | 0 | 768 |
| DB query actions | 0 | 87 |
| **graph** | **1339 nodes / 5668 edges** | **2865 nodes / 8491 edges** |

Before, the graph held routes, middleware and controllers and nothing else. After, it holds 593 service, 327 model, 113 command, 54 schedule, 38 listener, 34 validation-request, 30 event, 28 job and 4 channel nodes. Total scan time went from 17.5 s to 21.5 s.

### Compatibility

The PSR-4 map is a superset of what it was; `channel_registrars` defaults to empty and `Broadcast` stays built in; command attributes are consulted only when no property declares the same thing; and `console` remains an accepted filename keyword.

**But a default Laravel layout is not untouched, and this is the part to read before merging.** Declaring a command with Laravel 12's `#[Signature]` is a supported default; such a command was previously invisible to the scan, and reading it changes what the command *is*:

```
- "id": "cmd-acme-console-commands-backupdatabase"   label: Acme\Console\Commands\BackupDatabase
+ "id": "cmd-acme-backup-database"                   label: acme:backup-database
```

The label becomes the command a person actually types, which is the point. But the tab id is derived from it, so **every command that gains a signature is re-keyed, along with the call-chain hops beneath it** — measured on one application with five such commands: 173 stored subgraph blobs became unaddressable and 178 new ones took their place.

Those ids are what the viewer lists and what a saved link points at, so a bookmark to one of those tabs stops resolving. The orphaned blobs are cleaned up by #98 if that lands first; without it they stay on disk.

An application with no attribute-declared commands sees none of this.

