### PR TITLE
Fix: dependency tables spend the context budget instead of fitting into it

### DIFF
--- a/src/Ai/ContextExporter.php
+++ b/src/Ai/ContextExporter.php
@@ -17,6 +17,11 @@ class ContextExporter
         'filament_panel', 'filament_resource', 'filament_page', 'filament_widget', 'filament_relation_manager',
     ];
 
+    /**
+     * How much of what is left after the structural essentials the dependency tables may take.
+     */
+    private const PACKAGE_BUDGET_SHARE = 0.15;
+
     public function __construct(
         private readonly GraphStore $store,
         private readonly string $projectPath = '',
@@ -273,35 +278,27 @@ class ContextExporter
             $parts[] = '';
         }
 
-        // Backend packages (composer.json)
-        $composerPackages = $this->readComposerPackages();
-        if (! empty($composerPackages)) {
-            $parts[] = '## Backend Packages (composer.json)';
-            $parts[] = '| Package | Version | Dev |';
-            $parts[] = '|---------|---------|-----|';
-            foreach ($composerPackages as ['name' => $name, 'version' => $version, 'dev' => $dev]) {
-                $devMark = $dev ? 'yes' : '';
-                $parts[] = "| {$name} | {$version} | {$devMark} |";
-            }
-            $parts[] = '';
-        }
-
-        // Frontend packages (package.json)
-        $frontendPackages = $this->readFrontendPackages();
-        if (! empty($frontendPackages)) {
-            $parts[] = '## Frontend Packages (package.json)';
-            $parts[] = '| Package | Version | Dev |';
-            $parts[] = '|---------|---------|-----|';
-            foreach ($frontendPackages as ['name' => $name, 'version' => $version, 'dev' => $dev]) {
-                $devMark = $dev ? 'yes' : '';
-                $parts[] = "| {$name} | {$version} | {$devMark} |";
-            }
-            $parts[] = '';
-        }
-
         // Pre-budget structural content (always included)
         $structural = implode("\n", $parts);
         $charBudget -= strlen($structural);
+
+        // The dependency lists say what the project has installed, not what the focal node
+        // does, and on a large application they are long enough to be the whole export: a
+        // route asked for at 500 tokens came back at 1,264, of which 87% was these two
+        // tables and none was code. They get a share of what is left and no more.
+        $packageBudget = (int) ($charBudget * self::PACKAGE_BUDGET_SHARE);
+        $packages = $this->packageSection(
+            '## Backend Packages (composer.json)',
+            $this->readComposerPackages(),
+            $packageBudget,
+        );
+        $packages .= $this->packageSection(
+            '## Frontend Packages (package.json)',
+            $this->readFrontendPackages(),
+            $packageBudget - strlen($packages),
+        );
+        $structural .= $packages;
+        $charBudget -= strlen($packages);
 
         // Source snippets (budget-gated, focal node first).
         //
@@ -348,6 +345,47 @@ class ContextExporter
         }
 
         return $structural.implode("\n", $sourceParts);
