### PR TITLE
Fix: report memory exhaustion instead of exiting silently, and allow a configured limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,27 @@ Stress testing uses [`laramint/laravel-stress`](https://github.com/LaraMint/lara
 
 Single-label hostnames (Docker service names with no dots) and private IPv4 ranges are automatically allowed by the host validator, so pointing the Base URL at your internal network address will work without any extra config.
 
+## Memory
+
+A scan holds the whole graph and a parsed-AST cache at once, so a large application needs more than the 1024M default. When it does not fit, PHP kills the process — and with nothing to allocate, neither PHP's own error report nor anything else can render, so the run ends mid-step at exit 255 with no output at all.
+
+The scan holds a small reserve back for exactly that moment: it releases it at shutdown and says what happened and what to change.
+
+```
+The scan ran out of memory at --memory-limit=1024M. Raise it (--memory-limit=2048M),
+lift it entirely (--memory-limit=-1), or set `memory_limit` in config/laravel-brain.php
+so every scan of this project gets the larger value.
+```
+
+Set it once per project rather than remembering the flag:
+
+```php
+// config/laravel-brain.php
+'memory_limit' => env('LARAVEL_BRAIN_MEMORY_LIMIT', '2048M'),
+```
+
+`--memory-limit` still overrides it for a single run.
+
 ## Storage Driver
 
 Scan output (the graph) can be persisted in one of two ways, selected with the

--- a/config/laravel-brain.php
+++ b/config/laravel-brain.php
@@ -63,6 +63,22 @@ return [
     ],
 
     // -------------------------------------------------------------------------
+    // Memory Limit
+    // -------------------------------------------------------------------------
+    // Memory the scan runs with, applied before analysis starts. Accepts the PHP
+    // notation (1024M, 2G) or -1 for no limit; the minimum accepted is 1024M.
+    //
+    // A scan holds the whole graph plus a parsed AST cache, so a large application
+    // needs more than the default. When it does not fit, PHP kills the process — the
+    // scan reports that and names this setting rather than exiting silently.
+    //
+    // `--memory-limit` on the command overrides this for a single run.
+    //
+    // Override via the LARAVEL_BRAIN_MEMORY_LIMIT env variable.
+    //
+    'memory_limit' => env('LARAVEL_BRAIN_MEMORY_LIMIT', '1024M'),
+
+    // -------------------------------------------------------------------------
     // Auto-Discover Routes
     // -------------------------------------------------------------------------
     // When true, RouteAnalyzer skips AST parsing of route_paths and instead

--- a/src/Commands/MemoryExhaustionNotice.php
+++ b/src/Commands/MemoryExhaustionNotice.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaraMint\LaravelBrain\Commands;
+
+/**
+ * Turns PHP's memory-exhaustion fatal into something a person can act on.
+ *
+ * When the scan runs past `memory_limit`, PHP kills the process with exit code 255. On a
+ * CLI with `display_errors` off nothing reaches the terminal at all: the progress line
+ * stops mid-step and there is no message, no exit reason, and nothing in the log. The
+ * scan looks like it stopped for no reason, and the one thing that would fix it — a
+ * larger limit — is the one thing the output does not mention.
+ *
+ * The fatal is still recoverable at shutdown: {@see error_get_last()} holds it, and
+ * writing a line needs only a little memory back, which is what the caller's reserve
+ * buffer is for.
+ */
+final class MemoryExhaustionNotice
+{
+    /**
+     * Bytes held back so there is room to build and print the message after the heap is full.
+     */
+    public const RESERVE_BYTES = 262144;
+
+    /**
+     * The message for a memory-exhaustion fatal, or null for anything else — a normal exit,
+     * a parse error, an uncaught exception. Only the one condition this can explain is claimed.
+     *
+     * @param  array{type?: int, message?: string, file?: string, line?: int}|null  $lastError
+     */
+    public static function forLastError(?array $lastError, string $limitInEffect): ?string
+    {
+        if ($lastError === null || ($lastError['type'] ?? null) !== E_ERROR) {
+            return null;
+        }
+
+        $message = (string) ($lastError['message'] ?? '');
+        if (! str_contains($message, 'Allowed memory size of')) {
+            return null;
+        }
+
+        return sprintf(
+            'The scan ran out of memory at --memory-limit=%s. Raise it (%s), lift it entirely '
+            .'(--memory-limit=-1), or set `memory_limit` in config/laravel-brain.php so every '
+            .'scan of this project gets the larger value.',
+            $limitInEffect,
+            self::suggestion($limitInEffect),
+        );
+    }
+
+    /**
+     * A concrete next value to try: double what did not fit, so the advice is a command to
+     * run rather than an invitation to guess.
+     */
+    private static function suggestion(string $limitInEffect): string
+    {
+        if (! preg_match('/^(\d+)([KMGT]?)$/i', trim($limitInEffect), $matches)) {
+            return '--memory-limit=2048M';
+        }
+
+        return '--memory-limit='.((int) $matches[1] * 2).strtoupper($matches[2] ?: 'M');
+    }
+}

--- a/src/Commands/ScanCommand.php
+++ b/src/Commands/ScanCommand.php
@@ -15,23 +15,29 @@ class ScanCommand extends Command
     protected $signature = 'brain:scan
                             {--watch : Watch for PHP file changes and auto-rescan}
                             {--interval=3 : Poll interval in seconds (watch mode only)}
-                            {--memory-limit=1024M : Increase memory limit for scanning. Example: 1024M}
+                            {--memory-limit= : Memory limit for scanning, e.g. 1024M, 2G or -1. Defaults to config laravel-brain.memory_limit}
                             {--auto-discover : Force auto-discover routes mode for this scan (overrides config)}';
 
     protected $description = 'Analyze this Laravel project and open the interactive graph viewer';
+
+    /** The limit used when neither the option nor the config names one. */
+    public const DEFAULT_MEMORY_LIMIT = '1024M';
 
     /** @var array<string, float> step start times */
     private array $stepTimers = [];
 
     public function handle(): int
     {
-        $memoryLimit = $this->normalizeMemoryLimit($this->option('memory-limit'));
+        $memoryLimit = $this->normalizeMemoryLimit(
+            $this->option('memory-limit') ?? config('laravel-brain.memory_limit', self::DEFAULT_MEMORY_LIMIT),
+        );
 
         if ($memoryLimit === self::FAILURE) {
             return $memoryLimit;
         }
 
         ini_set('memory_limit', $memoryLimit);
+        $this->reportMemoryExhaustionOnShutdown((string) $memoryLimit);
 
         $projectPath = base_path();
 
@@ -40,6 +46,31 @@ class ScanCommand extends Command
         }
 
         return $this->runScan($projectPath, verbose: true);
+    }
+
+    /**
+     * Say so when the scan dies of memory exhaustion.
+     *
+     * PHP exits 255 on that fatal and, with `display_errors` off, prints nothing — the
+     * progress line simply stops. Registering the check at shutdown is the only place the
+     * fatal is still readable, and the reserve is released first so there is heap left to
+     * write the line with.
+     */
+    private function reportMemoryExhaustionOnShutdown(string $limitInEffect): void
+    {
+        $reserve = str_repeat(' ', MemoryExhaustionNotice::RESERVE_BYTES);
+
+        register_shutdown_function(function () use (&$reserve, $limitInEffect): void {
+            // Released first: with the heap full there is otherwise nothing to build a
+            // message with, and PHP's own report cannot render either.
+            $reserve = null;
+
+            $notice = MemoryExhaustionNotice::forLastError(error_get_last(), $limitInEffect);
+            if ($notice !== null) {
+                $this->newLine();
+                $this->error($notice);
+            }
+        });
     }
 
     // ── Watch mode ────────────────────────────────────────────────────────────

