### PR TITLE
Read the middleware file the application actually configures

### DIFF
--- a/src/Analysis/MiddlewareAnalyzer.php
+++ b/src/Analysis/MiddlewareAnalyzer.php
@@ -18,17 +18,36 @@ class MiddlewareAnalyzer
         $this->parser = new PhpFileParser;
     }
 
+    /**
+     * Which of the two files an application configures middleware in decides
+     * which one is read — not which of them happens to be on disk.
+     *
+     * `bootstrap/app.php` exists in every Laravel application, on both sides of
+     * the 11.0 boundary; what distinguishes the modern one is the
+     * `->withMiddleware(...)` call. So it is asked first and answers only when
+     * it holds that call, which is why a Laravel 10 application still reads its
+     * Kernel: its bootstrap file configures no middleware and declines.
+     *
+     * The case this exists for is an application upgraded to 11+ that kept
+     * `app/Http/Kernel.php` behind. Laravel does not read that file any more,
+     * and neither should this: reading it because it exists returned the stale
+     * or empty registry of a file the framework ignores, while the aliases and
+     * groups the application really registers sat unread in `bootstrap/app.php`.
+     */
     public function analyze(string $projectRoot): MiddlewareRegistry
     {
         $kernelPath = $projectRoot.'/app/Http/Kernel.php';
         $bootstrapPath = $projectRoot.'/bootstrap/app.php';
 
-        if (file_exists($kernelPath)) {
-            return $this->analyzeLaravel10($kernelPath);
+        if (file_exists($bootstrapPath)) {
+            $bootstrap = $this->analyzeLaravel11($bootstrapPath);
+            if ($bootstrap instanceof MiddlewareRegistry) {
+                return $bootstrap;
+            }
         }
 
-        if (file_exists($bootstrapPath)) {
-            return $this->analyzeLaravel11($bootstrapPath);
+        if (file_exists($kernelPath)) {
+            return $this->analyzeLaravel10($kernelPath);
         }
 
         return new MiddlewareRegistry([], [], []);
@@ -133,11 +152,23 @@ class MiddlewareAnalyzer
         return new MiddlewareRegistry($visitor->global, $visitor->groups, $visitor->aliases);
     }
 
-    private function analyzeLaravel11(string $bootstrapPath): MiddlewareRegistry
+    /**
+     * The registry `bootstrap/app.php` declares, or null when it declares none —
+     * meaning the file carries no `->withMiddleware(...)` call, which is every
+     * pre-11 bootstrap file and tells {@see analyze()} to read the Kernel.
+     *
+     * Null is not the same answer as an empty registry, and the difference is
+     * load-bearing: `->withMiddleware(function ($middleware) {
+     * $middleware->redirectGuestsTo('/login'); })` registers no alias and no
+     * group, yet it is still the file this application configures middleware
+     * in. An empty registry from here is that application; null is a file that
+     * never had an opinion.
+     */
+    private function analyzeLaravel11(string $bootstrapPath): ?MiddlewareRegistry
     {
         $parsed = $this->parser->parse($bootstrapPath);
         if ($parsed['ast'] === null) {
-            return new MiddlewareRegistry([], [], []);
+            return null;
         }
 
         $traverser = new NodeTraverser;
@@ -146,6 +177,8 @@ class MiddlewareAnalyzer
             public array $groups = [];
 
             public array $aliases = [];
+
+            public bool $configuresMiddleware = false;
 
             private array $useMap;
 
@@ -160,6 +193,10 @@ class MiddlewareAnalyzer
                     return null;
                 }
                 $methodName = $node->name instanceof Node\Identifier ? $node->name->toString() : null;
+
+                if ($methodName === 'withMiddleware') {
+                    $this->configuresMiddleware = true;
+                }
 
                 if (in_array($methodName, ['api', 'web'], true)) {
                     $this->groups[$methodName] = $this->extractAppendList($node);
@@ -255,6 +292,10 @@ class MiddlewareAnalyzer
 
         $traverser->addVisitor($visitor);
         $traverser->traverse($parsed['ast']);
+
+        if (! $visitor->configuresMiddleware) {
+            return null;
+        }
 
         return new MiddlewareRegistry([], $visitor->groups, $visitor->aliases);
     }

--- a/tests/Unit/MiddlewareSourcePreferenceTest.php
+++ b/tests/Unit/MiddlewareSourcePreferenceTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use LaraMint\LaravelBrain\Analysis\MiddlewareAnalyzer;
+use LaraMint\LaravelBrain\Analysis\RouteDefinition;
+use LaraMint\LaravelBrain\Analysis\SecurityAnalyzer;
+
+// =============================================================================
+// Which file MiddlewareAnalyzer::analyze() reads is decided by which one
+// configures middleware, not by which one exists. An application upgraded to
+// Laravel 11+ commonly keeps app/Http/Kernel.php behind; the framework stops
+// reading it, and so must this.
+// =============================================================================
+
+it('reads bootstrap/app.php when a Kernel is left behind by an upgrade', function () {
+    $registry = (new MiddlewareAnalyzer)->analyze(fixture('middleware-upgraded-kernel-stub'));
+
+    expect($registry->aliases)
+        ->toHaveKey('auth.customer')
+        ->and($registry->aliases['auth.customer'])->toBe('App\\Http\\Middleware\\AuthenticateCustomer');
+});
+
+it('does not resurrect an alias from a Kernel the framework no longer reads', function () {
+    // The stub declares `auth.retired`, naming a guard the application dropped.
+    // Reading it would resolve that alias to a class no route runs.
+    $registry = (new MiddlewareAnalyzer)->analyze(fixture('middleware-upgraded-kernel-stub'));
+
+    expect($registry->aliases)->not->toHaveKey('auth.retired');
+});
+
+it('reads the groups bootstrap/app.php appends when a Kernel is left behind', function () {
+    $registry = (new MiddlewareAnalyzer)->analyze(fixture('middleware-upgraded-kernel-stub'));
+
+    expect($registry->resolveGroup('api'))->toBe(['App\\Http\\Middleware\\ThrottleApi']);
+});
+
+it('still reads the Kernel of a Laravel 10 application', function () {
+    // Its bootstrap/app.php exists too — every application has one — but it
+    // configures no middleware, so it declines and the Kernel answers.
+    $registry = (new MiddlewareAnalyzer)->analyze(fixture('middleware-legacy-kernel'));
+
+    expect($registry->aliases)
+        ->toHaveKey('auth.customer')
+        ->and($registry->aliases['auth.customer'])->toBe('App\\Http\\Middleware\\AuthenticateCustomer')
+        ->and($registry->resolveGroup('api'))->toBe(['App\\Http\\Middleware\\ThrottleApi']);
+});
+
+it('returns an empty registry when neither file configures middleware', function () {
+    $registry = (new MiddlewareAnalyzer)->analyze(fixture('custom-auth-project'));
+
+    expect($registry->aliases)->toBe([])
+        ->and($registry->groups)->toBe([])
+        ->and($registry->global)->toBe([]);
+});
+
+it('classifies a route behind the live alias as authed rather than drawing a false PUBLIC_WRITE', function () {
+    // What reading the wrong file costs, end to end. Unresolved, `auth.customer`
+    // matches no auth pattern — `auth` matches `auth`, `auth:…` and `auth\…`,
+    // never a dotted sibling — so a guarded mutating route was reported as one
+    // anyone can call.
+    $registry = (new MiddlewareAnalyzer)->analyze(fixture('middleware-upgraded-kernel-stub'));
+
+    $route = new RouteDefinition(
+        method: 'DELETE',
+        uri: '/records/{record}',
+        controller: '',
+        action: 'destroy',
+        middlewares: ['auth.customer'],
+        name: '',
+        file: '',
+        line: 1,
+    );
+
+    $analysis = (new SecurityAnalyzer)->analyze([$route], $registry, [], fixture('middleware-upgraded-kernel-stub'));
+
+    $routeId = 'route::DELETE::/records/{record}';
+    expect($analysis[$routeId]['exposure'])->toBe('authed')
+        ->and(array_column($analysis[$routeId]['issues'], 'type'))->not->toContain('PUBLIC_WRITE');
+});

--- a/tests/fixtures/middleware-legacy-kernel/app/Http/Kernel.php
+++ b/tests/fixtures/middleware-legacy-kernel/app/Http/Kernel.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http;
+
+use App\Http\Middleware\AuthenticateCustomer;
+use App\Http\Middleware\ThrottleApi;
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+
+class Kernel extends HttpKernel
+{
+    protected $middlewareGroups = [
+        'api' => [
+            ThrottleApi::class,
+        ],
+    ];
+
+    protected $middlewareAliases = [
+        'auth.customer' => AuthenticateCustomer::class,
+    ];
+}

--- a/tests/fixtures/middleware-legacy-kernel/bootstrap/app.php
+++ b/tests/fixtures/middleware-legacy-kernel/bootstrap/app.php
@@ -1,0 +1,17 @@
+<?php
+
+use App\Http\Kernel;
+use Illuminate\Foundation\Application;
+
+// A Laravel 10 bootstrap file: it creates the application and binds the
+// kernels, and configures no middleware at all.
+$app = new Application(
+    $_ENV['APP_BASE_PATH'] ?? dirname(__DIR__)
+);
+
+$app->singleton(
+    Illuminate\Contracts\Http\Kernel::class,
+    Kernel::class
+);
+
+return $app;

--- a/tests/fixtures/middleware-upgraded-kernel-stub/app/Http/Kernel.php
+++ b/tests/fixtures/middleware-upgraded-kernel-stub/app/Http/Kernel.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http;
+
+use App\Http\Middleware\RetiredGuard;
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+
+/**
+ * Left behind by the upgrade to Laravel 11. Nothing loads it any more, and its
+ * aliases name a guard the application dropped — reading it in preference to
+ * bootstrap/app.php is how a live alias goes missing and a dead one arrives.
+ */
+class Kernel extends HttpKernel
+{
+    protected $middlewareAliases = [
+        'auth.retired' => RetiredGuard::class,
+    ];
+}

--- a/tests/fixtures/middleware-upgraded-kernel-stub/app/Http/Middleware/AuthenticateCustomer.php
+++ b/tests/fixtures/middleware-upgraded-kernel-stub/app/Http/Middleware/AuthenticateCustomer.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Auth\Middleware\Authenticate;
+
+/** The live guard the `auth.customer` alias in bootstrap/app.php points at. */
+class AuthenticateCustomer extends Authenticate {}

--- a/tests/fixtures/middleware-upgraded-kernel-stub/bootstrap/app.php
+++ b/tests/fixtures/middleware-upgraded-kernel-stub/bootstrap/app.php
@@ -1,0 +1,20 @@
+<?php
+
+use App\Http\Middleware\AuthenticateCustomer;
+use App\Http\Middleware\ThrottleApi;
+use Illuminate\Foundation\Application;
+
+// A Laravel 11+ application: this file is where middleware is configured, and
+// the Kernel beside it is the one the upgrade left behind.
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(web: __DIR__.'/../routes/web.php')
+    ->withMiddleware(function ($middleware) {
+        $middleware->alias([
+            'auth.customer' => AuthenticateCustomer::class,
+        ]);
+
+        $middleware->api(append: [
+            ThrottleApi::class,
+        ]);
+    })
+    ->create();


### PR DESCRIPTION
## What

`MiddlewareAnalyzer::analyze()` picked its source file by existence:

```php
if (file_exists($kernelPath)) {
    return $this->analyzeLaravel10($kernelPath);
}
```

`bootstrap/app.php` exists in every Laravel application, on both sides of the 11.0 boundary, so it could never be the discriminator — but `app/Http/Kernel.php` cannot be one either. An application upgraded to 11+ commonly keeps that file behind: nothing deletes it, nothing loads it, and it sits there holding whatever it held on the day of the upgrade.

For those applications the analyzer read the file the framework ignores. Measured on the fixture this PR adds — a Laravel 11 `bootstrap/app.php` registering `auth.customer`, beside a Kernel stub still declaring a retired guard:

| | aliases | groups |
|---|---|---|
| before | `{"auth.retired": "…\RetiredGuard"}` | `{}` |
| after | `{"auth.customer": "…\AuthenticateCustomer"}` | `{"api": ["…\ThrottleApi"]}` |

Every live registration missing, one dead one in their place.

## What it costs downstream

`resolveMiddlewares()` resolves a route's middleware through this registry before `classifyExposure()` reads it, so a missing alias is not a cosmetic gap. Unresolved, `auth.customer` stays the literal string — and that string matches no auth pattern, since `auth` matches `auth`, `auth:…` and `auth\…`, never a dotted sibling:

```
DELETE /records/{record}  middleware: auth.customer

before  exposure=public   PUBLIC_WRITE raised — "anyone can call this endpoint"
after   exposure=authed   no issue
```

The route is guarded by a guard that extends `Authenticate`. The finding was false, and it was false for every mutating route behind every custom alias in the application.

## The rule

The file that **configures** middleware wins, rather than the file that exists:

1. `bootstrap/app.php` is asked first, and answers only when it carries a `->withMiddleware(...)` call.
2. Otherwise the Kernel is read, which is what keeps a Laravel 10 application working — its bootstrap file exists too, creates the application, and configures no middleware, so it declines.
3. Neither: an empty registry, as before.

`analyzeLaravel11()` returns `?MiddlewareRegistry` for that: **null is not an empty registry**, and the difference is load-bearing. `->withMiddleware(function ($middleware) { $middleware->redirectGuestsTo('/login'); })` registers no alias and no group, yet it is still the file this application configures middleware in — an empty registry from there is that application, while null is a file that never had an opinion. Falling back to a stale Kernel in the first case is the bug this PR fixes, one step removed.

Two smaller things follow from the same change:

- **An unparseable `bootstrap/app.php` now falls through to the Kernel** instead of returning an empty registry.
- **The `web`/`api`/`alias` scan is confined to files that configure middleware.** The visitor matches those method names anywhere in the file, so a pre-11 bootstrap calling `->api(...)` on something unrelated could previously contribute a "group". It cannot now.

## What I did not do

**A union of both files.** It is the more forgiving reading, and it is what I first wrote, but it resurrects exactly what the Kernel stub gets wrong: an alias the application retired keeps resolving, and a group it removed keeps listing members. The framework reads one file, so this reads one file.

## Tests

`tests/Unit/MiddlewareSourcePreferenceTest.php`, with two fixture applications:

- an upgraded application (bootstrap + a Kernel stub) → aliases and groups come from bootstrap
- the same application → the stub's retired alias is **not** in the registry
- a Laravel 10 application (Kernel + a pre-11 bootstrap) → still reads the Kernel, aliases and groups both
- neither file configures middleware → empty registry
- end to end: the guarded `DELETE` above is `authed` with no `PUBLIC_WRITE`

Checked against the unpatched analyzer: 4 of the 6 fail without the source change, and the two that pass are the Laravel 10 and empty-registry cases — the ones that are there to hold still.

Full suite green (260 passed, 865 assertions), phpstan 0 errors, pint clean.

## Relationship to #92

Independent — different file, different question, and either order merges cleanly. They do compose: #92 recognises a guard by what it extends, and this one makes sure the alias naming that guard resolves to a class in the first place. The end-to-end test above passes on this branch alone, since `AuthenticateCustomer extends Authenticate` is the base `main` already walks to.
