### PR TITLE
Feat: read service providers and facades from configurable paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,23 @@ From each controller action (and Filament page method), the tracer follows:
 
 This produces the full edge list used to build the graph.
 
+### Service providers and facades
+
+Container registrations (`bind()`, `singleton()`, `scoped()` and their `*If` variants, plus the `$bindings` property) are read from service providers, and application-level facades — classes whose inheritance chain reaches `Illuminate\Support\Facades\Facade` — from the application's source tree. Both feed the graph: an edge that lands on an interface or an abstract class is wired through to the concrete class bound to it, and a facade call is wired through to the class behind its accessor.
+
+Both directories default to the standard skeleton and take glob patterns, so an application whose providers and facades live in packages points them at its own layout:
+
+```php
+// config/laravel-brain.php
+'container_bindings' => [
+    'provider_paths' => ['app-modules/*/src'],
+],
+
+'facades' => [
+    'paths' => ['app-modules/*/src'],
+],
+```
+
 ### Filament PHP support
 
 When Filament is installed, the scanner discovers every panel registered via service providers, then resolves its resources, pages, widgets, and relation managers — both explicitly listed (`->resources([...])`) and auto-discovered (`->discoverResources(for: '...')`). Filament page methods are traced through the same call-chain engine as controller actions, so models and services they touch appear in the graph.

--- a/config/laravel-brain.php
+++ b/config/laravel-brain.php
@@ -351,6 +351,42 @@ return [
     ],
 
     // -------------------------------------------------------------------------
+    // Container Binding Search Paths
+    // -------------------------------------------------------------------------
+    // Directories holding service providers, scanned recursively for container
+    // registrations: bind() / singleton() / scoped() (and their *If variants) plus
+    // the $bindings property.
+    //
+    // An entry is used as-is when it is a directory and expanded as a glob pattern
+    // otherwise, so an application whose providers live in packages can say:
+    //
+    //   'provider_paths' => ['app-modules/*/src'],
+    //
+    'container_bindings' => [
+        'provider_paths' => [
+            'app/Providers',
+        ],
+    ],
+
+    // -------------------------------------------------------------------------
+    // Facade Search Paths
+    // -------------------------------------------------------------------------
+    // Directories scanned for application-level facades — classes whose inheritance
+    // chain reaches Illuminate\Support\Facades\Facade. The same directories back the
+    // by-short-name lookup used to follow a facade's parent chain, so a base facade
+    // must be inside them too.
+    //
+    // Glob patterns are expanded, as above:
+    //
+    //   'paths' => ['app-modules/*/src'],
+    //
+    'facades' => [
+        'paths' => [
+            'app',
+        ],
+    ],
+
+    // -------------------------------------------------------------------------
     // Livewire Component Search Paths
     // -------------------------------------------------------------------------
     // Directories (relative to project root) that are searched when resolving

