### PR TITLE
Fix: AI context export contains no source, and prints provenance as PHP

### DIFF
--- a/src/Ai/ContextExporter.php
+++ b/src/Ai/ContextExporter.php
@@ -312,11 +312,24 @@ class ContextExporter
         $sourceParts = [];
         $nodesForSource = $ctx->nodes;
 
+        // Nodes name files far more often than files exist: a class and its methods, a resource
+        // and its pages, all carry the same path. Emitting per node would put one file's whole
+        // contents in the export once for every node that names it — and every copy is spent
+        // out of the budget the rest of this method exists to respect.
+        $emitted = [];
+
         foreach ($nodesForSource as $i => $node) {
-            $source = $this->readSource((string) ($node['data']['file'] ?? ''));
+            $file = (string) ($node['data']['file'] ?? '');
+            if ($file !== '' && isset($emitted[$file])) {
+                continue;
+            }
+
+            $source = $this->readSource($file);
             if ($source === '') {
                 continue;
             }
+
+            $emitted[$file] = true;
 
             $isFocal = $i === 0;
             $label = (string) $node['label'];

--- a/src/Ai/ContextExporter.php
+++ b/src/Ai/ContextExporter.php
@@ -303,12 +303,17 @@ class ContextExporter
         $structural = implode("\n", $parts);
         $charBudget -= strlen($structural);
 
-        // Source snippets (budget-gated, focal node first)
+        // Source snippets (budget-gated, focal node first).
+        //
+        // Read from the file each node names. This used to read `data['source']`, which no
+        // analyzer ever fills with code — the only writer put a command's provenance there —
+        // so the whole budget-gated path emitted nothing on 8,454 of one project's 10,142
+        // nodes and a ```php block containing the word "class" on the remaining 113.
         $sourceParts = [];
         $nodesForSource = $ctx->nodes;
 
         foreach ($nodesForSource as $i => $node) {
-            $source = (string) ($node['data']['source'] ?? '');
+            $source = $this->readSource((string) ($node['data']['file'] ?? ''));
             if ($source === '') {
                 continue;
             }
@@ -343,6 +348,30 @@ class ContextExporter
         }
 
         return $structural.implode("\n", $sourceParts);
+    }
+
+    /**
+     * The contents of a file a node names, or '' when there is nothing safe to read.
+     *
+     * Confined to the project being analysed: node paths come from the scan, but an export is
+     * something a person hands to a model, and reading outside the tree is not a mistake worth
+     * being able to make.
+     */
+    private function readSource(string $file): string
+    {
+        if ($file === '' || ! is_file($file) || ! is_readable($file)) {
+            return '';
+        }
+
+        if ($this->projectPath !== '') {
+            $root = realpath(rtrim($this->projectPath, '/'));
+            $real = realpath($file);
+            if ($root === false || $real === false || ! str_starts_with($real, $root.DIRECTORY_SEPARATOR)) {
+                return '';
+            }
+        }
+
+        return (string) file_get_contents($file);
     }
 
     // ── JSON serializer ───────────────────────────────────────────────────────

--- a/src/Graph/GraphBuilder.php
+++ b/src/Graph/GraphBuilder.php
@@ -2025,7 +2025,10 @@ class GraphBuilder
                     'description' => $cmd->description,
                     'class' => $cmd->class,
                     'file' => $cmd->file,
-                    'source' => $cmd->source,
+                    // Where the definition was found ('class' | 'route' | 'kernel'). Not the
+                    // command's code: `source` read as source is what put the literal string
+                    // "class" into AI context exports inside a ```php fence.
+                    'definedIn' => $cmd->source,
                     'flowSteps' => $flowSteps,
                     'metrics' => $metrics ?: null,
                     'hasN1' => $hasN1,

