### PR TITLE
Fix: drop subgraphs whose route no longer exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,10 @@ With the default `file` driver, `brain:scan` writes these files to
 .graph-{tab-id}.json   — Per-route subgraph (one per route)
 ```
 
-They are regenerated on every scan and are safe to gitignore:
+Every scan rewrites the whole set and drops the subgraphs it did not write, so a tab
+disappears from the viewer when the route behind it disappears from the application.
+
+They are safe to gitignore:
 
 ```gitignore
 storage/app/laravel-brain/

--- a/src/Commands/ScanCommand.php
+++ b/src/Commands/ScanCommand.php
@@ -264,6 +264,9 @@ class ScanCommand extends Command
 
         // Both a full and a scoped rescan split the whole graph, so what was just written
         // is the complete tab set; anything else in the store outlived its route.
+        // Ordering matters: the manifest above is what the viewer indexes tabs from, and it
+        // is written unconditionally, so pruning to the same set that produced it can only
+        // remove blobs nothing can address. Moving either out of this block breaks that.
         $store->pruneSubgraphsExcept(array_map('strval', array_keys($result->subgraphs)));
 
         // The one-time support prompt flag lives on disk regardless of driver.

--- a/src/Commands/ScanCommand.php
+++ b/src/Commands/ScanCommand.php
@@ -262,6 +262,10 @@ class ScanCommand extends Command
             $store->putSubgraph((string) $tabId, $subgraph->toJson());
         }
 
+        // Both a full and a scoped rescan split the whole graph, so what was just written
+        // is the complete tab set; anything else in the store outlived its route.
+        $store->pruneSubgraphsExcept(array_map('strval', array_keys($result->subgraphs)));
+
         // The one-time support prompt flag lives on disk regardless of driver.
         $storageDir = storage_path('app/laravel-brain');
         if (! is_dir($storageDir)) {

--- a/src/Http/Controllers/BrainController.php
+++ b/src/Http/Controllers/BrainController.php
@@ -57,6 +57,8 @@ class BrainController extends Controller
             $store->putSubgraph((string) $tabId, $subgraph->toJson());
         }
 