--- a/src/Analysis/ContainerBindingAnalyzer.php
+++ b/src/Analysis/ContainerBindingAnalyzer.php
@@ -18,35 +18,48 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 
 /**
- * Scans app/Providers for Laravel container registrations (bind/singleton/scoped and $bindings).
+ * Scans service providers for Laravel container registrations (bind/singleton/scoped
+ * and $bindings).
  */
 final class ContainerBindingAnalyzer
 {
+    /**
+     * Where providers live in a default Laravel skeleton.
+     *
+     * @var string[]
+     */
+    public const DEFAULT_PROVIDER_PATHS = ['app/Providers'];
+
     private PhpFileParser $parser;
+
+    /** @var string[] provider directories, relative to the project root */
+    private array $providerPaths;
 
     /** @var list<string> */
     private const BIND_METHODS = ['bind', 'singleton', 'scoped', 'bindIf', 'singletonIf', 'scopedIf'];
 
-    public function __construct(?PhpFileParser $parser = null)
-    {
+    /**
+     * @param  string[]  $providerPaths  provider directories, relative to the project root;
+     *                                   glob patterns are expanded
+     */
+    public function __construct(
+        ?PhpFileParser $parser = null,
+        array $providerPaths = self::DEFAULT_PROVIDER_PATHS,
+    ) {
         $this->parser = $parser ?? new PhpFileParser;
+        $this->providerPaths = $providerPaths;
     }
 
     public function analyze(string $projectRoot): ContainerBindingRegistry
     {
         $registry = new ContainerBindingRegistry;
         $root = rtrim($projectRoot, '/');
-        if (! is_dir($root.'/app/Providers')) {
-            return $registry;
-        }
+        $directories = SourceDirectories::resolve($root, $this->providerPaths);
 
-        $files = [];
-        foreach ([$root.'/app/Providers/*.php', $root.'/app/Providers/**/*.php'] as $pattern) {
-            foreach (glob($pattern) ?: [] as $file) {
-                $files[$file] = true;
-            }
-        }
-        $paths = array_keys($files);
+        // Recursive, where this used to be `*.php` plus `**/*.php`: PHP's glob does not
+        // cross directory separators, so the second pattern reached exactly one level down
+        // and a provider nested any deeper was silently skipped.
+        $paths = iterator_to_array(SourceDirectories::phpFiles($root, $directories), false);
         sort($paths);
 
         foreach ($paths as $file) {

--- a/src/Analysis/FacadeAnalyzer.php
+++ b/src/Analysis/FacadeAnalyzer.php
@@ -14,7 +14,8 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Namespace_;
 
 /**
- * Scans app/ for application-level Laravel facades and builds a FacadeRegistry.
+ * Scans the application's source directories for application-level Laravel facades
+ * and builds a FacadeRegistry.
  *
  * A facade is any concrete class whose inheritance chain leads to
  * Illuminate\Support\Facades\Facade (multi-level inheritance is supported, e.g.
@@ -29,18 +30,34 @@ final class FacadeAnalyzer
 {
     private const FACADE_BASE = 'Illuminate\\Support\\Facades\\Facade';
 
+    /**
+     * Where application source lives in a default Laravel skeleton.
+     *
+     * @var string[]
+     */
+    public const DEFAULT_PATHS = ['app'];
+
     private PhpFileParser $parser;
 
-    private string $appDir = '';
+    /** @var string[] source directories, relative to the project root */
+    private array $paths;
+
+    /** @var string[] the subset of that exists, relative to the project root */
+    private array $sourceDirs = [];
 
     private string $projectRoot = '';
 
     /** @var array<string, array{ast: mixed, useMap: array<string,string>}|null> */
     private array $parseCache = [];
 
-    public function __construct(?PhpFileParser $parser = null)
+    /**
+     * @param  string[]  $paths  source directories, relative to the project root;
+     *                           glob patterns are expanded
+     */
+    public function __construct(?PhpFileParser $parser = null, array $paths = self::DEFAULT_PATHS)
     {
         $this->parser = $parser ?? new PhpFileParser;
+        $this->paths = $paths;
     }
 
     public function analyze(string $projectRoot): FacadeRegistry
@@ -49,22 +66,16 @@ final class FacadeAnalyzer
         $this->parseCache = [];
         $this->facadeChainShortNames = [];
         $this->projectRoot = rtrim($projectRoot, '/');
-        $this->appDir = $this->projectRoot.'/app';
+        $this->sourceDirs = SourceDirectories::resolve($this->projectRoot, $this->paths);
 
-        if (! is_dir($this->appDir)) {
+        if ($this->sourceDirs === []) {
             return $registry;
         }
 
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($this->appDir, \FilesystemIterator::SKIP_DOTS)
+        $files = iterator_to_array(
+            SourceDirectories::phpFiles($this->projectRoot, $this->sourceDirs),
+            false,
         );
-
-        $files = [];
-        foreach ($iterator as $file) {
-            if ($file->getExtension() === 'php') {
-                $files[] = $file->getPathname();
-            }
-        }
 
         // Round one: only files that name Facade at all. A facade reaches Illuminate's Facade
         // through `extends`, and naming that class — imported, aliased or fully qualified —
@@ -214,7 +225,7 @@ final class FacadeAnalyzer
             return false;
         }
 
-        $file = $this->findFileInAppDir($fqcn);
+        $file = $this->findFileInSourceDirs($fqcn);
         if ($file === null) {
             return false;
         }
@@ -263,7 +274,7 @@ final class FacadeAnalyzer
             return null;
         }
 
-        $file = $this->findFileInAppDir($parentFqcn);
+        $file = $this->findFileInSourceDirs($parentFqcn);
         if ($file === null) {
             return null;
         }
@@ -359,10 +370,10 @@ final class FacadeAnalyzer
     }
 
     /**
-     * Find the PHP file for a FQCN by searching app/ for a file whose name
-     * matches the short class name.
+     * Find the PHP file for a FQCN by searching the configured source directories
+     * for a file whose name matches the short class name.
      */
-    private function findFileInAppDir(string $fqcn): ?string
+    private function findFileInSourceDirs(string $fqcn): ?string
     {
         if ($this->projectRoot === '') {
             return null;
@@ -372,7 +383,7 @@ final class FacadeAnalyzer
             ? substr($fqcn, strrpos($fqcn, '\\') + 1)
             : $fqcn;
 
-        return ProjectFileIndex::findFile($this->projectRoot, ['app'], $shortName.'.php');
+        return ProjectFileIndex::findFile($this->projectRoot, $this->sourceDirs, $shortName.'.php');
     }
 
     /**

--- a/src/Analysis/ProjectAnalyzer.php
+++ b/src/Analysis/ProjectAnalyzer.php
@@ -66,6 +66,12 @@ class ProjectAnalyzer
 
     private GraphSplitter $graphSplitter;
 
+    /** @var string[] */
+    private array $bindingProviderPaths = ContainerBindingAnalyzer::DEFAULT_PROVIDER_PATHS;
+
+    /** @var string[] */
+    private array $facadePaths = FacadeAnalyzer::DEFAULT_PATHS;
+
     /** @var callable(string, array): void */
     private $onProgress;
 
@@ -131,6 +137,17 @@ class ProjectAnalyzer
             trustedRouteUris: $this->stringList(config('laravel-brain.security.trusted_route_uris', [])),
         );
         $this->graphBuilder = new GraphBuilder;
+        $bindingProviderPaths = config(
+            'laravel-brain.container_bindings.provider_paths',
+            ContainerBindingAnalyzer::DEFAULT_PROVIDER_PATHS,
+        );
+        $this->bindingProviderPaths = is_array($bindingProviderPaths)
+            ? $bindingProviderPaths
+            : ContainerBindingAnalyzer::DEFAULT_PROVIDER_PATHS;
+
+        $facadePaths = config('laravel-brain.facades.paths', FacadeAnalyzer::DEFAULT_PATHS);
+        $this->facadePaths = is_array($facadePaths) ? $facadePaths : FacadeAnalyzer::DEFAULT_PATHS;
+
         $livewirePaths = config('laravel-brain.livewire.component_paths', []);
         if (is_array($livewirePaths) && $livewirePaths !== []) {
             $this->graphBuilder->setLivewireComponentPaths($livewirePaths);
@@ -417,12 +434,12 @@ class ProjectAnalyzer
         $this->emit('step:done', ['step' => 'security', 'count' => $issueCount, 'unit' => 'issue', 'message' => "    Found {$issueCount} security issue(s) across ".count($securityMap).' route(s)']);
 
         $this->emit('step:start', ['step' => 'container_bindings', 'label' => 'Scanning service providers', 'message' => '  → Scanning service providers (IoC bindings)...']);
-        $bindingRegistry = (new ContainerBindingAnalyzer)->analyze($projectRoot);
+        $bindingRegistry = (new ContainerBindingAnalyzer(null, $this->bindingProviderPaths))->analyze($projectRoot);
         $bindingCount = count($bindingRegistry->all());
         $this->emit('step:done', ['step' => 'container_bindings', 'count' => $bindingCount, 'unit' => 'binding', 'message' => "    Found {$bindingCount} container binding(s)"]);
 
         $this->emit('step:start', ['step' => 'facades', 'label' => 'Scanning facades', 'message' => '  → Scanning application facades...']);
-        $facadeRegistry = (new FacadeAnalyzer)->analyze($projectRoot);
+        $facadeRegistry = (new FacadeAnalyzer(null, $this->facadePaths))->analyze($projectRoot);
         $facadeRegistry->resolveWith($bindingRegistry);
         $facadeCount = count($facadeRegistry->all());
         $this->emit('step:done', ['step' => 'facades', 'count' => $facadeCount, 'unit' => 'facade', 'message' => "    Found {$facadeCount} facade(s)"]);

--- a/src/Analysis/SourceDirectories.php
+++ b/src/Analysis/SourceDirectories.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaraMint\LaravelBrain\Analysis;
+
+/**
+ * Expands configured source paths into the directories that actually exist.
+ *
+ * An entry is taken verbatim when it names a directory and treated as a glob
+ * pattern otherwise, which is what lets an application whose code lives in
+ * packages rather than in `app/` point an analyzer at its own layout —
+ * `app-modules/*` + `/src`, `packages/*` + `/src/Providers`, and so on.
+ *
+ * Paths stay relative to the project root on the way out: that is the form
+ * {@see ProjectFileIndex} takes, and prefixing the root is a concatenation.
+ */
+final class SourceDirectories
+{
+    /**
+     * @param  string[]  $patterns  paths or glob patterns, relative to the project root
+     * @return string[] existing directories, relative to the project root
+     */
+    public static function resolve(string $projectRoot, array $patterns): array
+    {
+        $root = rtrim($projectRoot, '/');
+        $directories = [];
+
+        foreach ($patterns as $pattern) {
+            $pattern = trim((string) $pattern);
+            if ($pattern === '') {
+                continue;
+            }
+
+            $absolute = $root.'/'.ltrim($pattern, '/');
+
+            if (is_dir($absolute)) {
+                $directories[] = ltrim($pattern, '/');
+
+                continue;
+            }
+
+            foreach (glob($absolute, GLOB_ONLYDIR | GLOB_BRACE) ?: [] as $match) {
+                $directories[] = ltrim(substr($match, strlen($root)), '/');
+            }
+        }
+
+        return array_values(array_unique($directories));
+    }
+
+    /**
+     * Every PHP file below the given directories, each file yielded once even when
+     * the directories overlap.
+     *
+     * @param  string[]  $directories  relative to the project root
+     * @return iterable<string> absolute file paths
+     */
+    public static function phpFiles(string $projectRoot, array $directories): iterable
+    {
+        $root = rtrim($projectRoot, '/');
+        $seen = [];
+
+        foreach ($directories as $directory) {
+            $absolute = $root.'/'.ltrim($directory, '/');
+            if (! is_dir($absolute)) {
+                continue;
+            }
+
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($absolute, \FilesystemIterator::SKIP_DOTS)
+            );
+
+            foreach ($iterator as $entry) {
+                if (! $entry->isFile() || $entry->getExtension() !== 'php') {
+                    continue;
+                }
+
+                $path = $entry->getRealPath() ?: $entry->getPathname();
+                if (isset($seen[$path])) {
+                    continue;
+                }
+                $seen[$path] = true;
+
+                yield $path;
+            }
+        }
+    }
+}

--- a/tests/Unit/ContainerBindingAnalyzerTest.php
+++ b/tests/Unit/ContainerBindingAnalyzerTest.php
@@ -23,3 +23,41 @@ it('extracts bindings from a provider that opens with declare(strict_types=1)', 
         ->providerFqcn->toBe('App\Providers\StrictTypesServiceProvider')
         ->kind->toBe('singleton');
 });
+
+// ── Configurable provider paths ───────────────────────────────────────────────
+
+it('finds nothing in a packaged application while the default app/Providers path is used', function () {
+    $registry = (new ContainerBindingAnalyzer)->analyze(fixture('packaged-app'));
+
+    expect($registry->get('Acme\Billing\Support\LedgerInterface'))->toBeNull();
+});
+
+it('reads bindings from providers that live in packages', function () {
+    $registry = (new ContainerBindingAnalyzer(null, ['packages/*/src/Providers']))
+        ->analyze(fixture('packaged-app'));
+
+    expect($registry->get('Acme\Billing\Support\LedgerInterface'))
+        ->concreteFqcn->toBe('Acme\Billing\Support\SqlLedger')
+        ->providerFqcn->toBe('Acme\Billing\Providers\BillingServiceProvider')
+        ->kind->toBe('singleton');
+});
+
+it('reaches a provider nested more than one directory deep', function () {
+    // The scan used to be `*.php` plus `**/*.php`, and PHP's glob does not cross
+    // directory separators — so exactly one level down was as far as it went.
+    $registry = (new ContainerBindingAnalyzer(null, ['packages/*/src/Providers']))
+        ->analyze(fixture('packaged-app'));
+
+    expect($registry->get('Acme\Billing\Support\InvoiceNumberer'))
+        ->concreteFqcn->toBe('Acme\Billing\Support\SequentialInvoiceNumberer')
+        ->providerFqcn->toBe('Acme\Billing\Providers\Nested\InvoiceServiceProvider')
+        ->kind->toBe('bind');
+});
+
+it('still reads app/Providers when it is among the configured paths', function () {
+    $registry = (new ContainerBindingAnalyzer(null, ['app/Providers', 'packages/*/src/Providers']))
+        ->analyze(fixture('laravel-project'));
+
+    expect($registry->get('App\Contracts\ThingRepositoryInterface'))
+        ->concreteFqcn->toBe('App\Repositories\SqlThingRepository');
+});

--- a/tests/Unit/FacadeAnalyzerTest.php
+++ b/tests/Unit/FacadeAnalyzerTest.php
@@ -179,3 +179,44 @@ it('discovers a facade whose own file never mentions Facade', function () {
 
     exec('rm -rf '.escapeshellarg($root));
 });
+
+// ── Configurable source paths ─────────────────────────────────────────────────
+
+it('finds nothing in a packaged application while the default app/ path is used', function () {
+    $registry = (new FacadeAnalyzer)->analyze(fixture('packaged-app'));
+
+    expect($registry->get('Acme\Billing\Facades\Ledger'))->toBeNull();
+});
+
+it('discovers facades that live in packages', function () {
+    $registry = (new FacadeAnalyzer(null, ['packages/*/src']))->analyze(fixture('packaged-app'));
+
+    expect($registry->get('Acme\Billing\Facades\Ledger'))
+        ->toBeInstanceOf(FacadeRecord::class)
+        ->accessor->toBe('Acme\Billing\Support\LedgerService')
+        ->concreteFqcn->toBe('Acme\Billing\Support\LedgerService');
+});
+
+it('follows a facade parent chain that crosses package boundaries', function () {
+    // Carrier extends AbstractCarrierFacade, which lives in a different package —
+    // the by-short-name lookup has to search every configured directory, not one.
+    $registry = (new FacadeAnalyzer(null, ['packages/*/src']))->analyze(fixture('packaged-app'));
+
+    expect($registry->get('Acme\Shipping\Facades\Carrier'))
+        ->toBeInstanceOf(FacadeRecord::class)
+        ->accessor->toBe('carrier');
+});
+
+it('does not register the abstract base facade of a packaged application', function () {
+    $registry = (new FacadeAnalyzer(null, ['packages/*/src']))->analyze(fixture('packaged-app'));
+
+    expect($registry->get('Acme\Shipping\Facades\AbstractCarrierFacade'))->toBeNull();
+});
+
+it('still discovers app/ facades when app is among the configured paths', function () {
+    $registry = (new FacadeAnalyzer(null, ['app', 'packages/*/src']))->analyze(fixture('laravel-project'));
+
+    expect($registry->get('App\Services\V3\ShortUrlV3Facade'))
+        ->toBeInstanceOf(FacadeRecord::class)
+        ->accessor->toBe('App\Services\V3\ShortUrlV3Service');
+});

--- a/tests/fixtures/packaged-app/packages/billing/src/Facades/Ledger.php
+++ b/tests/fixtures/packaged-app/packages/billing/src/Facades/Ledger.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Acme\Billing\Facades;
+
+use Acme\Billing\Support\LedgerService;
+use Illuminate\Support\Facades\Facade;
+
+class Ledger extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return LedgerService::class;
+    }
+}

