### PR TITLE
Read group declarations from bootstrap/app.php

### DIFF
--- a/src/Analysis/MiddlewareAnalyzer.php
+++ b/src/Analysis/MiddlewareAnalyzer.php
@@ -163,11 +163,75 @@ class MiddlewareAnalyzer
 
                 if (in_array($methodName, ['api', 'web'], true)) {
                     $this->groups[$methodName] = $this->extractAppendList($node);
+                } elseif ($methodName === 'group') {
+                    // `$middleware->group('admin', [...])` — how an application declares a group
+                    // of its own. The framework's own `web` and `api` are modified through the
+                    // methods above; every other group is born here.
+                    $this->declareGroup($node);
+                } elseif (in_array($methodName, ['appendToGroup', 'prependToGroup'], true)) {
+                    $this->addToGroup($node, $methodName === 'prependToGroup');
                 } elseif ($methodName === 'alias') {
                     $this->extractAliases($node);
                 }
 
                 return null;
+            }
+
+            /** `group(string $group, array $middleware)` — the whole membership, replacing any of it read so far. */
+            private function declareGroup(Node\Expr\MethodCall $node): void
+            {
+                $name = $this->groupNameArg($node);
+                if ($name === null || ! ($node->args[1] ?? null) instanceof Node\Arg) {
+                    return;
+                }
+
+                $members = $node->args[1]->value;
+                if ($members instanceof Node\Expr\Array_) {
+                    $this->groups[$name] = $this->extractClassArray($members);
+                }
+            }
+
+            /**
+             * `appendToGroup(string $group, array|string $middleware)` and its prepend twin. Laravel
+             * wraps a bare string, so `appendToGroup('web', Guard::class)` is one member, not none.
+             */
+            private function addToGroup(Node\Expr\MethodCall $node, bool $prepend): void
+            {
+                $name = $this->groupNameArg($node);
+                if ($name === null || ! ($node->args[1] ?? null) instanceof Node\Arg) {
+                    return;
+                }
+
+                $value = $node->args[1]->value;
+                $members = $value instanceof Node\Expr\Array_
+                    ? $this->extractClassArray($value)
+                    : array_filter([$this->extractClassString($value)]);
+
+                if ($members === []) {
+                    return;
+                }
+
+                $existing = $this->groups[$name] ?? [];
+                $this->groups[$name] = $prepend
+                    ? array_merge($members, $existing)
+                    : array_merge($existing, $members);
+            }
+
+            /**
+             * The group name a `group`-family call names, or null when it is not a literal — a
+             * variable or a constant is a name this cannot read, and guessing one would attribute
+             * middleware to a group that does not exist.
+             */
+            private function groupNameArg(Node\Expr\MethodCall $node): ?string
+            {
+                // First-class callable syntax puts a VariadicPlaceholder here, which has no `value`.
+                if (! ($node->args[0] ?? null) instanceof Node\Arg) {
+                    return null;
+                }
+
+                $name = $node->args[0]->value;
+
+                return $name instanceof Node\Scalar\String_ && $name->value !== '' ? $name->value : null;
             }
 
             private function extractAppendList(Node\Expr\MethodCall $node): array

--- a/tests/Unit/MiddlewareAliasFormTest.php
+++ b/tests/Unit/MiddlewareAliasFormTest.php
@@ -46,3 +46,40 @@ it('does not crash on the first-class callable $middleware->alias(...) form', fu
     expect($registry->aliases)->not->toHaveKey('...')
         ->and($registry->aliases)->toHaveKey('auth.named');
 });
+
+// =============================================================================
+// Group declarations in a Laravel 11+ bootstrap/app.php. `web` and `api` are
+// modified through their own methods; every other group an application has is
+// declared with group(), and added to with appendToGroup()/prependToGroup().
+// =============================================================================
+
+it('reads a group declared with $middleware->group()', function () {
+    $registry = (new MiddlewareAnalyzer)->analyze(fixture('middleware-group-declarations'));
+
+    expect($registry->resolveGroup('admin'))->toContain('App\\Http\\Middleware\\AuthenticateCustomer')
+        ->and($registry->resolveGroup('admin'))->toContain('can:administer');
+});
+
+it('appends and prepends to a declared group in the right order', function () {
+    $registry = (new MiddlewareAnalyzer)->analyze(fixture('middleware-group-declarations'));
+
+    expect($registry->resolveGroup('admin'))->toBe([
+        'App\\Http\\Middleware\\EnsureTenantMatches',
+        'App\\Http\\Middleware\\AuthenticateCustomer',
+        'can:administer',
+        'App\\Http\\Middleware\\ThrottleAdmin',
+    ]);
+});
+
+it('accepts a bare class string, which Laravel wraps for the caller', function () {
+    // `prependToGroup('admin', EnsureTenantMatches::class)` takes array|string.
+    $registry = (new MiddlewareAnalyzer)->analyze(fixture('middleware-group-declarations'));
+
+    expect($registry->resolveGroup('admin')[0])->toBe('App\\Http\\Middleware\\EnsureTenantMatches');
+});
+
+it('records a group that only ever had members added to it', function () {
+    $registry = (new MiddlewareAnalyzer)->analyze(fixture('middleware-group-declarations'));
+
+    expect($registry->resolveGroup('tenant'))->toBe(['App\\Http\\Middleware\\LogRequest']);
+});