--- a/tests/Unit/MemoryExhaustionNoticeTest.php
+++ b/tests/Unit/MemoryExhaustionNoticeTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use LaraMint\LaravelBrain\Commands\MemoryExhaustionNotice;
+
+it('explains a memory-exhaustion fatal and names the setting that fixes it', function () {
+    $notice = MemoryExhaustionNotice::forLastError([
+        'type' => E_ERROR,
+        'message' => 'Allowed memory size of 1073741824 bytes exhausted (tried to allocate 20480 bytes)',
+        'file' => '/app/vendor/nikic/php-parser/lib/PhpParser/Lexer.php',
+        'line' => 120,
+    ], '1024M');
+
+    expect($notice)->toContain('--memory-limit=1024M')
+        ->toContain('--memory-limit=-1')
+        ->toContain('config/laravel-brain.php');
+});
+
+it('suggests double what did not fit, so the advice is a command rather than a guess', function () {
+    $notice = MemoryExhaustionNotice::forLastError([
+        'type' => E_ERROR,
+        'message' => 'Allowed memory size of 1073741824 bytes exhausted',
+    ], '1024M');
+
+    expect($notice)->toContain('--memory-limit=2048M');
+});
+
+it('keeps the unit it was given when doubling', function () {
+    $notice = MemoryExhaustionNotice::forLastError([
+        'type' => E_ERROR,
+        'message' => 'Allowed memory size of 2147483648 bytes exhausted',
+    ], '2G');
+
+    expect($notice)->toContain('--memory-limit=4G');
+});
+
+it('falls back to a concrete suggestion when the limit is not a size', function () {
+    $notice = MemoryExhaustionNotice::forLastError([
+        'type' => E_ERROR,
+        'message' => 'Allowed memory size of 1073741824 bytes exhausted',
+    ], '-1');
+
+    expect($notice)->toContain('--memory-limit=2048M');
+});
+
+it('says nothing when the process ended normally', function () {
+    expect(MemoryExhaustionNotice::forLastError(null, '1024M'))->toBeNull();
+});
+
+it('says nothing for a fatal it cannot explain', function () {
+    // Claiming a memory problem for an unrelated crash would send the reader the wrong way.
+    $notice = MemoryExhaustionNotice::forLastError([
+        'type' => E_ERROR,
+        'message' => 'Uncaught TypeError: bad argument',
+    ], '1024M');
+
+    expect($notice)->toBeNull();
+});
+
+it('says nothing for a warning that merely mentions memory', function () {
+    $notice = MemoryExhaustionNotice::forLastError([
+        'type' => E_WARNING,
+        'message' => 'Allowed memory size of 1073741824 bytes exhausted',
+    ], '1024M');
+
+    expect($notice)->toBeNull();
+});