--- a/tests/fixtures/packaged-app/packages/billing/src/Providers/BillingServiceProvider.php
+++ b/tests/fixtures/packaged-app/packages/billing/src/Providers/BillingServiceProvider.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acme\Billing\Providers;
+
+use Acme\Billing\Support\LedgerInterface;
+use Acme\Billing\Support\SqlLedger;
+use Illuminate\Support\ServiceProvider;
+
+class BillingServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->singleton(LedgerInterface::class, SqlLedger::class);
+    }
+}

--- a/tests/fixtures/packaged-app/packages/billing/src/Providers/Nested/InvoiceServiceProvider.php
+++ b/tests/fixtures/packaged-app/packages/billing/src/Providers/Nested/InvoiceServiceProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Acme\Billing\Providers\Nested;
+
+use Acme\Billing\Support\InvoiceNumberer;
+use Acme\Billing\Support\SequentialInvoiceNumberer;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Two directory levels below the configured provider path — deeper than a glob
+ * can reach without crossing separators.
+ */
+class InvoiceServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->bind(InvoiceNumberer::class, SequentialInvoiceNumberer::class);
+    }
+}

--- a/tests/fixtures/packaged-app/packages/billing/src/Support/InvoiceNumberer.php
+++ b/tests/fixtures/packaged-app/packages/billing/src/Support/InvoiceNumberer.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Acme\Billing\Support;
+
+interface InvoiceNumberer {}