+    }
+
+    /**
+     * One dependency table, as much of it as $charBudget allows.
+     *
+     * Truncated rather than dropped: knowing the project runs Filament at all is worth a few
+     * lines, and the count says plainly what was left out instead of implying the list is whole.
+     *
+     * @param  list<array{name: string, version: string, dev: bool}>  $packages
+     */
+    private function packageSection(string $heading, array $packages, int $charBudget): string
+    {
+        if ($packages === [] || $charBudget <= 0) {
+            return '';
+        }
+
+        $rows = [$heading, '| Package | Version | Dev |', '|---------|---------|-----|'];
+        $used = strlen(implode("\n", $rows));
+        $shown = 0;
+
+        foreach ($packages as ['name' => $name, 'version' => $version, 'dev' => $dev]) {
+            $row = '| '.$name.' | '.$version.' | '.($dev ? 'yes' : '').' |';
+            if ($used + strlen($row) + 1 > $charBudget) {
+                break;
+            }
+            $rows[] = $row;
+            $used += strlen($row) + 1;
+            $shown++;
+        }
+
+        if ($shown === 0) {
+            return '';
+        }
+
+        $omitted = count($packages) - $shown;
+        if ($omitted > 0) {
+            $rows[] = "| …and {$omitted} more | | |";
+        }
+        $rows[] = '';
+
+        return "\n".implode("\n", $rows);
     }
 
     /**

--- a/src/Ai/ContextExporter.php
+++ b/src/Ai/ContextExporter.php
@@ -312,11 +312,24 @@ class ContextExporter
         $sourceParts = [];
         $nodesForSource = $ctx->nodes;
 
+        // Nodes name files far more often than files exist: a class and its methods, a resource
+        // and its pages, all carry the same path. Emitting per node would put one file's whole
+        // contents in the export once for every node that names it — and every copy is spent
+        // out of the budget the rest of this method exists to respect.
+        $emitted = [];
+
         foreach ($nodesForSource as $i => $node) {
-            $source = $this->readSource((string) ($node['data']['file'] ?? ''));
+            $file = (string) ($node['data']['file'] ?? '');
+            if ($file !== '' && isset($emitted[$file])) {
+                continue;
+            }
+
+            $source = $this->readSource($file);
             if ($source === '') {
                 continue;
             }
+
+            $emitted[$file] = true;
 
             $isFocal = $i === 0;
             $label = (string) $node['label'];

--- a/src/Ai/ContextExporter.php
+++ b/src/Ai/ContextExporter.php
@@ -303,12 +303,17 @@ class ContextExporter
         $structural = implode("\n", $parts);
         $charBudget -= strlen($structural);
 
-        // Source snippets (budget-gated, focal node first)
+        // Source snippets (budget-gated, focal node first).
+        //
+        // Read from the file each node names. This used to read `data['source']`, which no
+        // analyzer ever fills with code — the only writer put a command's provenance there —
+        // so the whole budget-gated path emitted nothing on 8,454 of one project's 10,142
+        // nodes and a ```php block containing the word "class" on the remaining 113.
         $sourceParts = [];
         $nodesForSource = $ctx->nodes;
 
         foreach ($nodesForSource as $i => $node) {
-            $source = (string) ($node['data']['source'] ?? '');
+            $source = $this->readSource((string) ($node['data']['file'] ?? ''));
             if ($source === '') {
                 continue;
             }
@@ -343,6 +348,30 @@ class ContextExporter
         }
 
         return $structural.implode("\n", $sourceParts);
+    }
+
+    /**
+     * The contents of a file a node names, or '' when there is nothing safe to read.
+     *
+     * Confined to the project being analysed: node paths come from the scan, but an export is
+     * something a person hands to a model, and reading outside the tree is not a mistake worth
+     * being able to make.
+     */
+    private function readSource(string $file): string
+    {
+        if ($file === '' || ! is_file($file) || ! is_readable($file)) {
+            return '';
+        }
+
+        if ($this->projectPath !== '') {
+            $root = realpath(rtrim($this->projectPath, '/'));
+            $real = realpath($file);
+            if ($root === false || $real === false || ! str_starts_with($real, $root.DIRECTORY_SEPARATOR)) {
+                return '';
+            }
+        }
+
+        return (string) file_get_contents($file);
     }
 
     // ── JSON serializer ───────────────────────────────────────────────────────

--- a/src/Ai/ContextExporter.php
+++ b/src/Ai/ContextExporter.php
@@ -287,14 +287,24 @@ class ContextExporter
         // route asked for at 500 tokens came back at 1,264, of which 87% was these two
         // tables and none was code. They get a share of what is left and no more.
         $packageBudget = (int) ($charBudget * self::PACKAGE_BUDGET_SHARE);
+
+        // Split, rather than first-come. Handing the whole share to the backend table let it
+        // spend all of it — on an application with 120 dependencies of each kind the frontend
+        // table was absent at every budget under 20,000, and an absent table is indistinguishable
+        // from a project that has no `package.json` at all. Whatever the first table leaves
+        // unspent rolls forward, so a project with only one of the two still gets the full share.
+        $backendPackages = $this->readComposerPackages();
+        $frontendPackages = $this->readFrontendPackages();
+        $firstShare = $frontendPackages === [] ? $packageBudget : intdiv($packageBudget, 2);
+
         $packages = $this->packageSection(
             '## Backend Packages (composer.json)',
-            $this->readComposerPackages(),
-            $packageBudget,
+            $backendPackages,
+            $firstShare,
         );
         $packages .= $this->packageSection(
             '## Frontend Packages (package.json)',
-            $this->readFrontendPackages(),
+            $frontendPackages,
             $packageBudget - strlen($packages),
         );
         $structural .= $packages;
@@ -327,16 +337,20 @@ class ContextExporter
                 break;
             }
 