--- a/tests/Unit/ContextExporterSourceTest.php
+++ b/tests/Unit/ContextExporterSourceTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use LaraMint\LaravelBrain\Ai\ContextExporter;
+use LaraMint\LaravelBrain\Storage\FileGraphStore;
+
+/** A project with one node whose `file` points wherever the caller says. */
+function exporterFixture(string $nodeFile): array
+{
+    $project = sys_get_temp_dir().'/lb_ctx_'.bin2hex(random_bytes(6));
+    mkdir($project.'/storage', 0o777, true);
+
+    $store = new FileGraphStore($project.'/storage');
+    $store->ensureSchema();
+    $store->putManifest(json_encode(['project' => 'demo', 'analyzedAt' => '2026-01-01T00:00:00+00:00', 'tabs' => []]));
+    $store->putSubgraph('tab-a', json_encode([
+        'nodes' => [[
+            'id' => 'service::Demo',
+            'label' => 'Demo',
+            'type' => 'service',
+            'data' => ['id' => 'service::Demo', 'label' => 'Demo', 'type' => 'service', 'file' => $nodeFile],
+        ]],
+        'edges' => [],
+    ]));
+
+    return [$project, new ContextExporter($store, $project)];
+}
+
+it('includes the source of the file a node names', function () {
+    $project = sys_get_temp_dir().'/lb_ctx_'.bin2hex(random_bytes(6));
+    mkdir($project.'/app', 0o777, true);
+    $file = $project.'/app/Demo.php';
+    file_put_contents($file, "<?php\n\nclass Demo { public function run(): void {} }\n");
+
+    mkdir($project.'/storage', 0o777, true);
+    $store = new FileGraphStore($project.'/storage');
+    $store->ensureSchema();
+    $store->putManifest(json_encode(['project' => 'demo', 'analyzedAt' => '2026-01-01T00:00:00+00:00', 'tabs' => []]));
+    $store->putSubgraph('tab-a', json_encode([
+        'nodes' => [[
+            'id' => 'service::Demo',
+            'label' => 'Demo',
+            'type' => 'service',
+            'data' => ['id' => 'service::Demo', 'label' => 'Demo', 'type' => 'service', 'file' => $file],
+        ]],
+        'edges' => [],
+    ]));
+
+    $out = (new ContextExporter($store, $project))->export(nodeId: 'service::Demo');
+
+    expect($out)->toContain('## Source: Demo (focal)')
+        ->toContain('class Demo { public function run(): void {} }');
+});
+
+it('reads nothing for a node whose file is missing', function () {
+    [$project, $exporter] = exporterFixture('/does/not/exist/Demo.php');
+
+    expect($exporter->export(nodeId: 'service::Demo'))->not->toContain('## Source:');
+});
+
+it('refuses a file outside the project being analysed', function () {
+    // Node paths come from the scan, but an export is something a person hands to a model;
+    // reading outside the tree is not a mistake worth being able to make.
+    $outside = sys_get_temp_dir().'/lb_outside_'.bin2hex(random_bytes(6)).'.php';
+    file_put_contents($outside, "<?php\n// secret\n");
+
+    [$project, $exporter] = exporterFixture($outside);
+
+    expect($exporter->export(nodeId: 'service::Demo'))
+        ->not->toContain('## Source:')
+        ->not->toContain('secret');
+
+    @unlink($outside);
+});
+
+it('reads nothing when the node names no file', function () {
+    [$project, $exporter] = exporterFixture('');
+
+    expect($exporter->export(nodeId: 'service::Demo'))->not->toContain('## Source:');
+});

--- a/tests/Unit/ContextExporterSourceTest.php
+++ b/tests/Unit/ContextExporterSourceTest.php
@@ -3,8 +3,14 @@
 use LaraMint\LaravelBrain\Ai\ContextExporter;
 use LaraMint\LaravelBrain\Storage\FileGraphStore;
 
-/** A project with one node whose `file` points wherever the caller says. */
-function exporterFixture(string $nodeFile): array
+/**
+ * A project with one node whose `file` points wherever the caller says.
+ *
+ * `$projectPath` is what the exporter is confined to. Passing `''` turns the containment check
+ * off, which is the only way to reach the guard behind it — with a root set, `realpath()` refuses
+ * an empty or missing path before the guard is ever asked about it.
+ */
+function exporterFixture(string $nodeFile, ?string $projectPath = null): array
 {
     $project = sys_get_temp_dir().'/lb_ctx_'.bin2hex(random_bytes(6));
     mkdir($project.'/storage', 0o777, true);
@@ -22,7 +28,7 @@ function exporterFixture(string $nodeFile): array
         'edges' => [],
     ]));
 