--- a/tests/fixtures/packaged-app/packages/billing/src/Support/LedgerInterface.php
+++ b/tests/fixtures/packaged-app/packages/billing/src/Support/LedgerInterface.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Acme\Billing\Support;
+
+interface LedgerInterface {}

--- a/tests/fixtures/packaged-app/packages/billing/src/Support/LedgerService.php
+++ b/tests/fixtures/packaged-app/packages/billing/src/Support/LedgerService.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Acme\Billing\Support;
+
+class LedgerService {}

--- a/tests/fixtures/packaged-app/packages/billing/src/Support/SequentialInvoiceNumberer.php
+++ b/tests/fixtures/packaged-app/packages/billing/src/Support/SequentialInvoiceNumberer.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Acme\Billing\Support;
+
+class SequentialInvoiceNumberer implements InvoiceNumberer {}

--- a/tests/fixtures/packaged-app/packages/billing/src/Support/SqlLedger.php
+++ b/tests/fixtures/packaged-app/packages/billing/src/Support/SqlLedger.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Acme\Billing\Support;
+
+class SqlLedger implements LedgerInterface {}

--- a/tests/fixtures/packaged-app/packages/shipping/src/Facades/AbstractCarrierFacade.php
+++ b/tests/fixtures/packaged-app/packages/shipping/src/Facades/AbstractCarrierFacade.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Acme\Shipping\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+abstract class AbstractCarrierFacade extends Facade {}

