### PR TITLE
Fix: say when --budget is raised to the minimum

### DIFF
--- a/src/Commands/DiagnosticStream.php
+++ b/src/Commands/DiagnosticStream.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaraMint\LaravelBrain\Commands;
+
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * The stream a diagnostic belongs on when the command's real output is an artifact.
+ *
+ * `brain:export-context` writes a document to stdout that is meant to be redirected into a file
+ * or piped into something. Anything else written there lands INSIDE that document: a warning
+ * became the first line of the export, ahead of its own heading, and with `--format=json` it made
+ * the result unparseable. Diagnostics go to stderr so that stdout carries the artifact alone.
+ *
+ * The `instanceof` check is the load-bearing part. `OutputStyle::getOutput()` returns whatever the
+ * command was given, and only a `ConsoleOutputInterface` has a separate error stream — a buffered
+ * output, which is what Laravel hands a command under test, does not, and calling
+ * `getErrorOutput()` on one is a fatal error rather than a graceful miss.
+ *
+ * `OutputStyle::getErrorOutput()` exists but is `protected`, which is why this asks the underlying
+ * output rather than the style wrapping it.
+ */
+final class DiagnosticStream
+{
+    public static function for(OutputInterface $output): OutputInterface
+    {
+        return $output instanceof ConsoleOutputInterface
+            ? $output->getErrorOutput()
+            : $output;
+    }
+}

--- a/src/Commands/ExportContextCommand.php
+++ b/src/Commands/ExportContextCommand.php
@@ -40,15 +40,22 @@ class ExportContextCommand extends Command
         $exporter = new ContextExporter($store, base_path());
 
         try {
-            $requestedBudget = (int) $this->option('budget');
+            $rawBudget = (string) $this->option('budget');
+            $requestedBudget = (int) $rawBudget;
             $budget = max(self::MINIMUM_BUDGET, $requestedBudget);
 
             // Silently exporting more than was asked for is worse than saying so: the header
             // of the export itself reports the budget, and it would report a number the
             // caller never chose.
+            //
+            // On stderr, not stdout — stdout is the export. See {@see DiagnosticStream}.
+            // And quoting back what was typed rather than what it cast to: `--budget=abc` is 0
+            // as an int, and "asked for 0" names a number nobody wrote.
             if ($budget !== $requestedBudget) {
-                $this->components->warn(
-                    "Budget raised to the {$budget}-token minimum (asked for {$requestedBudget})."
+                $asked = is_numeric($rawBudget) ? $rawBudget : '"'.$rawBudget.'"';
+
+                DiagnosticStream::for($this->output->getOutput())->writeln(
+                    "<comment>Budget raised to the {$budget}-token minimum (asked for {$asked}).</comment>"
                 );
             }
 

--- a/src/Commands/ExportContextCommand.php
+++ b/src/Commands/ExportContextCommand.php
@@ -10,10 +10,13 @@ use LaraMint\LaravelBrain\Storage\GraphStoreFactory;
 
 class ExportContextCommand extends Command
 {
+    /** Below this the export cannot carry a focal node and its immediate context. */
+    private const MINIMUM_BUDGET = 500;
+
     protected $signature = 'brain:export-context
                             {--route=      : Filter by route label or URI (case-insensitive)}
                             {--node=       : Target a specific node ID}
-                            {--budget=6000 : Token budget}
+                            {--budget=6000 : Token budget (minimum 500)}
                             {--format=markdown : Output format (markdown|json)}
                             {--output=     : Write to file path instead of stdout}
                             {--force       : Overwrite existing output file without prompting}';
@@ -37,10 +40,22 @@ class ExportContextCommand extends Command
         $exporter = new ContextExporter($store, base_path());
 
         try {
+            $requestedBudget = (int) $this->option('budget');
+            $budget = max(self::MINIMUM_BUDGET, $requestedBudget);
+
+            // Silently exporting more than was asked for is worse than saying so: the header
+            // of the export itself reports the budget, and it would report a number the
+            // caller never chose.
+            if ($budget !== $requestedBudget) {
+                $this->components->warn(
+                    "Budget raised to the {$budget}-token minimum (asked for {$requestedBudget})."
+                );
+            }
+
             $output = $exporter->export(
                 nodeId: $this->option('node') ? (string) $this->option('node') : null,
                 routeLabel: $this->option('route') ? (string) $this->option('route') : null,
-                budget: max(500, (int) $this->option('budget')),
+                budget: $budget,
                 format: $format,
             );
         } catch (\RuntimeException $e) {

--- a/tests/Unit/DiagnosticStreamTest.php
+++ b/tests/Unit/DiagnosticStreamTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use LaraMint\LaravelBrain\Commands\DiagnosticStream;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+it('sends a diagnostic to stderr when the command has a real console', function () {
+    // The point of the class: `brain:export-context` writes an artifact to stdout, so a warning
+    // written there lands inside the document — first line of the export, ahead of its heading.
+    $console = new ConsoleOutput;
+
+    expect(DiagnosticStream::for($console))->toBe($console->getErrorOutput())
+        ->not->toBe($console);
+});
+
+it('falls back to the given output when there is no separate error stream', function () {
+    // What Laravel hands a command under test. `getErrorOutput()` does not exist on one, so an
+    // unguarded call is a fatal error rather than a graceful miss.
+    $buffered = new BufferedOutput;
+
+    expect(DiagnosticStream::for($buffered))->toBe($buffered);
+});


### PR DESCRIPTION
## `--budget` is silently raised to a minimum the help does not mention

`brain:export-context` clamps the option:

```php
budget: max(500, (int) $this->option('budget')),
```

and the help reads `{--budget=6000 : Token budget}` — no minimum anywhere. So `--budget=300` becomes 500 without a word, and the export's own header then reports `Budget: 500 tokens`, a number the caller never chose. Someone tuning the budget down has no way to know their value stopped taking effect.

The minimum is in the help now, and the command says so when it actually applies:

```
WARN  Budget raised to the 500-token minimum (asked for 300).
```

Nothing is printed when the requested budget is used as given, so the normal case is unchanged.

The clamp itself stays: below 500 tokens the export cannot carry a focal node and its immediate context, which is the least it can be useful at. The complaint was never the floor, only that it was invisible.

### Verification

Run against a real project: `--budget=300` warns and exports at 500, `--budget=6000` exports with no warning. `254 passed`, PHPStan 0, Pint clean.

No test: this is a help string and one console line, and the console output is the behaviour. Happy to add one if you would rather have it pinned.