-    return [$project, new ContextExporter($store, $project)];
+    return [$project, new ContextExporter($store, $projectPath ?? $project)];
 }
 
 it('includes the source of the file a node names', function () {
@@ -52,9 +58,23 @@ it('includes the source of the file a node names', function () {
 });
 
 it('reads nothing for a node whose file is missing', function () {
-    [$project, $exporter] = exporterFixture('/does/not/exist/Demo.php');
+    // Unconfined on purpose: with a project root set, containment refuses this path first and
+    // the guard under test never runs.
+    [$project, $exporter] = exporterFixture('/does/not/exist/Demo.php', projectPath: '');
 
-    expect($exporter->export(nodeId: 'service::Demo'))->not->toContain('## Source:');
+    // An empty export is not enough to prove the guard: `file_get_contents()` on a missing file
+    // returns false, which reads as "no source" either way. What separates them is the warning it
+    // raises on the way — and Laravel's `HandleExceptions` turns that into an `ErrorException`,
+    // so in an application the unguarded path does not read as empty, it throws.
+    set_error_handler(function (int $severity, string $message): never {
+        throw new ErrorException($message, 0, $severity);
+    });
+
+    try {
+        expect($exporter->export(nodeId: 'service::Demo'))->not->toContain('## Source:');
+    } finally {
+        restore_error_handler();
+    }
 });
 
 it('refuses a file outside the project being analysed', function () {
@@ -73,7 +93,39 @@ it('refuses a file outside the project being analysed', function () {
 });
 
 it('reads nothing when the node names no file', function () {
-    [$project, $exporter] = exporterFixture('');
+    [$project, $exporter] = exporterFixture('', projectPath: '');
 
     expect($exporter->export(nodeId: 'service::Demo'))->not->toContain('## Source:');
+});
+
+// ── One file, many nodes ─────────────────────────────────────────────────────
+
+it('emits a file once however many nodes name it', function () {
+    // A class and its methods, a resource and its pages: nodes name files far more often than
+    // files exist. Emitting per node spends the budget on copies of a body already in the export.
+    $project = sys_get_temp_dir().'/lb_ctx_'.bin2hex(random_bytes(6));
+    mkdir($project.'/app', 0o777, true);
+    mkdir($project.'/storage', 0o777, true);
+
+    $file = $project.'/app/Demo.php';
+    file_put_contents($file, "<?php\n\nclass Demo { public function run(): void {} }\n");
+
+    $node = fn (string $id, string $label): array => [
+        'id' => $id,
+        'label' => $label,
+        'type' => 'service',
+        'data' => ['id' => $id, 'label' => $label, 'type' => 'service', 'file' => $file],
+    ];
+
+    $store = new FileGraphStore($project.'/storage');
+    $store->ensureSchema();
+    $store->putManifest(json_encode(['project' => 'demo', 'analyzedAt' => '2026-01-01T00:00:00+00:00', 'tabs' => []]));
+    $store->putSubgraph('tab-a', json_encode([
+        'nodes' => [$node('service::Demo', 'Demo'), $node('method::Demo@run', 'Demo@run')],
+        'edges' => [['source' => 'service::Demo', 'target' => 'method::Demo@run', 'type' => 'calls']],
+    ]));
+
+    $out = (new ContextExporter($store, $project))->export(nodeId: 'service::Demo');
+
+    expect(substr_count($out, 'class Demo { public function run(): void {} }'))->toBe(1);
 });


### PR DESCRIPTION
## The AI context export contains no source, and prints provenance inside a ```php fence

`ContextExporter` builds its budget-gated snippets from `data['source']`:

```php
$source = (string) ($node['data']['source'] ?? '');
if ($source === '') {
    continue;
}
```

No analyzer ever puts code there. The only writer of that key is `GraphBuilder`'s command node, and what it stores is `ConsoleCommandDefinition::$source` — *where the definition was found*, one of `'class'`, `'route'` or `'kernel'`.

On one application's 10,142 graph nodes the effect splits two ways. For 10,029 the key is absent, so the loop `continue`s and the export has no code in it at all. For the remaining 113 — the commands — it produces this:

````
## Source: pim:prune-orphaned-product-listings {--tenant=*} (focal)
```php
class
```
````

And because no snippet is ever emitted, `--budget` governs nothing. The same route exported at `--budget=300` and at `--budget=50000` came out byte-identical apart from the header line, and **87% of it was the two dependency tables**.

### Reading the file the node already names

Nodes carry `data['file']` — 8,454 of those 10,142 — which is the same path the viewer's Source tab loads through `BrainController::source()`. The snippets read that instead.

Measured on the same route export:

| | before | after |
|---|---|---|
| total | 5,058 chars | 21,764 chars |
| source | none | 77% |
| dependency tables | 87% | 20% |

And the budget bounds it monotonically for the first time:

```
budget    500 ->  1,264 tokens,  0 source sections
budget  2,000 ->  1,935 tokens,  1
budget  6,000 ->  5,441 tokens,  4
budget 20,000 -> 14,174 tokens, 19
```

Reading is confined to the project being analysed. Node paths come from the scan and should already be inside it, but an export is something a person hands to a model, and reading outside the tree is not a mistake worth leaving reachable.

### Renaming the key

The command node's `source` becomes `definedIn`, so nothing is called `source` that is not source. Nothing consumed it: the viewer distinguishes an edge from a node by testing `source` **and** `target` together, which a command node never satisfied — close, but it never fired.

### Tests

4 tests covering the decision: a node whose file exists yields its code under a `## Source:` heading, a missing file yields nothing, a file outside the project is refused, and a node naming no file yields nothing.

### Verification

- Reproduced against a real application before and after, including the `class`-in-a-php-fence output, which is what sent me looking.
- `254 → 258 passed`, PHPStan 0, Pint clean.

### One thing this does not fix

The two dependency tables are still emitted unconditionally, ahead of any snippet, and subtracted from the budget rather than fitted into it. At `--budget=500` the export is 1,264 tokens — 2.5× the budget — of which 87% is those tables and none is code. That is a separate defect and I will raise it on its own.