--- a/tests/fixtures/packaged-app/packages/shipping/src/Facades/Carrier.php
+++ b/tests/fixtures/packaged-app/packages/shipping/src/Facades/Carrier.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Acme\Shipping\Facades;
+
+/**
+ * Reaches Illuminate's Facade only through a base class that lives in ANOTHER
+ * package: the parent chain has to be followed across the configured directories,
+ * not just inside one of them.
+ */
+class Carrier extends AbstractCarrierFacade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return 'carrier';
+    }
+}


### PR DESCRIPTION
## Read service providers and facades from wherever they live

`ContainerBindingAnalyzer` looks in `app/Providers` and `FacadeAnalyzer` in `app/`, both hardcoded. An application that keeps its providers and facades in packages therefore reports `0 bindings` and `0 facades` - not an error, just an empty result - and with them the graph loses two kinds of edge: the one that wires an interface or abstract class through to the concrete class bound to it, and the one that wires a facade through to the class behind its accessor.

Both paths become configurable, defaulting to what they are today.

```php
// config/laravel-brain.php
'container_bindings' => [
    'provider_paths' => ['app-modules/*/src'],
],

'facades' => [
    'paths' => ['app-modules/*/src'],
],
```

An entry is used as-is when it names a directory and expanded as a glob pattern otherwise. A shared `SourceDirectories` helper does that expansion and the recursive PHP-file walk for both analyzers, de-duplicating by real path so overlapping patterns cannot scan a file twice.

