### PR TITLE
Read what a resource puts in the payload

### DIFF
--- a/src/Analysis/PhpStructureInspector.php
+++ b/src/Analysis/PhpStructureInspector.php
@@ -9,6 +9,7 @@ use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitorAbstract;
+use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 
 /**
  * Extracts enum cases, interface methods, and other structural members from PHP files
@@ -24,6 +25,16 @@ class PhpStructureInspector
      * @var array<string, array{kind: string, members: list<array<string, mixed>>}|null>
      */
     private array $inspectCache = [];
+
+    /**
+     * The same memo for {@see payloadKeys()}: GraphBuilder asks once per resource node, and a
+     * resource composing a sibling makes it ask about the same file again.
+     *
+     * @var array<string, list<array{key: string, value: string}>>
+     */
+    private array $payloadKeysCache = [];
+
+    private ?PrettyPrinter $printer = null;
 
     public function __construct(?PhpFileParser $parser = null)
     {
@@ -202,6 +213,201 @@ class PhpStructureInspector
      *
      * @return list<array{name: string, static: bool, visibility: string}>
      */
+    /**
+     * The keys a resource's `toArray()` writes into the payload, in the order it writes them, each
+     * with the expression that fills it.
+     *
+     * This is the last hop of a request and the only one whose shape a consumer of the API sees.
+     * The graph already knows a route reaches a resource; what the response carries was left inside
+     * the file, so a reader asking what an endpoint returns had to open it.
+     *
+     * A literal key is given as it is written; anything else is printed as the expression it is, so
+     * a key built from a constant reads as `Article::FIELD_SLUG` rather than being dropped. A spread
+     * (`...$this->meta()`) is one row keyed `...`, because the payload has more in it than the rows
+     * above and saying so is the honest answer. A list item with no key is `*`, the same stand-in
+     * {@see ValidationRulesExtractor} uses for one.
+     *
+     * Empty for a `toArray()` that returns anything but an array literal — `parent::toArray()`, an
+     * array built up over several statements, a merge. Those are payloads this cannot enumerate, and
+     * an empty list says nothing about them rather than claiming a payload with no keys.
+     *
+     * @return list<array{key: string, value: string}>
+     */
+    public function payloadKeys(string $file): array
+    {
+        if (array_key_exists($file, $this->payloadKeysCache)) {
+            return $this->payloadKeysCache[$file];
+        }
+
+        return $this->payloadKeysCache[$file] = $this->payloadKeysUncached($file);
+    }
+
+    /**
+     * @return list<array{key: string, value: string}>
+     */
+    private function payloadKeysUncached(string $file): array
+    {
+        if (! is_file($file)) {
+            return [];
+        }
+
+        $parsed = $this->parser->parse($file);
+        if ($parsed['ast'] === null) {
+            return [];
+        }
+
+        $method = $this->findMethod($parsed['ast'], 'toArray');
+        if ($method === null || $method->isAbstract()) {
+            return [];
+        }
+
+        $rows = [];
+        foreach ($this->returnedArrays($method->stmts ?? []) as $array) {
+            foreach ($array->items as $item) {
+                if (! $item instanceof Node\Expr\ArrayItem) {
+                    continue;
+                }
+
+                $rows[] = [
+                    'key' => $this->payloadKeyName($item),
+                    'value' => $this->oneLine($this->printer()->prettyPrintExpr($item->value)),
+                ];
+            }
+        }
+
+        return $rows;
+    }
+
+    private function payloadKeyName(Node\Expr\ArrayItem $item): string
+    {
+        if ($item->unpack) {
+            return '...';
+        }
+
+        if ($item->key === null) {
+            return '*';
+        }
+
+        return $item->key instanceof Node\Scalar\String_
+            ? $item->key->value
+            : $this->oneLine($this->printer()->prettyPrintExpr($item->key));
+    }
+
+    /**
+     * Every array literal the statements return, including from inside a conditional — a resource
+     * that returns one shape to an editor and another to everyone else has two payloads, and both
+     * are worth reading.
+     *
+     * @param  Node\Stmt[]  $stmts
+     * @return list<Node\Expr\Array_>
+     */
+    private function returnedArrays(array $stmts): array
+    {
+        $arrays = [];
+
+        foreach ($stmts as $stmt) {
+            if ($stmt instanceof Node\Stmt\Return_ && $stmt->expr instanceof Node\Expr\Array_) {
+                $arrays[] = $stmt->expr;
+
+                continue;
+            }
+
+            foreach ($this->nestedStatementLists($stmt) as $inner) {
+                foreach ($this->returnedArrays($inner) as $array) {
+                    $arrays[] = $array;
+                }
+            }
+        }
+
+        return $arrays;
+    }
+
+    /**
+     * @return list<Node\Stmt[]>
+     */
+    private function nestedStatementLists(Node\Stmt $stmt): array
+    {
+        if ($stmt instanceof Node\Stmt\If_) {
+            $lists = [$stmt->stmts];
+            foreach ($stmt->elseifs as $elseif) {
+                $lists[] = $elseif->stmts;
+            }
+            if ($stmt->else !== null) {
+                $lists[] = $stmt->else->stmts;
+            }
+
+            return $lists;
+        }
+
+        if ($stmt instanceof Node\Stmt\TryCatch) {
+            $lists = [$stmt->stmts];
+            foreach ($stmt->catches as $catch) {
+                $lists[] = $catch->stmts;
+            }
+            if ($stmt->finally !== null) {
+                $lists[] = $stmt->finally->stmts;
+            }
+
+            return $lists;
+        }
+
+        if ($stmt instanceof Node\Stmt\Switch_) {
+            $lists = [];
+            foreach ($stmt->cases as $case) {
+                $lists[] = $case->stmts;
+            }
+
+            return $lists;
+        }
+
+        return [];
+    }
+
+    /**
+     * A holder rather than a by-reference property, the same way
+     * {@see ValidationRulesExtractor::findRulesMethod()} does it: a promoted by-ref property reads
+     * to static analysis as written and never read, since the read happens through the reference.
+     *
+     * @param  Node\Stmt[]  $ast
+     */
+    private function findMethod(array $ast, string $name): ?Node\Stmt\ClassMethod
+    {
+        $holder = new \stdClass;
+        $holder->found = null;
+
+        $traverser = new NodeTraverser;
+        $traverser->addVisitor(new class($holder, $name) extends NodeVisitorAbstract
+        {
+            public function __construct(private \stdClass $holder, private string $name) {}
+
+            public function enterNode(Node $node): ?int
+            {
+                if ($node instanceof Node\Stmt\ClassMethod && $node->name->toString() === $this->name) {
+                    $this->holder->found = $node;
+
+                    return NodeTraverser::STOP_TRAVERSAL;
+                }
+
+                return null;
+            }
+        });
+        $traverser->traverse($ast);
+
+        /** @var Node\Stmt\ClassMethod|null */
+        return $holder->found;
+    }
+
+    /** A printed expression as one row: a multi-line value would break the list it is rendered in. */
+    private function oneLine(string $code): string
+    {
+        return trim((string) preg_replace('/\s+/', ' ', $code));
+    }
+
+    private function printer(): PrettyPrinter
+    {
+        return $this->printer ??= new PrettyPrinter;
+    }
+
     public function listClassMethods(string $file): array
     {
         if (! is_file($file)) {

--- a/src/Graph/GraphBuilder.php
+++ b/src/Graph/GraphBuilder.php
@@ -703,6 +703,11 @@ class GraphBuilder
                     ? $this->getStructureInspector()->listClassMethods($file)
                     : [];
                 $svcMetrics = $this->extractMethodMetrics($fqcn, $method);
+                // What the response carries. The graph already says a route reaches this resource;
+                // the payload's own shape is the part a consumer of the API sees.
+                $payloadKeys = ($file !== '' && is_file($file))
+                    ? $this->getStructureInspector()->payloadKeys($file)
+                    : [];
                 $this->graph->addNode(new Node($id, $type, "{$short}@{$method}", [
                     'fqcn' => $fqcn,
                     'method' => $method,
@@ -713,6 +718,7 @@ class GraphBuilder
                     ...($svcMetrics ? ['metrics' => $svcMetrics] : []),
                     ...($this->hasN1InSteps($flowSteps) ? ['hasN1' => true] : []),
                     ...($this->isFatMethod($svcMetrics) ? ['fatMethod' => true] : []),
+                    ...($payloadKeys === [] ? [] : ['payloadKeys' => $payloadKeys]),
                 ]));
                 break;
 

--- a/tests/Unit/ResourcePayloadKeysTest.php
+++ b/tests/Unit/ResourcePayloadKeysTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+use LaraMint\LaravelBrain\Analysis\ControllerAnalyzer;
+use LaraMint\LaravelBrain\Analysis\MethodTracer;
+use LaraMint\LaravelBrain\Analysis\MiddlewareRegistry;
+use LaraMint\LaravelBrain\Analysis\PhpStructureInspector;
+use LaraMint\LaravelBrain\Analysis\RouteAnalyzer;
+use LaraMint\LaravelBrain\Graph\GraphBuilder;
+
+function payloadKeysOf(string $resource): array
+{
+    return (new PhpStructureInspector)->payloadKeys(
+        fixture('resource-payloads')."/app/Http/Resources/{$resource}.php"
+    );
+}
+
+/** @param list<array{key: string, value: string}> $rows */
+function keysOnly(array $rows): array
+{
+    return array_column($rows, 'key');
+}
+
+it('reads the keys a resource writes, in the order it writes them', function () {
+    $keys = keysOnly(payloadKeysOf('ArticleResource'));
+
+    // The editor branch first, since it is returned first, then the public one.
+    expect($keys)->toBe([
+        'id', 'title', 'reviewer_notes',
+        'id', 'title', 'Article::FIELD_SLUG', 'author', 'tags', '...',
+    ]);
+});
+
+it('keeps what fills each key', function () {
+    $rows = payloadKeysOf('ArticleResource');
+    $byKey = [];
+    foreach ($rows as $row) {
+        $byKey[$row['key']] ??= $row['value'];
+    }
+
+    expect($byKey['author'])->toBe('new AuthorResource($this->author)')
+        ->and($byKey['tags'])->toBe("\$this->whenLoaded('tags')")
+        ->and($byKey['id'])->toBe('$this->id');
+});
+
+it('prints a key that is not a literal as the expression it is', function () {
+    // Dropping it would say the payload has one key fewer than it does.
+    expect(keysOnly(payloadKeysOf('ArticleResource')))->toContain('Article::FIELD_SLUG');
+});
+
+it('marks a spread rather than pretending the rows above are the whole payload', function () {
+    $rows = payloadKeysOf('ArticleResource');
+    $spread = array_values(array_filter($rows, fn (array $row): bool => $row['key'] === '...'));
+
+    expect($spread)->toHaveCount(1)
+        ->and($spread[0]['value'])->toBe('$this->meta()');
+});
+
+it('says nothing about a payload the parent builds', function () {
+    // `return parent::toArray($request)` enumerates nothing here, and an empty list is the honest
+    // answer: it is not a payload with no keys, it is a payload this cannot read.
+    expect(payloadKeysOf('AuthorResource'))->toBe([]);
+});
+
+it('says nothing about a payload built up over several statements', function () {
+    expect(payloadKeysOf('TagResource'))->toBe([]);
+});
+
+it('says nothing about a file that is not there', function () {
+    expect((new PhpStructureInspector)->payloadKeys('/no/such/Resource.php'))->toBe([]);
+});
+
+it('reads the same file once', function () {
+    // GraphBuilder asks per resource node, and a resource composing a sibling asks again.
+    $inspector = new PhpStructureInspector;
+    $file = fixture('resource-payloads').'/app/Http/Resources/ArticleResource.php';
+
+    expect($inspector->payloadKeys($file))->toBe($inspector->payloadKeys($file));
+});
+
+it('puts the payload on the resource node the graph builds', function () {
+    // The wiring: a route reaches ArticleResource, and the node the builder makes for it carries
+    // what that resource returns.
+    $project = fixture('resource-payloads');
+    $routes = (new RouteAnalyzer)->analyze($project);
+    $controllers = new ControllerAnalyzer;
+    $definitions = $controllers->analyze($project, $routes);
+    $traces = (new MethodTracer)->trace($definitions, $controllers->getPsr4Map(), $project);
+
+    // The project root is what gives the builder its PSR-4 map, and the file is what the payload
+    // is read from — without it the node has no file and nothing to read.
+    $graph = (new GraphBuilder)->build('test', $routes, new MiddlewareRegistry([], [], []), $definitions, $traces, [], $project);
+
+    $resource = null;
+    foreach ($graph->nodes() as $node) {
+        if ($node->type === 'resource') {
+            $resource = $node;
+            break;
+        }
+    }
+
+    expect($resource)->not->toBeNull()
+        ->and(array_column($resource->data['payloadKeys'] ?? [], 'key'))
+        ->toBe(['id', 'title', 'reviewer_notes', 'id', 'title', 'Article::FIELD_SLUG', 'author', 'tags', '...']);
+});

--- a/tests/fixtures/resource-payloads/app/Http/Controllers/ArticleController.php
+++ b/tests/fixtures/resource-payloads/app/Http/Controllers/ArticleController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Resources\ArticleResource;
+
+class ArticleController
+{
+    public function show($article)
+    {
+        return new ArticleResource($article);
+    }
+}

--- a/tests/fixtures/resource-payloads/app/Http/Resources/ArticleResource.php
+++ b/tests/fixtures/resource-payloads/app/Http/Resources/ArticleResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\Article;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ArticleResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        if ($request->user()?->isEditor()) {
+            return [
+                'id' => $this->id,
+                'title' => $this->title,
+                'reviewer_notes' => $this->reviewer_notes,
+            ];
+        }
+
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            Article::FIELD_SLUG => $this->slug,
+            'author' => new AuthorResource($this->author),
+            'tags' => $this->whenLoaded('tags'),
+            ...$this->meta(),
+        ];
+    }
+}