+            // The marker is part of the snippet, so it has to be part of the arithmetic that
+            // sizes it. Appending it afterwards put every truncated export exactly its own length
+            // over the budget — 32 bytes, the em dash costing three of them — at every budget.
+            $marker = "\n// [truncated — token budget]";
             $available = $charBudget - $overhead;
             $truncated = false;
             if (strlen($source) > $available) {
-                $source = substr($source, 0, $available);
+                $source = substr($source, 0, max(0, $available - strlen($marker)));
                 $truncated = true;
             }
 
             $snippet = $header.$source;
             if ($truncated) {
-                $snippet .= "\n// [truncated — token budget]";
+                $snippet .= $marker;
             }
             $snippet .= $footer;
 
@@ -353,11 +367,15 @@ class ContextExporter
      * Truncated rather than dropped: knowing the project runs Filament at all is worth a few
      * lines, and the count says plainly what was left out instead of implying the list is whole.
      *
+     * A table that does not fit at all still leaves its heading and its count behind. An empty
+     * string would say the same thing as "this project has no `package.json`", and those are not
+     * the same thing — telling them apart is the whole reason the truncation row exists.
+     *
      * @param  list<array{name: string, version: string, dev: bool}>  $packages
      */
     private function packageSection(string $heading, array $packages, int $charBudget): string
     {
-        if ($packages === [] || $charBudget <= 0) {
+        if ($packages === []) {
             return '';
         }
 
@@ -376,7 +394,7 @@ class ContextExporter
         }
 
         if ($shown === 0) {
-            return '';
+            return "\n".$heading."\n| …all ".count($packages)." omitted — token budget | | |\n";
         }
 
         $omitted = count($packages) - $shown;

--- a/src/Graph/GraphBuilder.php
+++ b/src/Graph/GraphBuilder.php
@@ -2025,7 +2025,10 @@ class GraphBuilder
                     'description' => $cmd->description,
                     'class' => $cmd->class,
                     'file' => $cmd->file,
-                    'source' => $cmd->source,
+                    // Where the definition was found ('class' | 'route' | 'kernel'). Not the
+                    // command's code: `source` read as source is what put the literal string
+                    // "class" into AI context exports inside a ```php fence.
+                    'definedIn' => $cmd->source,
                     'flowSteps' => $flowSteps,
                     'metrics' => $metrics ?: null,
                     'hasN1' => $hasN1,

--- a/tests/Unit/ContextExporterSourceTest.php
+++ b/tests/Unit/ContextExporterSourceTest.php
@@ -77,3 +77,63 @@ it('reads nothing when the node names no file', function () {
 
     expect($exporter->export(nodeId: 'service::Demo'))->not->toContain('## Source:');
 });
+
+// ── Dependency tables must fit the budget, not consume it ─────────────────────
+
+function exporterWithManyPackages(): array
+{
+    $project = sys_get_temp_dir().'/lb_ctx_'.bin2hex(random_bytes(6));
+    mkdir($project.'/app', 0o777, true);
+    mkdir($project.'/storage', 0o777, true);
+
+    $require = [];
+    for ($i = 0; $i < 120; $i++) {
+        $require["vendor/package-with-a-longish-name-{$i}"] = '^1.0';
+    }
+    file_put_contents($project.'/composer.json', json_encode(['require' => $require]));
+
+    $file = $project.'/app/Demo.php';
+    file_put_contents($file, "<?php\n\nclass Demo\n{\n    public function run(): void {}\n}\n");
+
+    $store = new FileGraphStore($project.'/storage');
+    $store->ensureSchema();
+    $store->putManifest(json_encode(['project' => 'demo', 'analyzedAt' => '2026-01-01T00:00:00+00:00', 'tabs' => []]));
+    $store->putSubgraph('tab-a', json_encode([
+        'nodes' => [[
+            'id' => 'service::Demo',
+            'label' => 'Demo',
+            'type' => 'service',
+            'data' => ['id' => 'service::Demo', 'label' => 'Demo', 'type' => 'service', 'file' => $file],
+        ]],
+        'edges' => [],
+    ]));
+
+    return [new ContextExporter($store, $project), $file];
+}
+
+it('does not let the dependency list eat the whole budget', function () {
+    [$exporter] = exporterWithManyPackages();
+
+    $out = $exporter->export(nodeId: 'service::Demo', budget: 500);
+
+    // The point of the export is the code the focal node runs; 120 package rows are not it.
+    expect($out)->toContain('## Source: Demo (focal)')
+        ->toContain('class Demo');
+});
+
+it('says how many packages it left out rather than implying the list is whole', function () {
+    [$exporter] = exporterWithManyPackages();
+
+    $out = $exporter->export(nodeId: 'service::Demo', budget: 500);
+
+    expect($out)->toMatch('/\|\s*…and \d+ more\s*\|/');
+});
+
+it('keeps the export inside the budget it was given', function () {
+    [$exporter] = exporterWithManyPackages();
+
+    $out = $exporter->export(nodeId: 'service::Demo', budget: 500);
+
+    // 4 characters per token is the ratio the exporter itself budgets with.
+    expect(strlen($out))->toBeLessThanOrEqual(500 * 4);
+});

--- a/tests/Unit/ContextExporterSourceTest.php
+++ b/tests/Unit/ContextExporterSourceTest.php
@@ -87,13 +87,18 @@ function exporterWithManyPackages(): array
     mkdir($project.'/storage', 0o777, true);
 
     $require = [];
+    $dependencies = [];
     for ($i = 0; $i < 120; $i++) {
         $require["vendor/package-with-a-longish-name-{$i}"] = '^1.0';
+        $dependencies["@scope/frontend-package-with-a-longish-name-{$i}"] = '^1.0';
     }
     file_put_contents($project.'/composer.json', json_encode(['require' => $require]));
+    file_put_contents($project.'/package.json', json_encode(['dependencies' => $dependencies]));
 
+    // Long enough that the snippet is truncated at every budget these tests use — the budget
+    // invariant below is only worth asserting on an export that actually hits the marker.
     $file = $project.'/app/Demo.php';
-    file_put_contents($file, "<?php\n\nclass Demo\n{\n    public function run(): void {}\n}\n");
+    file_put_contents($file, "<?php\n\nclass Demo\n{\n".str_repeat("    // filler\n", 500)."    public function run(): void {}\n}\n");
 
     $store = new FileGraphStore($project.'/storage');
     $store->ensureSchema();
@@ -136,4 +141,29 @@ it('keeps the export inside the budget it was given', function () {
 
     // 4 characters per token is the ratio the exporter itself budgets with.
     expect(strlen($out))->toBeLessThanOrEqual(500 * 4);
+});
+
+// ── Neither table may vanish without a trace ─────────────────────────────────
+
+it('keeps the frontend table from being crowded out by the backend one', function () {
+    // The backend table used to take the whole share, and an absent table says the same thing
+    // as "this project has no package.json" — which is the distinction the truncation row exists
+    // to preserve.
+    [$exporter] = exporterWithManyPackages();
+
+    $out = $exporter->export(nodeId: 'service::Demo', budget: 2000);
+
+    // Rows, not the heading: a crowded-out table still prints its heading and its omission
+    // count, so asserting the heading alone would pass with the share unsplit.
+    expect($out)->toContain('| vendor/package-with-a-longish-name-0 |')
+        ->toContain('| @scope/frontend-package-with-a-longish-name-0 |');
+});
+
+it('names a table it could not fit at all rather than omitting it silently', function () {
+    [$exporter] = exporterWithManyPackages();
+
+    $out = $exporter->export(nodeId: 'service::Demo', budget: 100);
+
+    expect($out)->toContain('## Frontend Packages (package.json)')
+        ->toMatch('/…all 120 omitted/');
 });

--- a/tests/Unit/ContextExporterSourceTest.php
+++ b/tests/Unit/ContextExporterSourceTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use LaraMint\LaravelBrain\Ai\ContextExporter;
+use LaraMint\LaravelBrain\Storage\FileGraphStore;
+
+/** A project with one node whose `file` points wherever the caller says. */
+function exporterFixture(string $nodeFile): array
+{
+    $project = sys_get_temp_dir().'/lb_ctx_'.bin2hex(random_bytes(6));
+    mkdir($project.'/storage', 0o777, true);
+
+    $store = new FileGraphStore($project.'/storage');
+    $store->ensureSchema();
+    $store->putManifest(json_encode(['project' => 'demo', 'analyzedAt' => '2026-01-01T00:00:00+00:00', 'tabs' => []]));
+    $store->putSubgraph('tab-a', json_encode([
+        'nodes' => [[
+            'id' => 'service::Demo',
+            'label' => 'Demo',
+            'type' => 'service',
+            'data' => ['id' => 'service::Demo', 'label' => 'Demo', 'type' => 'service', 'file' => $nodeFile],
+        ]],
+        'edges' => [],
+    ]));
+
+    return [$project, new ContextExporter($store, $project)];
+}
+
+it('includes the source of the file a node names', function () {
+    $project = sys_get_temp_dir().'/lb_ctx_'.bin2hex(random_bytes(6));
+    mkdir($project.'/app', 0o777, true);
+    $file = $project.'/app/Demo.php';
+    file_put_contents($file, "<?php\n\nclass Demo { public function run(): void {} }\n");
+
+    mkdir($project.'/storage', 0o777, true);
+    $store = new FileGraphStore($project.'/storage');
+    $store->ensureSchema();
+    $store->putManifest(json_encode(['project' => 'demo', 'analyzedAt' => '2026-01-01T00:00:00+00:00', 'tabs' => []]));
+    $store->putSubgraph('tab-a', json_encode([
+        'nodes' => [[
+            'id' => 'service::Demo',
+            'label' => 'Demo',
+            'type' => 'service',
+            'data' => ['id' => 'service::Demo', 'label' => 'Demo', 'type' => 'service', 'file' => $file],
+        ]],
+        'edges' => [],
+    ]));
+
+    $out = (new ContextExporter($store, $project))->export(nodeId: 'service::Demo');
+
+    expect($out)->toContain('## Source: Demo (focal)')
+        ->toContain('class Demo { public function run(): void {} }');
+});
+
+it('reads nothing for a node whose file is missing', function () {
+    [$project, $exporter] = exporterFixture('/does/not/exist/Demo.php');
+
+    expect($exporter->export(nodeId: 'service::Demo'))->not->toContain('## Source:');
+});
+
+it('refuses a file outside the project being analysed', function () {
+    // Node paths come from the scan, but an export is something a person hands to a model;
+    // reading outside the tree is not a mistake worth being able to make.
+    $outside = sys_get_temp_dir().'/lb_outside_'.bin2hex(random_bytes(6)).'.php';
+    file_put_contents($outside, "<?php\n// secret\n");
+
+    [$project, $exporter] = exporterFixture($outside);
+
+    expect($exporter->export(nodeId: 'service::Demo'))
+        ->not->toContain('## Source:')
+        ->not->toContain('secret');
+
+    @unlink($outside);
+});
+
+it('reads nothing when the node names no file', function () {
+    [$project, $exporter] = exporterFixture('');
+
+    expect($exporter->export(nodeId: 'service::Demo'))->not->toContain('## Source:');
+});

--- a/tests/Unit/ContextExporterSourceTest.php
+++ b/tests/Unit/ContextExporterSourceTest.php
@@ -3,8 +3,14 @@
 use LaraMint\LaravelBrain\Ai\ContextExporter;
 use LaraMint\LaravelBrain\Storage\FileGraphStore;
 
-/** A project with one node whose `file` points wherever the caller says. */
-function exporterFixture(string $nodeFile): array
+/**
+ * A project with one node whose `file` points wherever the caller says.
+ *
+ * `$projectPath` is what the exporter is confined to. Passing `''` turns the containment check
+ * off, which is the only way to reach the guard behind it — with a root set, `realpath()` refuses
+ * an empty or missing path before the guard is ever asked about it.
+ */
+function exporterFixture(string $nodeFile, ?string $projectPath = null): array
 {
     $project = sys_get_temp_dir().'/lb_ctx_'.bin2hex(random_bytes(6));
     mkdir($project.'/storage', 0o777, true);
@@ -22,7 +28,7 @@ function exporterFixture(string $nodeFile): array
         'edges' => [],
     ]));
 