### Two details that are easy to miss

**`FacadeAnalyzer` hardcodes `app/` in two places, not one.** Besides the directory it iterates, the by-short-name lookup it uses to follow a facade's parent chain is pinned to `['app']`. Fixing only the first finds facades that extend Illuminate's `Facade` directly and loses every facade that reaches it through an application-level base class - exactly the case the analyzer's second pass exists to handle. Both now follow the configured directories, and `findFileInAppDir()` is renamed to `findFileInSourceDirs()` to stop the old assumption reading as intentional. There is a test for a facade whose base class lives in a *different* package.

**`ContainerBindingAnalyzer` never reached deeply nested providers, even under the default path.** The scan was `app/Providers/*.php` plus `app/Providers/**/*.php`, and PHP's `glob()` does not cross directory separators - `**` matches a single segment like `*` does. So `app/Providers/Domain/Billing/BillingServiceProvider.php` was silently skipped. The walk is now recursive, which fixes that independently of the path change; a fixture provider sits two levels down to pin it.

### Tests

9 new tests, no existing test changed, against a new `packaged-app` fixture: two packages, a provider nested two levels deep, a facade with a `::class` accessor, a facade whose base class lives in another package, and an abstract base as a negative control. Each analyzer gets a test asserting that the *same* fixture yields nothing under the default paths, and one asserting that `app/` still works when it is among the configured paths.