### PR DESCRIPTION
## A scan that runs out of memory says nothing at all

On a large application `brain:scan` ends like this:

```
 ○ Scanning routes..    ✓ routes.. 380 routes (0.01s)
 ○ Scanning middleware..    ✓ middleware.. (0.00s)
 ○ Analyzing controllers..    ✓ controllers.. 223 controllers (0.21s)
 ○ Tracing full lifecycle..
```

Nine lines, stopping mid-step, exit code 255. No mention of memory, no PHP fatal, nothing in the Laravel log, empty stderr. It reads like the scanner gave up for no reason.

It ran out of memory. Measured on the same project: `--memory-limit=1024M` exits 255, `1536M` and `2048M` complete. And the reason nothing is printed is the same reason it died — with the heap full there is nothing left to allocate a report with, so PHP's own "Allowed memory size … exhausted" never renders either.

The default is `1024M`, and `normalizeMemoryLimit()` enforces `1024M` as the **minimum** the command will accept. So the value that fails is the lowest one available, the user cannot go lower, and nothing in the output suggests going higher.

### Saying what happened

The fatal is still readable at shutdown through `error_get_last()`. What is missing at that point is memory to act on it, so the command holds 256KB back and releases it first:

```php
$reserve = str_repeat(' ', MemoryExhaustionNotice::RESERVE_BYTES);

register_shutdown_function(function () use (&$reserve, $limitInEffect): void {
    $reserve = null;
    $notice = MemoryExhaustionNotice::forLastError(error_get_last(), $limitInEffect);
    if ($notice !== null) {
        $this->newLine();
        $this->error($notice);
    }
});
```

Which turns the silence into:

```
The scan ran out of memory at --memory-limit=1024M. Raise it (--memory-limit=2048M),
lift it entirely (--memory-limit=-1), or set `memory_limit` in config/laravel-brain.php
so every scan of this project gets the larger value.
```

The suggested value is double what did not fit, keeping the unit it was given, so the advice is a command to run rather than an invitation to guess.

A side effect worth knowing: with the reserve released, **PHP's own fatal renders too**. Before the change that run printed nothing; after it, the same run prints `Allowed memory size of 1073741824 bytes exhausted` as well as the line above. The reserve is not only for our message — it is what lets any error reporting work at that moment.

**And it depends on how the heap fills, which is why this looks intermittent.** Measured at a 32M limit, varying the size of the allocation that finally fails:

| failing allocation | without the reserve | with the reserve |
|---|---|---|
| 1 MB | printed | printed |
| 100 KB | printed | printed |
| 1 KB | **silent** | printed |
| 64 B | **silent** | printed |

A run that dies asking for one large block leaves that much slack behind and would have reported itself anyway. A run that dies in small increments has nothing left — and small increments is what parsing does, which is why the scan is the case that goes quiet. (Boundary measured by @SanderMuller in review; I had claimed the silence unconditionally.)

### Setting it once per project

The limit now comes from config, so an application that needs 2G stops relying on everyone remembering the flag:

```php
// config/laravel-brain.php
'memory_limit' => env('LARAVEL_BRAIN_MEMORY_LIMIT', '1024M'),
```

`--memory-limit` still wins for a single run. Omitted, the option falls through to the config, which defaults to the previous `1024M` — so nothing changes for anyone who does not set it. The signature default moved from `1024M` to empty for that reason; that is the only way to tell "not passed" from "passed the same value".

### Why the message is its own class

`MemoryExhaustionNotice` is separated from the command so the decision can be tested without exhausting memory inside a test. 7 tests: the message names the limit and the config key, the suggestion doubles, the unit is preserved, an unparseable limit still yields something concrete, and it stays silent for a normal exit, for an unrelated fatal, and for a warning that merely mentions memory. That last one matters — claiming a memory problem for an unrelated crash sends the reader the wrong way.

### Verification

- Reproduced against a real application, before and after, at the default limit: 9 lines and silence before; the same run with the notice and PHP's own fatal after. Exit code stays 255 either way, which is correct — this reports the failure, it does not swallow it.
- `254 → 261 passed`, PHPStan 0 errors, Pint clean.

PHPStan caught the first shape of this, where the reserve was a property: `never read, only written`. It was right — the reserve's lifetime belongs to the shutdown handler, not to the command object, so it is a local captured by reference now.