--- a/tests/fixtures/resource-payloads/app/Http/Resources/AuthorResource.php
+++ b/tests/fixtures/resource-payloads/app/Http/Resources/AuthorResource.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class AuthorResource extends JsonResource
+{
+    // A payload this cannot enumerate: the parent builds it, and nothing here says what is in it.
+    public function toArray($request): array
+    {
+        return parent::toArray($request);
+    }
+}

--- a/tests/fixtures/resource-payloads/app/Http/Resources/TagResource.php
+++ b/tests/fixtures/resource-payloads/app/Http/Resources/TagResource.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TagResource extends JsonResource
+{
+    // Built up over several statements, which is a payload the reader has to open the file for.
+    public function toArray($request): array
+    {
+        $payload = ['id' => $this->id];
+
+        if ($this->slug) {
+            $payload['slug'] = $this->slug;
+        }
+
+        return $payload;
+    }
+}

--- a/tests/fixtures/resource-payloads/composer.json
+++ b/tests/fixtures/resource-payloads/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "test/resource-payloads",
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    }
+}

--- a/tests/fixtures/resource-payloads/routes/api.php
+++ b/tests/fixtures/resource-payloads/routes/api.php
@@ -1,0 +1,6 @@
+<?php
+
+use App\Http\Controllers\ArticleController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/articles/{article}', [ArticleController::class, 'show']);


