### PR TITLE
Recognise every framework auth middleware, not only Authenticate

### DIFF
--- a/src/Analysis/SecurityAnalyzer.php
+++ b/src/Analysis/SecurityAnalyzer.php
@@ -52,6 +52,25 @@ class SecurityAnalyzer
         'Illuminate\\Routing\\Middleware\\ValidateSignature',
     ];
 
+    /**
+     * The framework middlewares an `extends` chain terminates on, which is the
+     * same set the patterns above name — by alias (`auth`, `verified`,
+     * `signed`) or literally. Matching a name and walking a chain
+     * are two ways of asking one question, so they answer from one list: a
+     * middleware that IS one of these classes, or descends from one, gates the
+     * request whichever form it reaches this analyzer in.
+     *
+     * The chain is what a name cannot see. `App\Http\Middleware\RequireOtp
+     * extends EnsureEmailIsVerified` matches no pattern and no basename, and
+     * its route is classified `public` on a guard that is really there.
+     */
+    private const AUTH_BASE_CLASSES = [
+        'Illuminate\\Auth\\Middleware\\Authenticate',
+        'Illuminate\\Auth\\Middleware\\AuthenticateWithBasicAuth',
+        'Illuminate\\Auth\\Middleware\\EnsureEmailIsVerified',
+        'Illuminate\\Routing\\Middleware\\ValidateSignature',
+    ];
+
     /** Middleware that redirects authenticated users away (login/register pages). */
     private const GUEST_PATTERNS = [
         'guest',
@@ -622,9 +641,10 @@ class SecurityAnalyzer
     }
 
     /**
-     * True when $fqcn is the framework's Authenticate middleware or any class
-     * whose `extends` chain reaches it. Results are memoised per scan so each
-     * FQCN is walked at most once.
+     * True when $fqcn is one of the framework middlewares in
+     * {@see self::AUTH_BASE_CLASSES} or any class whose `extends` chain
+     * reaches one. Results are memoised per scan so each FQCN is walked at
+     * most once.
      */
     private function isAuthClass(string $fqcn): bool
     {
@@ -635,7 +655,7 @@ class SecurityAnalyzer
         if (isset($this->authClassCache[$fqcn])) {
             return $this->authClassCache[$fqcn];
         }
-        if ($fqcn === 'Illuminate\\Auth\\Middleware\\Authenticate') {
+        if (in_array($fqcn, self::AUTH_BASE_CLASSES, true)) {
             return $this->authClassCache[$fqcn] = true;
         }
 

--- a/src/Analysis/SecurityAnalyzer.php
+++ b/src/Analysis/SecurityAnalyzer.php
@@ -43,6 +43,7 @@ class SecurityAnalyzer
      */
     private const AUTH_PATTERNS = [
         'auth',
+        'auth.basic',
         'sanctum',
         'jwt',
         'passport',
@@ -54,8 +55,8 @@ class SecurityAnalyzer
 
     /**
      * The framework middlewares an `extends` chain terminates on, which is the
-     * same set the patterns above name — by alias (`auth`, `verified`,
-     * `signed`) or literally. Matching a name and walking a chain
+     * same set the patterns above name — by alias (`auth`, `auth.basic`,
+     * `verified`, `signed`) or literally. Matching a name and walking a chain
      * are two ways of asking one question, so they answer from one list: a
      * middleware that IS one of these classes, or descends from one, gates the
      * request whichever form it reaches this analyzer in.

--- a/tests/Unit/SecurityAnalyzerTest.php
+++ b/tests/Unit/SecurityAnalyzerTest.php
@@ -533,3 +533,67 @@ it('terminates on a cyclic middleware extends chain instead of exhausting memory
     expect($analysis['route::POST::/cyclic']['exposure'])->toBe('public')
         ->and(issueTypes($analysis, 'route::POST::/cyclic'))->toContain('PUBLIC_WRITE');
 });
+
+// =============================================================================
+// The same walk, for the other three framework auth middlewares. `Authenticate`
+// is not the only class an application extends to build a guard, and a
+// descendant of the other three matched no pattern, no basename and no chain.
+// =============================================================================
+
+it('classifies a descendant of any framework auth middleware as authed', function (string $middleware) {
+    $route = makeSecurityRoute('DELETE', '/records/{record}', [$middleware]);
+
+    $analysis = (new SecurityAnalyzer)->analyze(
+        [$route],
+        new MiddlewareRegistry([], [], []),
+        [],
+        customAuthFixtureRoot(),
+    );
+
+    $routeId = 'route::DELETE::/records/{record}';
+    expect($analysis[$routeId]['exposure'])->toBe('authed')
+        ->and(issueTypes($analysis, $routeId))->not->toContain('PUBLIC_WRITE');
+})->with([
+    'basic auth' => 'App\\Http\\Middleware\\RequireBasicCredentials',
+    'email verification' => 'App\\Http\\Middleware\\RequireOtp',
+    'signed URL' => 'App\\Http\\Middleware\\CheckSignedLink',
+    // Two hops: the walk follows a parent it cannot match rather than stopping there.
+    'signed URL, one class further out' => 'App\\Http\\Middleware\\CheckExpiringSignedLink',
+]);
+
+it('classifies the framework auth middlewares themselves as authed by class name', function (string $middleware) {
+    // The same question asked of the class an application registers directly.
+    // `AuthenticateWithBasicAuth` and `EnsureEmailIsVerified` were classified
+    // `public` here, while their `auth.basic` and `verified` aliases were not —
+    // one middleware, two answers, decided by the form it arrived in.
+    $route = makeSecurityRoute('POST', '/records', [$middleware]);
+
+    $analysis = (new SecurityAnalyzer)->analyze(
+        [$route],
+        new MiddlewareRegistry([], [], []),
+        [],
+        customAuthFixtureRoot(),
+    );
+
+    expect($analysis['route::POST::/records']['exposure'])->toBe('authed');
+})->with([
+    'Illuminate\\Auth\\Middleware\\Authenticate',
+    'Illuminate\\Auth\\Middleware\\AuthenticateWithBasicAuth',
+    'Illuminate\\Auth\\Middleware\\EnsureEmailIsVerified',
+    'Illuminate\\Routing\\Middleware\\ValidateSignature',
+]);
+
+it('still classifies a middleware that authenticates nothing as public', function () {
+    // The widening is four framework classes, not "anything with a parent".
+    $route = makeSecurityRoute('POST', '/records', ['App\\Http\\Middleware\\CyclicA']);
+
+    $analysis = (new SecurityAnalyzer)->analyze(
+        [$route],
+        new MiddlewareRegistry([], [], []),
+        [],
+        customAuthFixtureRoot(),
+    );
+
+    expect($analysis['route::POST::/records']['exposure'])->toBe('public')
+        ->and(issueTypes($analysis, 'route::POST::/records'))->toContain('PUBLIC_WRITE');
+});

--- a/tests/Unit/SecurityAnalyzerTest.php
+++ b/tests/Unit/SecurityAnalyzerTest.php
@@ -583,6 +583,15 @@ it('classifies the framework auth middlewares themselves as authed by class name
     'Illuminate\\Routing\\Middleware\\ValidateSignature',
 ]);
 
+it('classifies the auth.basic alias as authed', function () {
+    // Laravel's own alias for AuthenticateWithBasicAuth. It is not the `auth`
+    // pattern — that one matches `auth`, `auth:…` and `auth\…`, never a dotted
+    // sibling — so it needs naming in its own right.
+    $route = makeSecurityRoute('POST', '/records', ['auth.basic']);
+
+    expect(exposure($route, new MiddlewareRegistry([], [], [])))->toBe('authed');
+});
+
 it('still classifies a middleware that authenticates nothing as public', function () {
     // The widening is four framework classes, not "anything with a parent".
     $route = makeSecurityRoute('POST', '/records', ['App\\Http\\Middleware\\CyclicA']);

--- a/tests/fixtures/custom-auth-project/app/Http/Middleware/CheckExpiringSignedLink.php
+++ b/tests/fixtures/custom-auth-project/app/Http/Middleware/CheckExpiringSignedLink.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Http\Middleware;
+
+/**
+ * Two hops from the framework class: the walk has to keep following parents,
+ * not stop at the first one it cannot match.
+ */
+class CheckExpiringSignedLink extends CheckSignedLink {}

--- a/tests/fixtures/custom-auth-project/app/Http/Middleware/CheckSignedLink.php
+++ b/tests/fixtures/custom-auth-project/app/Http/Middleware/CheckSignedLink.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Routing\Middleware\ValidateSignature;
+
+/** A signed-URL guard renamed for the application, one hop from the framework class. */
+class CheckSignedLink extends ValidateSignature {}

--- a/tests/fixtures/custom-auth-project/app/Http/Middleware/RequireBasicCredentials.php
+++ b/tests/fixtures/custom-auth-project/app/Http/Middleware/RequireBasicCredentials.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Auth\Middleware\AuthenticateWithBasicAuth;
+
+/**
+ * A guard on top of HTTP Basic auth — the shape a machine-to-machine endpoint
+ * takes. Nothing in its name says "auth", and `auth.basic` is not the `auth`
+ * pattern, so only the extends chain recognises it.
+ */
+class RequireBasicCredentials extends AuthenticateWithBasicAuth {}

--- a/tests/fixtures/custom-auth-project/app/Http/Middleware/RequireOtp.php
+++ b/tests/fixtures/custom-auth-project/app/Http/Middleware/RequireOtp.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Auth\Middleware\EnsureEmailIsVerified;
+
+/**
+ * A second confirmation step layered on the framework's verification guard.
+ * The `verified` alias is already an auth pattern; this is the same guard
+ * under a name of the application's own.
+ */
+class RequireOtp extends EnsureEmailIsVerified {}


### PR DESCRIPTION
## What

The `extends` walk added in #51 terminates on one class, `Illuminate\Auth\Middleware\Authenticate`. An application builds a guard by extending whichever framework middleware does the check it needs, and there are four. A descendant of the other three matched no pattern, no basename and no chain.

The walk now terminates on all four, from one list beside the patterns it mirrors.

Measured before the change, one route per row, `POST` with no other middleware:

| the middleware a route carries | before | after |
|---|---|---|
| `auth` (alias) | `authed` | `authed` |
| `verified` (alias) | `authed` | `authed` |
| `signed` (alias) | `authed` | `authed` |
| `auth.basic` (alias) | **`public`** | `authed` |
| `Illuminate\Auth\Middleware\Authenticate` | `authed` | `authed` |
| `Illuminate\Routing\Middleware\ValidateSignature` | `authed` | `authed` |
| `Illuminate\Auth\Middleware\AuthenticateWithBasicAuth` | **`public`** | `authed` |
| `Illuminate\Auth\Middleware\EnsureEmailIsVerified` | **`public`** | `authed` |

Every `public` in that column is a mutating route drawing a `PUBLIC_WRITE` — "anyone can call this endpoint" — on a route that is guarded.

## The inconsistency it removes

Read the table by pairs and the bug is not "three classes are missing". It is that **one middleware got two answers depending on the form it arrived in**: `verified` is authentication, `EnsureEmailIsVerified` — the class that alias resolves to — was not. An application that registers the alias itself (`$middleware->alias(['verified' => EnsureEmailIsVerified::class])`) hands the analyzer the FQCN, and the same guard silently changes meaning.

So this is not a new opinion about what counts as authentication. It is the existing opinion, applied to whichever form the middleware reaches `classifyExposure()` in. Matching a name and walking a chain are two ways of asking one question, and they now answer from one list.

## Why these four

They are the classes `AUTH_PATTERNS` already reaches, by alias or literally — with one gap that had to be closed for the sentence to be true: `auth.basic` is not the `auth` pattern (`auth` matches `auth`, `auth:…` and `auth\…`, never a dotted sibling), so Laravel's own alias for HTTP Basic auth was read as no guard at all. The second commit names it.

## The honest limit

`EnsureEmailIsVerified` does not itself authenticate. It presupposes a user and checks a property of them, and in real applications it is always paired with `auth`. Including it is defensible only because Brain already treats its alias as authentication — `verified` has been in `AUTH_PATTERNS` from the start — so this makes the class agree with the alias rather than deciding something new.

If you would rather Brain did not treat verification as authentication, the change to make is removing `verified` from `AUTH_PATTERNS` and this base with it. That is a one-line pair and I am happy to send it; what should not stay is the current state, where the answer depends on which of the two forms an application happened to write.

## What it still does not cover

- **A named middleware group.** `classifyExposure()` reads the resolved middleware list, and `resolveMiddlewares()` resolves aliases only — `MiddlewareRegistry::resolveGroup()` still has no caller. A route gated only by a member of an `api`/`web` group is unchanged by this PR.
- **A middleware that authenticates without extending a framework class** — a from-scratch API-key or HMAC guard. That is what `laravel-brain.security.auth_middleware` is for, and the config path is unchanged.

## Cost

None to speak of. The added work is an `in_array` over four strings before the walk that already ran; no file is parsed that was not parsed before, and the per-scan memo is untouched. Naming `auth.basic` in the patterns actually saves a walk, since a pattern hit returns before `isAuthClass()` is asked.

## Tests

Appended to `tests/Unit/SecurityAnalyzerTest.php`, with four middleware fixtures added to `custom-auth-project`:

- a descendant of each of the three newly reached bases → `authed`, no `PUBLIC_WRITE`
- a descendant two hops out (`CheckExpiringSignedLink extends CheckSignedLink extends ValidateSignature`) → `authed`, so the walk keeps following a parent it cannot match instead of stopping there
- each of the four framework classes given directly by FQCN → `authed`
- the `auth.basic` alias → `authed`
- a middleware that authenticates nothing still → `public`, `PUBLIC_WRITE` still raised: the widening is four framework classes, not "anything with a parent"

Checked against the unpatched analyzer: 7 of the 10 datasets fail without the source change, and the three that pass are the two forms `main` already handled plus the negative case — which is what those are there to hold still.

Full suite green (264 passed, 868 assertions), phpstan 0 errors, pint clean.

## Two commits, separable

1. the classifier — the base set and the walk
2. the `auth.basic` alias

The first stands alone if you would rather leave the alias list untouched; the second is what makes the alias and class forms of basic auth agree, so I would keep them together.