-    return [$project, new ContextExporter($store, $project)];
+    return [$project, new ContextExporter($store, $projectPath ?? $project)];
 }
 
 it('includes the source of the file a node names', function () {
@@ -52,9 +58,23 @@ it('includes the source of the file a node names', function () {
 });
 
 it('reads nothing for a node whose file is missing', function () {
-    [$project, $exporter] = exporterFixture('/does/not/exist/Demo.php');
+    // Unconfined on purpose: with a project root set, containment refuses this path first and
+    // the guard under test never runs.
+    [$project, $exporter] = exporterFixture('/does/not/exist/Demo.php', projectPath: '');
 
-    expect($exporter->export(nodeId: 'service::Demo'))->not->toContain('## Source:');
+    // An empty export is not enough to prove the guard: `file_get_contents()` on a missing file
+    // returns false, which reads as "no source" either way. What separates them is the warning it
+    // raises on the way — and Laravel's `HandleExceptions` turns that into an `ErrorException`,
+    // so in an application the unguarded path does not read as empty, it throws.
+    set_error_handler(function (int $severity, string $message): never {
+        throw new ErrorException($message, 0, $severity);
+    });
+
+    try {
+        expect($exporter->export(nodeId: 'service::Demo'))->not->toContain('## Source:');
+    } finally {
+        restore_error_handler();
+    }
 });
 
 it('refuses a file outside the project being analysed', function () {
@@ -73,7 +93,39 @@ it('refuses a file outside the project being analysed', function () {
 });
 
 it('reads nothing when the node names no file', function () {
-    [$project, $exporter] = exporterFixture('');
+    [$project, $exporter] = exporterFixture('', projectPath: '');
 
     expect($exporter->export(nodeId: 'service::Demo'))->not->toContain('## Source:');
+});
+
+// ── One file, many nodes ─────────────────────────────────────────────────────
+
+it('emits a file once however many nodes name it', function () {
+    // A class and its methods, a resource and its pages: nodes name files far more often than
+    // files exist. Emitting per node spends the budget on copies of a body already in the export.
+    $project = sys_get_temp_dir().'/lb_ctx_'.bin2hex(random_bytes(6));
+    mkdir($project.'/app', 0o777, true);
+    mkdir($project.'/storage', 0o777, true);
+
+    $file = $project.'/app/Demo.php';
+    file_put_contents($file, "<?php\n\nclass Demo { public function run(): void {} }\n");
+
+    $node = fn (string $id, string $label): array => [
+        'id' => $id,
+        'label' => $label,
+        'type' => 'service',
+        'data' => ['id' => $id, 'label' => $label, 'type' => 'service', 'file' => $file],
+    ];
+
+    $store = new FileGraphStore($project.'/storage');
+    $store->ensureSchema();
+    $store->putManifest(json_encode(['project' => 'demo', 'analyzedAt' => '2026-01-01T00:00:00+00:00', 'tabs' => []]));
+    $store->putSubgraph('tab-a', json_encode([
+        'nodes' => [$node('service::Demo', 'Demo'), $node('method::Demo@run', 'Demo@run')],
+        'edges' => [['source' => 'service::Demo', 'target' => 'method::Demo@run', 'type' => 'calls']],
+    ]));
+
+    $out = (new ContextExporter($store, $project))->export(nodeId: 'service::Demo');
+
+    expect(substr_count($out, 'class Demo { public function run(): void {} }'))->toBe(1);
 });


### PR DESCRIPTION
## The dependency tables spend the budget instead of fitting into it

> Builds on #103, which is what makes the budget mean anything at all. Merge that one first.

Both package tables are built into the "always included" structural block and then subtracted from the budget:

```php
$structural = implode("\n", $parts);   // includes both tables
$charBudget -= strlen($structural);
```

On an application with 120-odd dependencies the tables are long enough to be the entire export. A route asked for at `--budget=500` came back at **1,264 tokens — 2.5× the budget — of which 87% was those two tables and none was the code the route runs.**

They say what the project has installed. They do not say anything about the focal node, which is what the export exists to describe.

### Fitting them

They now take at most 15% of what remains after the structural essentials, and state how many rows they dropped:

```
| …and 96 more | | |
```

Truncated rather than omitted: knowing the project runs Filament at all is worth a few lines, and the count says plainly what was left out instead of implying the list is whole.

Same route, before → after:

| budget | before | after |
|---|---|---|
| 500 | 1,264 tokens · 87% packages · 0 source | **500 tokens · 10% · 1 source** |
| 2,000 | 1,935 tokens · 57% packages · 1 source | 1,884 tokens · 14% · 2 source |
| 6,000 | 5,441 tokens · 20% packages · 4 source | 5,416 tokens · 16% · 4 source |
| 20,000 | 14,174 tokens · 8% packages · 19 source | unchanged — the tables fit whole |

The 500 row is the one that matters: the *tables* now fit inside what the budget leaves, and what is left is spent on code rather than on a dependency list.

Not the export as a whole — that would overclaim. The structural node and edge listing is emitted ahead of the budget and can exceed it on its own (2,923 characters against a 2,000-character limit on one reviewed application, before any table or snippet). This PR does not touch that and does not claim to.

At 20,000 nothing changes, and nothing should — there the tables fit and no truncation row appears.

### Tests

3 tests: at a small budget the focal node's code is still present, the dropped count is stated, and the export stays inside `budget * 4` characters — the same ratio the exporter budgets with.

### Verification

Measured against a real 120-dependency application at four budgets, before and after. `258 → 261 passed`, PHPStan 0, Pint clean.