--- a/tests/fixtures/middleware-group-declarations/bootstrap/app.php
+++ b/tests/fixtures/middleware-group-declarations/bootstrap/app.php
@@ -1,0 +1,26 @@
+<?php
+
+use App\Http\Middleware\AuthenticateCustomer;
+use App\Http\Middleware\EnsureTenantMatches;
+use App\Http\Middleware\LogRequest;
+use App\Http\Middleware\ThrottleAdmin;
+use Illuminate\Foundation\Application;
+
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(web: __DIR__.'/../routes/web.php')
+    ->withMiddleware(function ($middleware) {
+        // A group of the application's own: the framework's web and api are modified
+        // through their own methods, every other group is declared here.
+        $middleware->group('admin', [
+            AuthenticateCustomer::class,
+            'can:administer',
+        ]);
+
+        // Added to afterwards, in both directions.
+        $middleware->appendToGroup('admin', [ThrottleAdmin::class]);
+        $middleware->prependToGroup('admin', EnsureTenantMatches::class);
+
+        // A group nobody declared, added to all the same.
+        $middleware->appendToGroup('tenant', [LogRequest::class]);
+    })
+    ->create();


### PR DESCRIPTION
## What

`MiddlewareAnalyzer` reads a Laravel 11+ `bootstrap/app.php` for `->web(append: …)`, `->api(append: …)` and `->alias(…)`. Those two methods modify the framework's own groups. **Every group an application declares for itself is declared somewhere else**, and none of it was read:

```php
$middleware->group('admin', [AuthenticateCustomer::class, 'can:administer']);
$middleware->appendToGroup('admin', [ThrottleAdmin::class]);
$middleware->prependToGroup('tenant', EnsureTenantMatches::class);
```

Before this, `$registry->groups` held `web` and `api` and nothing else, so `resolveGroup('admin')` answered `[]` — the same answer it gives for a group that does not exist.

## The three calls

From `Illuminate\Foundation\Configuration\Middleware`:

- `group(string $group, array $middleware)` — the whole membership. Read as a replacement, which is what the framework does with it.
- `appendToGroup(string $group, array|string $middleware)` — merged onto what is known so far.
- `prependToGroup(string $group, array|string $middleware)` — merged in front, so the order the registry reports is the order the middleware runs.

Both `…ToGroup` methods take `array|string` and Laravel wraps a bare one, so `prependToGroup('admin', EnsureTenantMatches::class)` is one member rather than none. A group that only ever has members appended to it is recorded from those, since an application may add to a group the framework declares.

A name that is not a literal string — a variable, a constant — is left alone rather than guessed at: attributing middleware to a group whose name cannot be read would put it under a group that does not exist. The first-class callable form (`->group(...)`) carries a `VariadicPlaceholder` with no `value`, and is guarded the same way `extractAliases()` guards it.

## Why it matters beyond the registry

A group is where an application puts the guard it wants on a set of routes, and a group nothing knows about resolves to nothing. Anything asking what a route runs — including the exposure classification in #95 — gets the group's name and no members, so a route behind `admin` reads as guarded by a middleware called `admin` that does not exist.

## Honest limit

The framework's own `web` and `api` members still come only from what an application appends to them. Their default contents live in Laravel, not in the application's source, so a scan of the project cannot see them — unchanged by this PR, and worth knowing when reading a `web` group that looks short.

## Tests

`tests/Unit/MiddlewareAliasFormTest.php`, with a `middleware-group-declarations` fixture:

- a group declared with `group()` → its members, including a parameterised alias member
- append and prepend → the order the middleware runs
- a bare class string rather than an array → one member
- a group that only ever had members appended → recorded from those

All four fail without the source change. Full suite green (258 passed, 858 assertions) over two `--order-by=random` runs, phpstan 0 errors, pint clean.

## Relationship to the other open PRs

Touches `MiddlewareAnalyzer` like #93 does, but a different part of it — #93 decides *which file* is read, this decides *what is read* in the 11+ one. They stack in either order; if #93 lands first this needs no change, and if this lands first #93 needs none.

#95 is the consumer that makes the difference visible: it expands a group when classifying a route's exposure, and can only expand what the registry holds.