### PR DESCRIPTION
## What

The graph already says a route reaches `ArticleResource`. What the response actually carries — the last hop of the request, and the only part a consumer of the API ever sees — was left inside the file:

```
resource  ArticleResource@toArray
  fqcn, method, file, flowSteps, members, visibility
```

A reader asking "what does this endpoint return" had to open the resource. Now the node carries it:

| key | value |
|---|---|
| `id` | `$this->id` |
| `title` | `$this->title` |
| `Article::FIELD_SLUG` | `$this->slug` |
| `author` | `new AuthorResource($this->author)` |
| `tags` | `$this->whenLoaded('tags')` |
| `...` | `$this->meta()` |

`PhpStructureInspector::payloadKeys()` reads them; `GraphBuilder` puts them on the `resource` node as `payloadKeys`, beside `members` — the same shape and the same place `validationRules` already occupies for a Form Request, so the sidebar renders them through its property list with no frontend change. A section of their own, like the "Validation rules" one, is the natural follow-up and needs a rebuilt asset bundle, so I left it out of this PR rather than committing a bundle built on my toolchain. Happy to add it if you want it here.

## What it will and will not claim

The extractor answers with what it can actually read, and says nothing where it cannot:

- **A literal key** is given as written.
- **A key that is not a literal** is printed as the expression it is, so `Article::FIELD_SLUG` appears instead of the row disappearing. A reader can see there is a key there and where it comes from.
- **A spread** (`...$this->meta()`) is one row keyed `...`. The payload has more in it than the rows above, and a list that quietly omitted it would read as complete.
- **A list item with no key** is `*`, the stand-in `ValidationRulesExtractor` already uses for one.
- **A payload it cannot enumerate yields nothing at all**: `return parent::toArray($request)`, an array built up over several statements, a merge. An empty list is "this was not readable", never "this payload has no keys" — which is why the data key is omitted entirely rather than set to `[]`.

Both branches of a conditional `toArray()` are read, in the order they are returned. A resource that returns one shape to an editor and another to everyone else has two payloads, and both are worth seeing.

## Cost

One extra parse per resource file, memoised per file for the build — the same shape as `inspectFile()` beside it, and for the same reason: a resource composing a sibling makes GraphBuilder ask about the same file twice. Nothing else in a scan changes; no new pass, no new traversal of the project.

## Tests

`tests/Unit/ResourcePayloadKeysTest.php`, with a `resource-payloads` fixture project:

- the keys of a conditional `toArray()`, both branches, in order
- the expression that fills each key, including a nested resource and a `whenLoaded`
- a constant key, printed rather than dropped
- a spread, as its own row
- `parent::toArray()` and an array built up over statements → nothing
- a file that is not there → nothing
- the same file asked twice → the same answer (the memo)
- the wiring: a route reaches the resource, and the node the builder makes for it carries the payload

Full suite green (263 passed, 866 assertions) over two `--order-by=random` runs, phpstan 0 errors, pint clean. The diff is additive — 206 new lines in `PhpStructureInspector`, none removed.

## Relationship to the other open PRs

Independent of #92-#96; different file, different subsystem.