Full suite: `263 passed (870 assertions)`, up from 254. `pint` clean, `phpstan` 0 errors.

### Verified against a real application

A ~90-package monolith with no `app/` directory:

| | before | after |
|---|---|---|
| container bindings | 0 | 57 |
| facades | 0 | 4 |

Node and edge totals are unchanged in that run, which is what should happen: these registries do not create nodes, they wire existing ones. `maybeWireContainerBinding()` fires only when a call-chain edge lands on an interface or abstract class, and in the application measured the call chains are still thin for an unrelated reason (its classes live in packages the PSR-4 map does not cover - a separate change). The 57 bindings are real and correctly attributed; what they wire up grows as the call graph does.

### Compatibility

Defaults are the previous hardcoded paths, so a standard Laravel application scans exactly as before, with one deliberate exception: a provider nested more than one directory below `app/Providers` is now found.

That is a behaviour change on a default installation, not only on the layouts this PR is about. An application that keeps providers in, say, `app/Providers/Domain/Billing/` gains the bindings they register and the interface-to-concrete edges that follow from them — a graph that grew after upgrading, with nothing in the configuration changed, is explained by this. It is the behaviour the glob was reaching for and never achieved, so the fix is right; it is worth knowing it is visible.

Both analyzer constructors gain one optional argument after the existing `?PhpFileParser`.