+        $store->pruneSubgraphsExcept(array_map('strval', array_keys($result->subgraphs)));
+
         return response()->json([
             'success' => true,
             'message' => 'Project scan completed successfully.',

--- a/src/Http/Controllers/BrainController.php
+++ b/src/Http/Controllers/BrainController.php
@@ -57,6 +57,9 @@ class BrainController extends Controller
             $store->putSubgraph((string) $tabId, $subgraph->toJson());
         }
 
+        // Ordering matters: the manifest above is what the viewer indexes tabs from, and it
+        // is written unconditionally, so pruning to the same set that produced it can only
+        // remove blobs nothing can address. Moving either out of this block breaks that.
         $store->pruneSubgraphsExcept(array_map('strval', array_keys($result->subgraphs)));
 
         return response()->json([

--- a/src/Storage/DatabaseGraphStore.php
+++ b/src/Storage/DatabaseGraphStore.php
@@ -65,6 +65,18 @@ final class DatabaseGraphStore implements GraphStore
         $this->put($tabId, $json);
     }
 
+    public function pruneSubgraphsExcept(array $keep): void
+    {
+        if (! $this->ready()) {
+            return;
+        }
+
+        $this->query()
+            ->where('tab', '!=', self::MANIFEST_KEY)
+            ->whereNotIn('tab', $keep)
+            ->delete();
+    }
+
     public function subgraphIds(): array
     {
         if (! $this->ready()) {

--- a/src/Storage/FileGraphStore.php
+++ b/src/Storage/FileGraphStore.php
@@ -66,6 +66,17 @@ final class FileGraphStore implements GraphStore
         return $ids;
     }
 
+    public function pruneSubgraphsExcept(array $keep): void
+    {
+        $keep = array_flip($keep);
+
+        foreach ($this->subgraphIds() as $tabId) {
+            if (! isset($keep[$tabId])) {
+                @unlink($this->path($tabId));
+            }
+        }
+    }
+
     private function path(string $tabId): string
     {
         return $this->dir.'/.graph-'.$tabId.'.json';

--- a/src/Storage/GraphStore.php
+++ b/src/Storage/GraphStore.php
@@ -35,4 +35,16 @@ interface GraphStore
      * @return list<string>
      */
     public function subgraphIds(): array;
+
+    /**
+     * Drop every stored subgraph whose tab id is not in $keep.
+     *
+     * A scan writes the complete set of tabs, so anything already stored and not
+     * written by it belongs to a route, command or channel that no longer exists.
+     * Left behind, those blobs keep answering {@see subgraphIds()} and the viewer
+     * goes on listing tabs for a surface the application dropped.
+     *
+     * @param  list<string>  $keep  tab ids the current scan wrote
+     */
+    public function pruneSubgraphsExcept(array $keep): void;
 }

--- a/tests/Unit/DatabaseGraphStoreTest.php
+++ b/tests/Unit/DatabaseGraphStoreTest.php
@@ -1,0 +1,98 @@
+<?php
+
+use Illuminate\Container\Container;
+use Illuminate\Database\Capsule\Manager as Capsule;
+use Illuminate\Support\Facades\Facade;
+use LaraMint\LaravelBrain\Storage\DatabaseGraphStore;
+
+/**
+ * The database driver needs a connection but not an application: a Capsule over
+ * in-memory sqlite is enough for the DB and Schema facades the store reaches for.
+ */
+function databaseGraphStore(): DatabaseGraphStore
+{
+    $container = new Container;
+    Container::setInstance($container);
+
+    $capsule = new Capsule($container);
+    $capsule->addConnection(['driver' => 'sqlite', 'database' => ':memory:']);
+    $capsule->setAsGlobal();
+    $capsule->bootEloquent();
+
+    $container->instance('db', $capsule->getDatabaseManager());
+    Facade::clearResolvedInstances();
+    Facade::setFacadeApplication($container);
+
+    $store = new DatabaseGraphStore;
+    $store->ensureSchema();
+
+    return $store;
+}
+
+/** @param string[] $tabIds */
+function seedDatabaseStore(DatabaseGraphStore $store, array $tabIds): void
+{
+    $store->putManifest('{"tabs":[]}');
+
+    foreach ($tabIds as $tabId) {
+        $store->putSubgraph($tabId, '{"nodes":[],"edges":[]}');
+    }
+}
+
+afterEach(function () {
+    Facade::clearResolvedInstances();
+    Facade::setFacadeApplication(null);
+    Container::setInstance(null);
+});
+
+it('drops the rows the scan no longer wrote', function () {
+    $store = databaseGraphStore();
+    seedDatabaseStore($store, ['tab-a', 'tab-b', 'tab-c']);
+
+    $store->pruneSubgraphsExcept(['tab-a', 'tab-c']);
+
+    expect($store->subgraphIds())->toBe(['tab-a', 'tab-c'])
+        ->and($store->getSubgraph('tab-b'))->toBeNull();
+});
+
+it('keeps the manifest when the keep list is empty', function () {
+    $store = databaseGraphStore();
+    seedDatabaseStore($store, ['tab-a', 'tab-b']);
+
+    // `whereNotIn('tab', [])` compiles to `1 = 1`, so this statement deletes every row
+    // it is not otherwise constrained away from — the `tab != __manifest__` clause is
+    // the only thing standing between an empty scan and losing the manifest with it.
+    $store->pruneSubgraphsExcept([]);
+
+    expect($store->subgraphIds())->toBe([])
+        ->and($store->hasManifest())->toBeTrue()
+        ->and($store->getManifest())->toBe('{"tabs":[]}');
+});
+
+it('keeps every row the scan wrote', function () {
+    $store = databaseGraphStore();
+    seedDatabaseStore($store, ['tab-a', 'tab-b']);
+
+    $store->pruneSubgraphsExcept(['tab-a', 'tab-b']);
+
+    expect($store->subgraphIds())->toBe(['tab-a', 'tab-b']);
+});
+
+it('is a no-op before the table exists', function () {
+    $container = new Container;
+    Container::setInstance($container);
+
+    $capsule = new Capsule($container);
+    $capsule->addConnection(['driver' => 'sqlite', 'database' => ':memory:']);
+    $capsule->setAsGlobal();
+    $capsule->bootEloquent();
+    $container->instance('db', $capsule->getDatabaseManager());
+    Facade::clearResolvedInstances();
+    Facade::setFacadeApplication($container);
+
+    $store = new DatabaseGraphStore;
+
+    $store->pruneSubgraphsExcept(['tab-a']);
+
+    expect($store->subgraphIds())->toBe([]);
+});

--- a/tests/Unit/FileGraphStoreTest.php
+++ b/tests/Unit/FileGraphStoreTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use LaraMint\LaravelBrain\Storage\FileGraphStore;
+
+function graphStoreTmpDir(): string
+{
+    $dir = sys_get_temp_dir().'/lb-store-'.bin2hex(random_bytes(6));
+    mkdir($dir, 0o777, true);
+
+    return $dir;
+}
+
+/** @param string[] $tabIds */
+function seedStore(string $dir, array $tabIds): FileGraphStore
+{
+    $store = new FileGraphStore($dir);
+    $store->ensureSchema();
+    $store->putManifest('{"tabs":[]}');
+
+    foreach ($tabIds as $tabId) {
+        $store->putSubgraph($tabId, '{"nodes":[],"edges":[]}');
+    }
+
+    return $store;
+}
+
+it('drops a stored subgraph the scan no longer wrote', function () {
+    $dir = graphStoreTmpDir();
+    $store = seedStore($dir, ['get-users', 'get-orders']);
+
+    // `get-orders` is the route that was deleted from the application.
+    $store->pruneSubgraphsExcept(['get-users']);
+
+    expect($store->subgraphIds())->toBe(['get-users'])
+        ->and($store->getSubgraph('get-orders'))->toBeNull();
+});
+
+it('keeps every subgraph the scan wrote', function () {
+    $dir = graphStoreTmpDir();
+    $store = seedStore($dir, ['get-users', 'get-orders', 'post-orders']);
+
+    $store->pruneSubgraphsExcept(['get-users', 'get-orders', 'post-orders']);
+
+    expect($store->subgraphIds())->toHaveCount(3);
+});
+
+it('never prunes the manifest', function () {
+    $dir = graphStoreTmpDir();
+    $store = seedStore($dir, ['get-users']);
+
+    // The manifest is not a tab, so an empty keep list must not take it with them.
+    $store->pruneSubgraphsExcept([]);
+
+    expect($store->subgraphIds())->toBe([])
+        ->and($store->hasManifest())->toBeTrue()
+        ->and($store->getManifest())->toBe('{"tabs":[]}');
+});
+
+it('is a no-op on a store that holds nothing yet', function () {
+    $dir = graphStoreTmpDir();
+    $store = new FileGraphStore($dir);
+
+    $store->pruneSubgraphsExcept(['get-users']);
+
+    expect($store->subgraphIds())->toBe([]);
+});
+
+it('leaves a subgraph whose id was written again under a new scan', function () {
+    $dir = graphStoreTmpDir();
+    $store = seedStore($dir, ['get-users']);
+
+    $store->putSubgraph('get-users', '{"nodes":[{"id":"n1"}],"edges":[]}');
+    $store->pruneSubgraphsExcept(['get-users']);
+
+    expect($store->getSubgraph('get-users'))->toBe('{"nodes":[{"id":"n1"}],"edges":[]}');
+});


### PR DESCRIPTION
## Drop subgraphs whose route no longer exists

A scan writes one subgraph blob per tab and never removes the ones it did not write. `subgraphIds()` reports whatever is stored, so a route that is deleted or renamed leaves its blob behind and the viewer keeps listing a tab for a surface the application no longer has.

Measured on one application: a package upgrade changed a module's route surface, and the eight URIs it dropped left **33 orphaned tab files** in `storage/app/laravel-brain/`. Three days and several scans later they were still listed — there is no path by which they ever go away, short of deleting the directory by hand.

Both drivers leaked: `FileGraphStore` never unlinked a file, `DatabaseGraphStore` never deleted a row. So pruning goes on the `GraphStore` contract, next to the `subgraphIds()` it mirrors, and both places that persist a scan call it — `ScanCommand` and `BrainController`.

### Why pruning to "what this scan wrote" is safe

This was the one thing worth checking, because getting it wrong would delete live tabs on every `--watch` poll rather than leave dead ones around.

It holds: a scoped rescan merges its partial result into the previous graph and the splitter runs on the **merged** graph, so `$result->subgraphs` is the complete tab set in both the full and the scoped mode. Both modes then persist through the same block in `ScanCommand::runScan()`. There is no path that writes a subset of tabs.

The manifest is not a tab and is excluded by `subgraphIds()` already, so it survives pruning — including `pruneSubgraphsExcept([])`, which there is a test for.

### Alternative considered

A `--prune` flag, leaving the current behaviour as the default. I did not take it: the store is a cache of the last scan, and a blob no tab can address is not data the flag would be protecting. Happy to add the flag instead if you would rather the drivers never delete without being asked.

### Tests

5 new tests against `FileGraphStore`: a subgraph the scan did not write is dropped, ones it did write are kept, the manifest is never pruned, an empty store is a no-op, and a rewritten subgraph keeps its new content.

`DatabaseGraphStore` has no test — the Unit suite runs on plain PHPUnit with no Laravel container or connection, and standing one up for this seemed a larger change than the fix. The implementation is the same query `subgraphIds()` already uses, with `delete()` and a `whereNotIn`.

Full suite: `259 passed (861 assertions)`, up from 254. `pint` clean, `phpstan` 0 errors.

### Compatibility

The contract gains a method, so a third-party `GraphStore` implementation outside this package would need to add it. Both in-tree drivers implement it, and no stored payload changes shape — the only difference is that a scan now leaves the directory (or table) holding exactly the tabs the manifest lists.
