### PR TITLE
Benchmark every pull request against its own merge base

### DIFF
--- a/.github/workflows/benchmark-comment.yml
+++ b/.github/workflows/benchmark-comment.yml
@@ -1,0 +1,70 @@
+name: Benchmark Comment
+
+# Posts what the Benchmark workflow measured. Split out because it needs a token
+# that can write to pull requests, which the benchmark job itself — running code
+# from the pull request — must not have.
+
+# The comment body is markdown produced by code from the pull request, so it is
+# untrusted: nothing from the artifact is interpolated into a shell command or a
+# workflow expression. The pull request number is checked to be a number, and the
+# body is handed to the action as a file. The comment this job looks for is found
+# by a fixed marker rather than by anything read out of the artifact.
+
+on:
+  workflow_run:
+    workflows: [Benchmark]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  comment:
+    name: Comment
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+      pull-requests: write
+
+    steps:
+      - name: Download the result
+        uses: actions/download-artifact@v8
+        with:
+          name: benchmark-result
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read the pull request number
+        id: meta
+        run: |
+          # The artifact is produced by a workflow running pull request code, so
+          # nothing in it is trusted: the number has to be a number before it is
+          # used to address a comment.
+          number="$(sed -n '1p' benchmark-result.md)"
+
+          if ! [[ "$number" =~ ^[0-9]+$ ]]; then
+            echo "::error::first line of the artifact is not a pull request number"
+            exit 1
+          fi
+
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+          tail -n +2 benchmark-result.md > benchmark-comment.md
+
+      - name: Find the existing comment
+        uses: peter-evans/find-comment@v4
+        id: find
+        with:
+          issue-number: ${{ steps.meta.outputs.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- laravel-brain-benchmark -->'
+
+      - name: Post or update the comment
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          issue-number: ${{ steps.meta.outputs.number }}
+          comment-id: ${{ steps.find.outputs.comment-id }}
+          edit-mode: replace
+          body-path: benchmark-comment.md

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,138 @@
+name: Benchmark
+
+# Measures the pull request against its own merge base and writes the result to
+# an artifact. Commenting is a separate workflow (benchmark-comment.yml), because
+# this one runs with a read-only token so it is safe on pull requests from forks.
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'benchmark/**'
+      - 'composer.json'
+      - 'composer.lock'
+      - '.github/workflows/benchmark.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: benchmark-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: Benchmark
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    env:
+      # Rounds of (base, head). Every round is a fresh process per arm; the arms
+      # alternate so machine load lands on both instead of on one of them.
+      ROUNDS: 5
+      # Timed repetitions inside one process, after one untimed warmup.
+      REPS: 2
+
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@v7
+        with:
+          path: head
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Resolve merge base
+        id: mergebase
+        working-directory: head
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          # The PR's own merge base, not the current tip of the base branch:
+          # comparing against the tip reports other people's merges as this
+          # pull request's differences.
+          git fetch --no-tags origin "$BASE_REF"
+          sha="$(git merge-base HEAD FETCH_HEAD)"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "Merge base: $sha"
+
+      - name: Checkout merge base
+        uses: actions/checkout@v7
+        with:
+          path: base
+          ref: ${{ steps.mergebase.outputs.sha }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: dom, curl, libxml, mbstring, zip
+          coverage: none
+
+      - name: Cache Composer downloads
+        uses: actions/cache@v6
+        with:
+          # A miss only costs the download, so both arms' lockfiles in the key is
+          # the whole of it — nothing about a measurement depends on this.
+          path: ~/.cache/composer/files
+          key: composer-benchmark-${{ hashFiles('head/composer.lock', 'base/composer.lock') }}
+          restore-keys: composer-benchmark-
+
+      - name: Install dependencies (pull request)
+        working-directory: head
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Install dependencies (merge base)
+        working-directory: base
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Generate the corpora
+        working-directory: head
+        run: |
+          # Both arms scan the same generated tree, so node/edge/parse-count
+          # deltas can only come from the code change. Generating it up front
+          # keeps generation out of the first measured round, and a broken
+          # harness fails here rather than halfway through the comparison.
+          php benchmark/benchmark.php \
+            --reps=1 --warmups=0 \
+            --corpus-dir="$RUNNER_TEMP/corpora" \
+            --out="$RUNNER_TEMP/discard.json"
+
+      - name: Run the arms, interleaved
+        working-directory: head
+        run: |
+          mkdir -p "$RUNNER_TEMP/arm-base" "$RUNNER_TEMP/arm-head"
+
+          for round in $(seq 1 "$ROUNDS"); do
+            for arm in base head; do
+              BRAIN_BENCH_AUTOLOAD="$GITHUB_WORKSPACE/$arm/vendor/autoload.php" \
+              php benchmark/benchmark.php \
+                --reps="$REPS" --warmups=1 \
+                --corpus-dir="$RUNNER_TEMP/corpora" \
+                --out="$RUNNER_TEMP/arm-$arm/round-$round.json"
+            done
+          done
+
+      - name: Render the comment
+        working-directory: head
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ steps.mergebase.outputs.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Line 1 is the pull request number, consumed by the comment workflow.
+          echo "$PR_NUMBER" > "$RUNNER_TEMP/benchmark-result.md"
+          php benchmark/compare.php \
+            "$RUNNER_TEMP/arm-base" "$RUNNER_TEMP/arm-head" \
+            --base-sha="$BASE_SHA" \
+            --head-sha="$HEAD_SHA" \
+            >> "$RUNNER_TEMP/benchmark-result.md"
+
+          # The same table on the run's own summary page, for anyone who lands
+          # there instead of on the pull request.
+          tail -n +2 "$RUNNER_TEMP/benchmark-result.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the result
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-result
+          path: ${{ runner.temp }}/benchmark-result.md

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,115 @@
+# Benchmark suite
+
+What a scan costs, and what it detects, measured on a Laravel application this
+directory generates. Every pull request that touches `src/`, `benchmark/` or the
+Composer files gets the comparison posted as a comment.
+
+## Running it
+
+```bash
+composer benchmark                       # table on stderr
+php benchmark/benchmark.php --json       # machine-readable
+php benchmark/benchmark.php --markdown   # markdown table
+```
+
+Useful options:
+
+| Option | Meaning |
+|---|---|
+| `--reps=N` | timed repetitions per scenario (default 5) |
+| `--warmups=N` | untimed repetitions first (default 1) |
+| `--scenario=NAME` | run one scenario only |
+| `--corpus-dir=DIR` | where the generated applications live (default: system temp) |
+| `--out=FILE` | write the JSON to a file instead of stdout |
+
+The generated applications are cached in `--corpus-dir` and keyed by the
+generator's own hash, so editing `generate-corpus.php` regenerates them rather
+than silently reusing a stale tree.
+
+## Scenarios
+
+| Scenario | What it runs |
+|---|---|
+| `scan-small` | `ProjectAnalyzer::analyze()` over ~400 PHP files |
+| `scan-large` | the same over ~1,200 PHP files, which catches costs that grow faster than the file count |
+| `trace-methods` | `MethodTracer` over every entry-point method of the ~400-file tree — the call-tracing half of a build, isolated from the rest |
+
+A default run — three scenarios, one warmup and five timed repetitions each —
+takes a few seconds once the applications have been generated.
+
+The application is synthetic and deliberately awkward: a service, repository and
+model layer shared by many entry points, chains four deep, and classes with
+private helpers and call-free getters. It is a workload, not an average app, so
+read the absolute times as such.
+
+## Reading the two kinds of number
+
+**Counts** — nodes, edges, tabs, routes, security issues, `parse()` calls, and a
+per-node-type breakdown. Deterministic: the same code over the same generated
+tree produces the same figures, whatever the tree's path and however many times
+it is scanned — the runner asserts that across repetitions and says so in the
+comment if it ever fails to hold. Both CI arms scan one tree on one pinned PHP
+version, so a difference belongs to the change. That is worth looking at, not
+automatically worth fixing: an analyzer that detects more will move them by
+design.
+
+**Timing** — a median over repetitions. Wall clock on a shared runner is noisy
+enough to invent a result, so the comparison reports how far the base arm's own
+repetitions sat from its median — discounting the single worst on each side —
+marks any delta inside that as not measurable, and prints their full spread next
+to it. Discounting rather than taking the extremes: one stalled repetition would
+otherwise set a floor that hides every real regression behind it.
+
+The phase split gets the same treatment per phase, from that phase's own
+repetitions, because a phase is noisier than the scan containing it. On an
+unchanged pull request the facade phase has been seen to range over 2x between
+repetitions of identical code; without its own floor it would read as a 50%
+improvement.
+
+`parse()` calls are the stable companion to a timing claim — a change in speed
+with the parse count unmoved is good evidence that only speed moved.
+
+A note on the guards in `benchmark.php`: it feature-detects the caches it
+clears (`method_exists`, `property_exists`) because it also runs against *other*
+checkouts of `src/` — the merge base's, in CI — where a given cache may not exist
+yet. Static analysis of this checkout cannot see that, which is why `benchmark/`
+is deliberately outside `phpstan.neon`'s paths.
+
+## How the comparison runs in CI
+
+`benchmark.yml` checks out the pull request and its **merge base** — not the
+current tip of the base branch, which would report other people's merges as this
+pull request's differences — installs both, generates the applications once, and
+alternates the arms round by round so machine load lands on both. The pull
+request's own copy of the benchmark measures both arms: `BRAIN_BENCH_AUTOLOAD`
+points `bootstrap.php` at each checkout's `vendor/autoload.php` in turn, so the
+harness code is identical and only `src/` differs.
+
+`compare.php` then renders the comment. `benchmark-comment.yml` posts it from a
+separate `workflow_run` job, because the job that runs pull request code must not
+hold a token that can write to the pull request.
+
+To reproduce a CI comparison locally:
+
+```bash
+BASE="$(git merge-base HEAD origin/main)"
+git worktree add --detach ../brain-base "$BASE"
+(cd ../brain-base && composer install)
+mkdir -p /tmp/arm-base /tmp/arm-head
+
+for round in 1 2 3 4 5; do
+  BRAIN_BENCH_AUTOLOAD="$(cd ../brain-base && pwd)/vendor/autoload.php" \
+    php benchmark/benchmark.php --reps=2 --corpus-dir=/tmp/brain-corpora \
+      --out="/tmp/arm-base/round-$round.json"
+
+  BRAIN_BENCH_AUTOLOAD="$PWD/vendor/autoload.php" \
+    php benchmark/benchmark.php --reps=2 --corpus-dir=/tmp/brain-corpora \
+      --out="/tmp/arm-head/round-$round.json"
+done
+
+php benchmark/compare.php /tmp/arm-base /tmp/arm-head
+```
+
+Build the base arm from a separate checkout, never with `git stash` — once the
+work is committed, `stash` reverts nothing and succeeds, and both arms end up
+running the same code.

--- a/benchmark/benchmark.php
+++ b/benchmark/benchmark.php
@@ -1,0 +1,638 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Benchmark suite for laravel-brain.
+ *
+ * Measures a scan of a generated Laravel application and reports two kinds of
+ * number, which must be read differently:
+ *
+ *   Graph output   nodes, edges, tabs, routes, security issues, parse() calls,
+ *                  and a per-node-type breakdown. Deterministic: the same code
+ *                  over the same generated tree gives the same figures however
+ *                  often it is scanned and wherever the tree sits, and every
+ *                  repetition is checked against the last to make sure. A change
+ *                  here is a change in what Brain detects.
+ *
+ *   Timing         median wall clock over N repetitions. Useful, but noisy on
+ *                  shared hardware — compare it against the spread of the
+ *                  baseline's own repetitions before calling it a regression.
+ *
+ * Scenarios:
+ *   scan-small     full ProjectAnalyzer scan of the scale-1 corpus (~400 files)
+ *   scan-large     full ProjectAnalyzer scan of the scale-3 corpus (~1,200 files)
+ *   trace-methods  MethodTracer over every entry-point method in the scale-1
+ *                  corpus — the call-tracing half of a build, isolated
+ *
+ * Usage:
+ *   php benchmark/benchmark.php                      run and print a table
+ *   php benchmark/benchmark.php --json               machine-readable, to stdout
+ *   php benchmark/benchmark.php --out=result.json    machine-readable, to a file
+ *   php benchmark/benchmark.php --markdown           markdown table
+ *
+ * Options:
+ *   --reps=N          timed repetitions per scenario (default 5)
+ *   --warmups=N       untimed repetitions first (default 1)
+ *   --scenario=NAME   run one scenario only
+ *   --corpus-dir=DIR  where corpora are generated and cached
+ *                     (default: <tmp>/laravel-brain-benchmark)
+ *
+ * The corpora are generated on first use and reused afterwards. Both arms of a
+ * comparison must scan the same generated tree — pass the same --corpus-dir.
+ */
+
+use LaraMint\LaravelBrain\Analysis\MethodTracer;
+use LaraMint\LaravelBrain\Analysis\ProjectAnalyzer;
+use LaraMint\LaravelBrain\Analysis\ProjectFileIndex;
+use LaraMint\LaravelBrain\Parser\PhpFileParser;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+
+require __DIR__.'/bootstrap.php';
+
+brain_bench_bootstrap();
+
+// ─── options ────────────────────────────────────────────────────────────────
+
+function opt(string $name): ?string
+{
+    foreach ($GLOBALS['argv'] as $arg) {
+        if (str_starts_with($arg, "--{$name}=")) {
+            return substr($arg, strlen($name) + 3);
+        }
+    }
+
+    return null;
+}
+
+function flag(string $name): bool
+{
+    return in_array("--{$name}", $GLOBALS['argv'], true);
+}
+
+$reps = max(1, (int) (opt('reps') ?? 5));
+$warmups = max(0, (int) (opt('warmups') ?? 1));
+$only = opt('scenario');
+$out = opt('out');
+$asJson = flag('json') || $out !== null;
+$asMarkdown = flag('markdown') || flag('ci');
+$corpusDir = opt('corpus-dir') ?? sys_get_temp_dir().'/laravel-brain-benchmark';
+
+// ─── corpora ────────────────────────────────────────────────────────────────
+
+/**
+ * Generate the corpus for a scale if it is not already there, and return its path.
+ *
+ * The marker file records the scale and the generator's own hash: change the
+ * generator and every cached corpus is rebuilt, so a stale tree can never be
+ * silently reused.
+ */
+function corpus(string $baseDir, float $scale): string
+{
+    $generator = __DIR__.'/generate-corpus.php';
+    $hash = is_file($generator) ? hash_file('sha256', $generator) : false;
+
+    if ($hash === false) {
+        fwrite(STDERR, "generator not found at {$generator}\n");
+        exit(1);
+    }
+
+    $stamp = sprintf('%s-%s', $scale, substr($hash, 0, 12));
+    $dir = sprintf('%s/corpus-%s', $baseDir, $stamp);
+
+    if (is_file($dir.'/.generated')) {
+        return $dir;
+    }
+
+    if (! is_dir($baseDir) && ! mkdir($baseDir, 0755, true) && ! is_dir($baseDir)) {
+        fwrite(STDERR, "cannot create corpus dir {$baseDir}\n");
+        exit(1);
+    }
+
+    if (! function_exists('exec')) {
+        fwrite(STDERR, sprintf(
+            "exec() is disabled, so the corpus cannot be generated here. Run it by hand:\n  php %s %s %s\n",
+            $generator,
+            $dir,
+            $scale,
+        ));
+        exit(1);
+    }
+
+    $cmd = sprintf(
+        '%s %s %s %s',
+        escapeshellarg(PHP_BINARY),
+        escapeshellarg($generator),
+        escapeshellarg($dir),
+        escapeshellarg((string) $scale),
+    );
+
+    // The generator reports what it produced on stderr; keep it out of stdout,
+    // which carries the JSON, but show it if generation fails.
+    $output = [];
+    exec($cmd.' 2>&1', $output, $status);
+
+    if ($status !== 0 || ! is_dir($dir.'/app')) {
+        fwrite(STDERR, "corpus generation failed for scale {$scale}:\n".implode("\n", $output)."\n");
+        exit(1);
+    }
+
+    file_put_contents($dir.'/.generated', $stamp."\n");
+
+    return $dir;
+}
+
+function php_file_count(string $dir): int
+{
+    if (! is_dir($dir)) {
+        return 0;
+    }
+
+    $n = 0;
+
+    foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS)) as $f) {
+        if ($f->getExtension() === 'php') {
+            $n++;
+        }
+    }
+
+    return $n;
+}
+
+// ─── measurement helpers ────────────────────────────────────────────────────
+
+/**
+ * Clear every build-scoped static cache, so each repetition is a cold build.
+ *
+ * Guarded with method_exists/class_exists: this file is also run against other
+ * checkouts of src/ (the base branch in CI), where a cache may not exist yet.
+ */
+function reset_build_state(): void
+{
+    if (method_exists(PhpFileParser::class, 'clearSharedCache')) {
+        PhpFileParser::clearSharedCache();
+    }
+
+    if (property_exists(PhpFileParser::class, 'parseCount')) {
+        PhpFileParser::$parseCount = 0;
+    }
+
+    if (class_exists(ProjectFileIndex::class) && method_exists(ProjectFileIndex::class, 'clear')) {
+        ProjectFileIndex::clear();
+    }
+
+    gc_collect_cycles();
+}
+
+/**
+ * The counts that must reproduce, with the ones that cannot stripped out.
+ *
+ * Peak memory is the process's, not the scenario's, so it grows as the process
+ * runs and would make every repetition look like a different build.
+ *
+ * @param  array<string, int>  $counts
+ * @return array<string, int>
+ */
+function deterministic_counts(array $counts): array
+{
+    unset($counts['process_peak_mem_mb']);
+
+    return $counts;
+}
+
+/** parse() call count, or null when this checkout does not instrument it. */
+function parse_count(): ?int
+{
+    return property_exists(PhpFileParser::class, 'parseCount') ? PhpFileParser::$parseCount : null;
+}
+
+/** @param  list<float>  $xs */
+function median(array $xs): float
+{
+    sort($xs);
+    $n = count($xs);
+
+    if ($n === 0) {
+        return 0.0;
+    }
+
+    return $n % 2 ? $xs[intdiv($n, 2)] : ($xs[intdiv($n, 2) - 1] + $xs[intdiv($n, 2)]) / 2;
+}
+
+/**
+ * Run one scenario: warmups, then $reps timed repetitions.
+ *
+ * The scenario times itself and reports 'ms', so only the work under
+ * measurement is timed — not the harness counting up the result afterwards.
+ *
+ * Counts are taken from the last repetition. They are expected to be identical
+ * in every repetition; when they are not, 'counts_stable' says so rather than
+ * letting one repetition's figures stand in silently for a build that is not
+ * reproducible.
+ *
+ * @param  callable(): array{ms: float, counts: array<string, int>, phases_ms: array<string, float>}  $run
+ * @return array{times_ms: list<float>, median_ms: float, counts: array<string, int>, counts_stable: bool, phases_ms: array<string, float>}
+ */
+function measure(callable $run, int $reps, int $warmups): array
+{
+    $times = [];
+    $counts = null;
+    $stable = true;
+    $phaseSamples = [];
+
+    for ($i = 0; $i < $warmups + $reps; $i++) {
+        reset_build_state();
+        $result = $run();
+
+        if ($i < $warmups) {
+            continue;
+        }
+
+        $times[] = $result['ms'];
+
+        if ($counts !== null && deterministic_counts($result['counts']) !== deterministic_counts($counts)) {
+            $stable = false;
+        }
+
+        $counts = $result['counts'];
+
+        foreach ($result['phases_ms'] as $phase => $phaseMs) {
+            $phaseSamples[$phase][] = $phaseMs;
+        }
+    }
+
+    $phases = [];
+
+    foreach ($phaseSamples as $phase => $samples) {
+        $phases[$phase] = round(median($samples), 2);
+    }
+
+    arsort($phases);
+
+    return [
+        'times_ms' => array_map(static fn (float $ms): float => round($ms, 2), $times),
+        'median_ms' => round(median($times), 2),
+        'counts' => $counts ?? [],
+        'counts_stable' => $stable,
+        'phases_ms' => $phases,
+    ];
+}
+
+// ─── scenario bodies ────────────────────────────────────────────────────────
+
+/**
+ * A full scan, and everything a consumer can count in its result.
+ *
+ * Times the scan itself; the counting afterwards is harness work and is left
+ * out of the measurement.
+ *
+ * @return array{ms: float, counts: array<string, int>, phases_ms: array<string, float>}
+ */
+function scan(string $corpus): array
+{
+    // The default progress callback echoes to stdout, which would corrupt the
+    // JSON and markdown output; this one also times each phase.
+    $open = [];
+    $phases = [];
+
+    $t0 = hrtime(true);
+
+    $result = (new ProjectAnalyzer)->analyze($corpus, static function (string $event, array $data) use (&$open, &$phases): void {
+        $step = $data['step'] ?? null;
+
+        if (! is_string($step)) {
+            return;
+        }
+
+        if ($event === 'step:start') {
+            $open[$step] = hrtime(true);
+        } elseif ($event === 'step:done' && isset($open[$step])) {
+            $phases[$step] = ($phases[$step] ?? 0) + (hrtime(true) - $open[$step]) / 1e6;
+            unset($open[$step]);
+        }
+    });
+
+    $ms = (hrtime(true) - $t0) / 1e6;
+
+    $issues = 0;
+    $routesWithIssues = 0;
+    $byType = [];
+
+    foreach ($result->fullGraph->nodes() as $node) {
+        $byType[$node->type] = ($byType[$node->type] ?? 0) + 1;
+        $nodeIssues = $node->data['security']['issues'] ?? null;
+
+        if (is_array($nodeIssues) && $nodeIssues !== []) {
+            $issues += count($nodeIssues);
+            $routesWithIssues++;
+        }
+    }
+
+    ksort($byType);
+
+    $counts = [
+        'nodes' => $result->fullGraph->nodeCount(),
+        'edges' => $result->fullGraph->edgeCount(),
+        'tabs' => count($result->subgraphs),
+        'routes' => $result->totalRoutes,
+        'commands' => $result->totalCommands,
+        'channels' => $result->totalChannels,
+        'filament_resources' => $result->totalFilamentResources,
+        'security_issues' => $issues,
+        'nodes_with_security_issues' => $routesWithIssues,
+        'unresolved_dispatchers' => count($result->unresolvedDispatchers),
+        // Cumulative for the whole process, so it depends on which scenarios ran
+        // before this one. Reported, never diffed.
+        'process_peak_mem_mb' => (int) round(memory_get_peak_usage(true) / 1048576),
+    ];
+
+    foreach ($byType as $type => $n) {
+        $counts['node_type:'.$type] = $n;
+    }
+
+    $parses = parse_count();
+
+    if ($parses !== null) {
+        $counts['parse_calls'] = $parses;
+    }
+
+    return ['ms' => $ms, 'counts' => $counts, 'phases_ms' => $phases];
+}
+
+/**
+ * Every non-abstract, non-static instance method on the entry-point classes —
+ * the workload a consumer that traces entry points drives into MethodTracer.
+ *
+ * Enumerated once, outside the timed loop.
+ *
+ * @return list<array{0: string, 1: string}>
+ */
+function entry_point_methods(string $corpus): array
+{
+    $roots = [
+        'App\\Jobs' => 'app/Jobs',
+        'App\\Listeners' => 'app/Listeners',
+        'App\\Console\\Commands' => 'app/Console/Commands',
+        'App\\Http\\Middleware' => 'app/Http/Middleware',
+        'App\\Livewire' => 'app/Livewire',
+        'App\\Observers' => 'app/Observers',
+    ];
+
+    $parser = new PhpFileParser;
+    $pairs = [];
+
+    foreach ($roots as $namespace => $relative) {
+        $dir = $corpus.'/'.$relative;
+
+        if (! is_dir($dir)) {
+            continue;
+        }
+
+        $files = [];
+
+        foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS)) as $file) {
+            if ($file->getExtension() === 'php') {
+                $files[] = $file->getPathname();
+            }
+        }
+
+        // Directory iteration order is filesystem-dependent; the tracer's
+        // shared class cache makes the order matter for timing.
+        sort($files);
+
+        foreach ($files as $path) {
+            $parsed = $parser->parse($path);
+
+            if (! $parsed['ast']) {
+                continue;
+            }
+
+            $visitor = new class extends NodeVisitorAbstract
+            {
+                /** @var list<string> */
+                public array $methods = [];
+
+                public bool $abstract = false;
+
+                public function enterNode(Node $node): ?int
+                {
+                    if ($node instanceof Node\Stmt\Class_ && $node->isAbstract()) {
+                        $this->abstract = true;
+                    }
+
+                    if ($node instanceof Node\Stmt\ClassMethod
+                        && $node->name->toString() !== '__construct'
+                        && ! $node->isAbstract()
+                        && ! $node->isStatic()) {
+                        $this->methods[] = $node->name->toString();
+                    }
+
+                    return null;
+                }
+            };
+
+            $traverser = new NodeTraverser;
+            $traverser->addVisitor($visitor);
+            $traverser->traverse($parsed['ast']);
+
+            if ($visitor->abstract) {
+                continue;
+            }
+
+            foreach ($visitor->methods as $method) {
+                $pairs[] = [$namespace.'\\'.basename($path, '.php'), $method];
+            }
+        }
+    }
+
+    return $pairs;
+}
+
+/**
+ * The PSR-4 map the tracer resolves class names through.
+ *
+ * Read the corpus's Composer-generated map when present, as a real application
+ * would: a hand-written single-prefix map sends resolveFile() down its
+ * recursive-walk fallback, which is a benchmark artifact rather than a workload.
+ *
+ * @return array<string, list<string>>
+ */
+function psr4_map(string $corpus): array
+{
+    $file = $corpus.'/vendor/composer/autoload_psr4.php';
+
+    if (! is_file($file)) {
+        return ['App' => [$corpus.'/app']];
+    }
+
+    // The generated file references these two variables.
+    $baseDir = $corpus;
+    $vendorDir = $corpus.'/vendor';
+
+    $raw = require $file;
+
+    if (! is_array($raw)) {
+        return ['App' => [$corpus.'/app']];
+    }
+
+    $map = [];
+
+    foreach ($raw as $namespace => $paths) {
+        $map[rtrim((string) $namespace, '\\')] = array_values((array) $paths);
+    }
+
+    return $map;
+}
+
+/**
+ * @param  list<array{0: string, 1: string}>  $pairs
+ * @param  array<string, list<string>>  $psr4
+ * @return array{ms: float, counts: array<string, int>, phases_ms: array<string, float>}
+ */
+function trace_methods(string $corpus, array $pairs, array $psr4): array
+{
+    $t0 = hrtime(true);
+
+    $tracer = new MethodTracer;
+    $edges = 0;
+
+    foreach ($pairs as [$fqcn, $method]) {
+        $edges += count($tracer->traceMethod($fqcn, $method, $psr4, $corpus));
+    }
+
+    $ms = (hrtime(true) - $t0) / 1e6;
+
+    $counts = [
+        'traced_methods' => count($pairs),
+        'traced_edges' => $edges,
+        'process_peak_mem_mb' => (int) round(memory_get_peak_usage(true) / 1048576),
+    ];
+
+    $parses = parse_count();
+
+    if ($parses !== null) {
+        $counts['parse_calls'] = $parses;
+    }
+
+    return ['ms' => $ms, 'counts' => $counts, 'phases_ms' => []];
+}
+
+// ─── run ────────────────────────────────────────────────────────────────────
+
+$small = corpus($corpusDir, 1.0);
+$large = corpus($corpusDir, 3.0);
+
+$scenarios = [
+    'scan-small' => [
+        'label' => sprintf('Full scan — %s files', number_format(php_file_count($small.'/app'))),
+        'run' => static fn (array $prepared): array => scan($small),
+    ],
+    'scan-large' => [
+        'label' => sprintf('Full scan — %s files', number_format(php_file_count($large.'/app'))),
+        'run' => static fn (array $prepared): array => scan($large),
+    ],
+    'trace-methods' => [
+        'label' => 'Method tracing — every entry-point method',
+        // Enumerating the entry points is the consumer's job, not the tracer's,
+        // so it happens once, before any repetition is timed.
+        'prepare' => static fn (): array => [entry_point_methods($small), psr4_map($small)],
+        'run' => static function (array $prepared) use ($small): array {
+            [$pairs, $psr4] = $prepared;
+
+            return trace_methods($small, $pairs, $psr4);
+        },
+    ],
+];
+
+if ($only !== null) {
+    if (! isset($scenarios[$only])) {
+        fwrite(STDERR, "unknown scenario {$only}; have: ".implode(', ', array_keys($scenarios))."\n");
+        exit(1);
+    }
+
+    $scenarios = [$only => $scenarios[$only]];
+}
+
+$results = [];
+
+foreach ($scenarios as $name => $scenario) {
+    $prepared = isset($scenario['prepare']) ? ($scenario['prepare'])() : [];
+    $run = $scenario['run'];
+    $measured = measure(static fn (): array => $run($prepared), $reps, $warmups);
+    $results[$name] = ['label' => $scenario['label']] + $measured;
+
+    if (! $measured['counts_stable']) {
+        fwrite(STDERR, sprintf("WARNING: %s produced different counts across repetitions\n", $name));
+    }
+}
+
+$payload = [
+    'meta' => [
+        'php' => PHP_VERSION,
+        'reps' => $reps,
+        'warmups' => $warmups,
+        'corpus_dir' => $corpusDir,
+    ],
+    'scenarios' => $results,
+];
+
+// ─── output ─────────────────────────────────────────────────────────────────
+
+if ($asJson) {
+    $json = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)."\n";
+
+    if ($out !== null) {
+        file_put_contents($out, $json);
+        exit(0);
+    }
+
+    echo $json;
+    exit(0);
+}
+
+if ($asMarkdown) {
+    printf(
+        "## Benchmark results\n\n_PHP %s, median of %d %s._\n\n",
+        PHP_VERSION,
+        $reps,
+        $reps === 1 ? 'repetition' : 'repetitions',
+    );
+    echo "| Scenario | Median | Nodes | Edges | Routes | parse() |\n";
+    echo "|---|---:|---:|---:|---:|---:|\n";
+
+    $count = static fn (?int $value): string => $value === null ? '—' : number_format($value);
+
+    foreach ($results as $r) {
+        printf(
+            "| %s | %.0f ms | %s | %s | %s | %s |\n",
+            $r['label'],
+            $r['median_ms'],
+            $count($r['counts']['nodes'] ?? null),
+            $count($r['counts']['edges'] ?? $r['counts']['traced_edges'] ?? null),
+            $count($r['counts']['routes'] ?? null),
+            $count($r['counts']['parse_calls'] ?? null),
+        );
+    }
+
+    exit(0);
+}
+
+fprintf(STDERR, "\n  PHP %s · %d warmup + %d timed repetitions · corpora in %s\n\n", PHP_VERSION, $warmups, $reps, $corpusDir);
+
+foreach ($results as $name => $r) {
+    fprintf(STDERR, "  %-14s %-44s %8.1f ms\n", $name, $r['label'], $r['median_ms']);
+
+    foreach ($r['counts'] as $key => $value) {
+        if (! str_starts_with($key, 'node_type:')) {
+            fprintf(STDERR, "  %-14s   %-42s %8d\n", '', $key, $value);
+        }
+    }
+
+    foreach ($r['phases_ms'] as $phase => $ms) {
+        fprintf(STDERR, "  %-14s   %-42s %8.1f ms\n", '', 'phase '.$phase, $ms);
+    }
+
+    fprintf(STDERR, "\n");
+}

--- a/benchmark/bootstrap.php
+++ b/benchmark/bootstrap.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Minimal Laravel container + config bootstrap, so the analyzers' config() calls
+ * work outside a full Laravel application.
+ *
+ * ProjectAnalyzer::analyze() takes the project root explicitly, so only 'config'
+ * and 'path.base' need binding.
+ *
+ * The autoloader is resolved from BRAIN_BENCH_AUTOLOAD when that is set. That is
+ * what lets one copy of the benchmark measure a different checkout's src/: the CI
+ * job points it at the base branch's vendor/autoload.php for one arm and at the
+ * pull request's for the other, so both arms run identical harness code.
+ */
+
+use Illuminate\Config\Repository;
+use Illuminate\Container\Container;
+
+$autoload = getenv('BRAIN_BENCH_AUTOLOAD');
+
+if (! is_string($autoload) || $autoload === '') {
+    $autoload = __DIR__.'/../vendor/autoload.php';
+}
+
+if (! is_file($autoload)) {
+    fwrite(STDERR, "autoloader not found at {$autoload} — run composer install\n");
+    exit(1);
+}
+
+require $autoload;
+
+/**
+ * @param  array<string, mixed>  $config  extra config to merge (e.g. laravel-brain.* overrides)
+ */
+function brain_bench_bootstrap(array $config = []): Container
+{
+    $container = new Container;
+    Container::setInstance($container);
+
+    $repo = new Repository(array_replace_recursive([
+        'app' => [
+            'name' => 'BenchmarkApp',
+            'url' => 'http://localhost',
+        ],
+        // Every analyzer passes its own default to config(), so an empty node is
+        // enough to make config('laravel-brain.*') resolvable.
+        'laravel-brain' => [],
+    ], $config));
+
+    $container->instance('config', $repo);
+    $container->instance('path.base', getcwd());
+
+    return $container;
+}

--- a/benchmark/compare.php
+++ b/benchmark/compare.php
@@ -1,0 +1,448 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Compare two arms of the benchmark and render the pull-request comment.
+ *
+ * Each arm is a directory of per-repetition JSON files written by
+ * benchmark.php --out=<file>. The repetitions are expected to have been run
+ * interleaved (base, head, base, head, …) in one session, so that machine load
+ * lands on both arms rather than on one of them.
+ *
+ * Two kinds of number come out, and they are reported separately on purpose:
+ *
+ *   Counts    deterministic. A difference is a real change in what the scan
+ *             detects, and is reported whether it looks like an improvement or
+ *             not — an added analyzer legitimately changes them.
+ *
+ *   Timing    noisy on shared runners. The spread of the base arm's own
+ *             repetitions is reported as a noise floor, and any delta inside it
+ *             is labelled as such instead of being presented as a result.
+ *
+ * Usage:
+ *   php benchmark/compare.php <baseDir> <headDir> [--base-sha=X] [--head-sha=Y]
+ */
+$baseDir = $argv[1] ?? null;
+$headDir = $argv[2] ?? null;
+
+if ($baseDir === null || $headDir === null) {
+    fwrite(STDERR, "usage: compare.php <baseDir> <headDir> [--base-sha=X] [--head-sha=Y]\n");
+    exit(1);
+}
+
+function opt(string $name): ?string
+{
+    foreach ($GLOBALS['argv'] as $arg) {
+        if (str_starts_with($arg, "--{$name}=")) {
+            return substr($arg, strlen($name) + 3);
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Load every repetition in an arm.
+ *
+ * @return array{
+ *     php: string,
+ *     reps: int,
+ *     samples: array<string, list<float>>,
+ *     counts: array<string, array<string, int>>,
+ *     labels: array<string, string>,
+ *     phases: array<string, array<string, list<float>>>,
+ *     unstable: list<string>,
+ * }
+ */
+function load_arm(string $dir): array
+{
+    $files = glob(rtrim($dir, '/').'/*.json') ?: [];
+
+    if ($files === []) {
+        fwrite(STDERR, "no benchmark result files in {$dir}\n");
+        exit(1);
+    }
+
+    sort($files);
+
+    $php = '?';
+    $samples = [];
+    $counts = [];
+    $labels = [];
+    $phases = [];
+    $unstable = [];
+    $reps = 0;
+
+    foreach ($files as $file) {
+        $payload = json_decode((string) file_get_contents($file), true);
+
+        if (! is_array($payload) || ! isset($payload['scenarios']) || ! is_array($payload['scenarios'])) {
+            fwrite(STDERR, "unreadable benchmark result: {$file}\n");
+            exit(1);
+        }
+
+        $php = (string) ($payload['meta']['php'] ?? $php);
+
+        foreach ($payload['scenarios'] as $name => $scenario) {
+            foreach ($scenario['times_ms'] ?? [] as $ms) {
+                $samples[$name][] = (float) $ms;
+                $reps++;
+            }
+
+            // Counts are deterministic, so they must agree in every repetition
+            // and every round. If they do not, the arm is not reproducible and
+            // no count delta from it means anything — say so instead of letting
+            // whichever file was read last decide.
+            if (($scenario['counts_stable'] ?? true) === false) {
+                $unstable[$name] = true;
+            }
+
+            if (isset($counts[$name]) && deterministic_counts($counts[$name]) !== deterministic_counts($scenario['counts'] ?? [])) {
+                $unstable[$name] = true;
+            }
+
+            $counts[$name] = $scenario['counts'] ?? [];
+            $labels[$name] = (string) ($scenario['label'] ?? $name);
+
+            foreach ($scenario['phases_ms'] ?? [] as $phase => $ms) {
+                $phases[$name][$phase][] = (float) $ms;
+            }
+        }
+    }
+
+    return [
+        'php' => $php,
+        'reps' => $samples === [] ? 0 : (int) round($reps / count($samples)),
+        'samples' => $samples,
+        'counts' => $counts,
+        'labels' => $labels,
+        'phases' => $phases,
+        'unstable' => array_keys($unstable),
+    ];
+}
+
+/**
+ * The counts that must reproduce, with the ones that cannot stripped out.
+ *
+ * Peak memory belongs to the process rather than to the scenario, so it moves
+ * with scenario order and would make every round look like a different build.
+ *
+ * @param  array<string, int>  $counts
+ * @return array<string, int>
+ */
+function deterministic_counts(array $counts): array
+{
+    unset($counts['process_peak_mem_mb']);
+
+    return $counts;
+}
+
+/** @param  list<float>  $xs */
+function median(array $xs): float
+{
+    sort($xs);
+    $n = count($xs);
+
+    if ($n === 0) {
+        return 0.0;
+    }
+
+    return $n % 2 ? $xs[intdiv($n, 2)] : ($xs[intdiv($n, 2) - 1] + $xs[intdiv($n, 2)]) / 2;
+}
+
+/**
+ * The machine's noise, as a percentage of the median: how far the base arm's
+ * tenth and ninetieth percentiles sit from its own median. An effect smaller
+ * than this is not measurable here.
+ *
+ * Percentiles rather than the extremes, because a shared runner stalls: one
+ * repetition landing 50% off would otherwise set a floor that hides every real
+ * regression behind it. Wide ones rather than the quartiles, because a runner
+ * that is genuinely unsteady must still be allowed to say so — at ten
+ * repetitions per arm this discounts the single worst on each side and no more.
+ * The full spread is reported next to it either way.
+ *
+ * @param  list<float>  $xs
+ * @return array{noise_pct: float, min: float, max: float}
+ */
+function spread(array $xs): array
+{
+    sort($xs);
+    $m = median($xs);
+    $n = count($xs);
+
+    if ($m <= 0.0 || $n < 2) {
+        return ['noise_pct' => 0.0, 'min' => $xs[0] ?? 0.0, 'max' => $xs[$n - 1] ?? 0.0];
+    }
+
+    $q = static function (float $p) use ($xs, $n): float {
+        $i = (int) round($p * ($n - 1));
+
+        return $xs[max(0, min($n - 1, $i))];
+    };
+
+    $worst = max(abs($q(0.10) - $m), abs($q(0.90) - $m));
+
+    return ['noise_pct' => $worst / $m * 100, 'min' => $xs[0], 'max' => $xs[$n - 1]];
+}
+
+/**
+ * How a timing delta should be reported, given the base arm's own repetitions.
+ *
+ * One rule for the totals and for the phase split, because a phase is exactly
+ * as noisy as the scan it is part of — more so, being smaller.
+ *
+ * @param  list<float>  $baseSamples
+ * @return array{delta: string, noise: string}
+ */
+function delta_verdict(array $baseSamples, float $baseMedian, float $headMedian): array
+{
+    $deltaPct = $baseMedian > 0 ? ($headMedian - $baseMedian) / $baseMedian * 100 : 0.0;
+    $noise = spread($baseSamples)['noise_pct'];
+    $delta = sprintf('%+.1f%%', $deltaPct);
+
+    if (count($baseSamples) < 4) {
+        // Too few repetitions to know what the machine was doing, so the noise
+        // floor is not a floor yet and nothing here is worth emphasising.
+        $delta = sprintf('%+.1f%% _(too few repetitions to judge)_', $deltaPct);
+    } elseif (abs($deltaPct) <= $noise) {
+        $delta = sprintf('%+.1f%% _(within noise)_', $deltaPct);
+    } elseif (abs($deltaPct) >= 10.0) {
+        $delta = sprintf('**%+.1f%%**', $deltaPct);
+    }
+
+    return ['delta' => $delta, 'noise' => sprintf('±%.1f%%', $noise)];
+}
+
+function delta_cell(int $base, int $head): string
+{
+    if ($base === $head) {
+        return '';
+    }
+
+    return sprintf(' **%+d**', $head - $base);
+}
+
+$base = load_arm($baseDir);
+$head = load_arm($headDir);
+
+$scenarios = array_keys($head['samples']);
+$baseSha = opt('base-sha');
+$headSha = opt('head-sha');
+
+// ─── header ─────────────────────────────────────────────────────────────────
+
+// A stable marker, so the comment job can find and replace its own comment
+// without matching on prose that may change.
+$lines = ['<!-- laravel-brain-benchmark -->'];
+$lines[] = '## Benchmark';
+$lines[] = '';
+
+$provenance = sprintf('PHP %s · %d repetitions per arm, interleaved in one job', $head['php'], $head['reps']);
+
+if ($baseSha !== null && $headSha !== null) {
+    $provenance = sprintf('base `%s` → head `%s` · %s', substr($baseSha, 0, 7), substr($headSha, 0, 7), $provenance);
+}
+
+$lines[] = $provenance;
+$lines[] = '';
+
+$unstable = array_values(array_unique(array_merge($base['unstable'], $head['unstable'])));
+
+if ($unstable !== []) {
+    $lines[] = '> [!WARNING]';
+    $lines[] = sprintf(
+        '> The counts below are not reproducible for %s: repetitions of the same code over the same generated application disagreed. Read no count delta from this run until that is explained.',
+        implode(', ', array_map(static fn (string $n): string => '`'.$n.'`', $unstable)),
+    );
+    $lines[] = '';
+}
+
+// ─── what the scan detected ─────────────────────────────────────────────────
+
+$lines[] = '### What the scan detects';
+$lines[] = '';
+$lines[] = 'Deterministic: both arms scan the same generated application on the same PHP version, and every repetition is checked to produce the same figures. A difference here is a change in what Brain detects, not machine noise — which is worth looking at rather than automatically worth fixing, since detecting more legitimately moves these.';
+$lines[] = '';
+$lines[] = '| Scenario | Nodes | Edges | Tabs | Routes | Security issues | parse() calls |';
+$lines[] = '|---|---:|---:|---:|---:|---:|---:|';
+
+$changedCounts = [];
+
+foreach ($scenarios as $name) {
+    $b = $base['counts'][$name] ?? [];
+    $h = $head['counts'][$name] ?? [];
+
+    $cell = static function (string $key) use ($b, $h): string {
+        if (! array_key_exists($key, $h)) {
+            return '—';
+        }
+
+        $headValue = (int) $h[$key];
+
+        if (! array_key_exists($key, $b)) {
+            return sprintf('%s **new**', number_format($headValue));
+        }
+
+        return number_format($headValue).delta_cell((int) $b[$key], $headValue);
+    };
+
+    $lines[] = sprintf(
+        '| %s | %s | %s | %s | %s | %s | %s |',
+        $head['labels'][$name] ?? $name,
+        $cell('nodes'),
+        array_key_exists('edges', $h) ? $cell('edges') : $cell('traced_edges'),
+        $cell('tabs'),
+        $cell('routes'),
+        $cell('security_issues'),
+        $cell('parse_calls'),
+    );
+
+    // Every count, not just the ones the table has room for — including the
+    // per-node-type breakdown, where a single analyzer change shows up first.
+    foreach ($h as $key => $value) {
+        // Process-cumulative, so it depends on scenario order rather than on
+        // the change: reported in the JSON, never diffed here.
+        if ($key === 'process_peak_mem_mb') {
+            continue;
+        }
+
+        $before = $b[$key] ?? null;
+
+        if ($before !== (int) $value) {
+            $changedCounts[] = sprintf(
+                '- `%s` / `%s`: %s → **%s**',
+                $name,
+                $key,
+                $before === null ? '(absent)' : number_format((int) $before),
+                number_format((int) $value),
+            );
+        }
+    }
+
+    foreach ($b as $key => $value) {
+        if ($key !== 'process_peak_mem_mb' && ! array_key_exists($key, $h)) {
+            $changedCounts[] = sprintf('- `%s` / `%s`: %s → **(absent)**', $name, $key, number_format((int) $value));
+        }
+    }
+}
+
+$lines[] = '';
+
+if ($changedCounts === []) {
+    $lines[] = 'No count changed on either corpus, including the per-node-type breakdown.';
+} else {
+    $lines[] = '<details><summary>'.count($changedCounts).' count(s) changed — full list</summary>';
+    $lines[] = '';
+    foreach ($changedCounts as $line) {
+        $lines[] = $line;
+    }
+    $lines[] = '';
+    $lines[] = '</details>';
+}
+
+$lines[] = '';
+
+// ─── timing ─────────────────────────────────────────────────────────────────
+
+$lines[] = '### Timing';
+$lines[] = '';
+$lines[] = 'Median wall clock on a shared CI runner. Noise is how far the base arm\'s own repetitions sat from its median, discounting the single worst on each side, with their full spread beside it; a delta inside the noise is not a measurable effect.';
+$lines[] = '';
+$lines[] = '| Scenario | Base | Head | Δ | Noise | Base spread |';
+$lines[] = '|---|---:|---:|---:|---:|---:|';
+
+foreach ($scenarios as $name) {
+    $baseSamples = $base['samples'][$name] ?? [];
+    $headSamples = $head['samples'][$name] ?? [];
+
+    if ($baseSamples === []) {
+        $lines[] = sprintf('| %s | — | %.0f ms | new scenario | — | — |', $head['labels'][$name] ?? $name, median($headSamples));
+
+        continue;
+    }
+
+    $bm = median($baseSamples);
+    $hm = median($headSamples);
+    $baseSpread = spread($baseSamples);
+    $verdict = delta_verdict($baseSamples, $bm, $hm);
+
+    $lines[] = sprintf(
+        '| %s | %.0f ms | %.0f ms | %s | %s | %.0f–%.0f ms |',
+        $head['labels'][$name] ?? $name,
+        $bm,
+        $hm,
+        $verdict['delta'],
+        $verdict['noise'],
+        $baseSpread['min'],
+        $baseSpread['max'],
+    );
+}
+
+$lines[] = '';
+
+// ─── phase split ────────────────────────────────────────────────────────────
+
+$phaseScenario = null;
+
+foreach ($scenarios as $name) {
+    if (($head['phases'][$name] ?? []) !== []) {
+        $phaseScenario = $name;
+    }
+}
+
+if ($phaseScenario !== null) {
+    $lines[] = '<details><summary>Phase split — '.($head['labels'][$phaseScenario] ?? $phaseScenario).'</summary>';
+    $lines[] = '';
+    $lines[] = 'A phase carries at least as much runner noise as the scan it is part of, so each one gets its own noise floor from the base arm\'s repetitions of that phase. Useful for locating a large move; a phase that is a few percent of the scan cannot be read at a few percent of accuracy.';
+    $lines[] = '';
+    $lines[] = '| Phase | Base | Head | Δ | Noise |';
+    $lines[] = '|---|---:|---:|---:|---:|';
+
+    $headPhases = $head['phases'][$phaseScenario];
+    $basePhases = $base['phases'][$phaseScenario] ?? [];
+
+    $medians = [];
+
+    foreach ($headPhases as $phase => $samples) {
+        $medians[$phase] = median($samples);
+    }
+
+    arsort($medians);
+
+    foreach ($medians as $phase => $hm) {
+        $baseSamples = $basePhases[$phase] ?? null;
+        $bm = $baseSamples === null ? null : median($baseSamples);
+
+        // Phases that cost nothing on either arm are noise columns, not news.
+        if ($hm < 1.0 && ($bm === null || $bm < 1.0)) {
+            continue;
+        }
+
+        if ($bm === null || $bm <= 0.0) {
+            $lines[] = sprintf('| %s | — | %.1f ms | — | — |', $phase, $hm);
+
+            continue;
+        }
+
+        $verdict = delta_verdict($baseSamples, $bm, $hm);
+
+        $lines[] = sprintf(
+            '| %s | %.1f ms | %.1f ms | %s | %s |',
+            $phase,
+            $bm,
+            $hm,
+            $verdict['delta'],
+            $verdict['noise'],
+        );
+    }
+
+    $lines[] = '';
+    $lines[] = '</details>';
+    $lines[] = '';
+}
+
+$lines[] = '<sub>Scans a synthetic Laravel application generated by `benchmark/generate-corpus.php`, not a real one — the shapes are chosen to stress the scan, so treat the absolute times as a workload, not as a user\'s scan. Reproduce locally with `composer benchmark`.</sub>';
+
+echo implode("\n", $lines)."\n";

--- a/benchmark/generate-corpus.php
+++ b/benchmark/generate-corpus.php
@@ -1,0 +1,492 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Deterministic synthetic Laravel application generator for the benchmark suite.
+ *
+ * The tree is shaped to stress the real scan hotspots rather than to be pretty:
+ *   - many files (redundant cross-analyzer re-parsing shows up here)
+ *   - a shared downstream service/repository/model layer reachable from many
+ *     entry points (shared-subtree re-walks in the method tracer show up here)
+ *   - deep chains: entry point -> service -> service -> repository -> model
+ *   - entry classes (jobs, listeners, commands, middleware, Livewire
+ *     components, observers) with several methods each, including private
+ *     helpers and call-free getters
+ *
+ * Output is byte-identical for a given scale — there is no randomness — so both
+ * arms of a comparison can scan the same generated tree.
+ *
+ * Usage: php generate-corpus.php <outDir> [scale]
+ *   scale 1.0 is ~400 PHP files under app/; 3.0 is ~1,200.
+ */
+$outDir = $argv[1] ?? (__DIR__.'/fixtures/app');
+$scale = (float) ($argv[2] ?? 1.0);
+
+$n = static fn (int $base): int => max(1, (int) round($base * $scale));
+
+$counts = [
+    'controllers' => $n(40),
+    'services' => $n(60),
+    'repositories' => $n(20),
+    'models' => $n(30),
+    'jobs' => $n(60),
+    'listeners' => $n(22),
+    'commands' => $n(34),
+    'middleware' => $n(34),
+    'livewire' => $n(80),
+    'observers' => $n(3),
+    'events' => $n(12),
+];
+
+// ─── filesystem helpers ──────────────────────────────────────────────────────
+function rmrf(string $dir): void
+{
+    if (! is_dir($dir)) {
+        return;
+    }
+    $it = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+    foreach ($it as $f) {
+        $f->isDir() ? rmdir($f->getPathname()) : unlink($f->getPathname());
+    }
+    rmdir($dir);
+}
+
+function put(string $path, string $contents): void
+{
+    $dir = dirname($path);
+    if (! is_dir($dir)) {
+        mkdir($dir, 0755, true);
+    }
+    file_put_contents($path, $contents);
+}
+
+rmrf($outDir);
+mkdir($outDir, 0755, true);
+
+$pad = static fn (int $i): string => str_pad((string) $i, 3, '0', STR_PAD_LEFT);
+
+// ─── pick a shared downstream target deterministically ───────────────────────
+$svc = static fn (int $i): string => 'Service'.str_pad((string) ($i % max(1, $GLOBALS['counts']['services'])), 3, '0', STR_PAD_LEFT);
+$repo = static fn (int $i): string => 'Repository'.str_pad((string) ($i % max(1, $GLOBALS['counts']['repositories'])), 3, '0', STR_PAD_LEFT);
+$model = static fn (int $i): string => 'Model'.str_pad((string) ($i % max(1, $GLOBALS['counts']['models'])), 3, '0', STR_PAD_LEFT);
+$job = static fn (int $i): string => 'Job'.str_pad((string) ($i % max(1, $GLOBALS['counts']['jobs'])), 3, '0', STR_PAD_LEFT);
+$event = static fn (int $i): string => 'Event'.str_pad((string) ($i % max(1, $GLOBALS['counts']['events'])), 3, '0', STR_PAD_LEFT);
+
+// A few call-heavy body lines that reference shared downstream nodes.
+$bodyCalls = function (int $seed, int $lines = 4) use ($model, $job, $event): string {
+    $out = [];
+    for ($k = 0; $k < $lines; $k++) {
+        $t = ($seed + $k * 7);
+        switch ($t % 5) {
+            case 0: $out[] = "        \$this->svcA->handle{$k}(\$id);";
+                break;
+            case 1: $out[] = "        \$this->repo->fetch{$k}(\$id);";
+                break;
+            case 2: $out[] = "        \\App\\Models\\{$model($t)}::query()->where('id', \$id)->first();";
+                break;
+            case 3: $out[] = "        \\App\\Jobs\\{$job($t)}::dispatch(\$id);";
+                break;
+            case 4: $out[] = "        event(new \\App\\Events\\{$event($t)}(\$id));";
+                break;
+        }
+    }
+
+    return implode("\n", $out);
+};
+
+// ─── models ──────────────────────────────────────────────────────────────────
+for ($i = 0; $i < $counts['models']; $i++) {
+    $name = 'Model'.$pad($i);
+    $rel1 = 'Model'.$pad(($i + 1) % $counts['models']);
+    $rel2 = 'Model'.$pad(($i + 2) % $counts['models']);
+    put("$outDir/app/Models/$name.php", <<<PHP
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class $name extends Model
+{
+    protected \$fillable = ['id', 'name', 'status', 'amount'];
+
+    public function related()
+    {
+        return \$this->hasMany($rel1::class);
+    }
+
+    public function owner()
+    {
+        return \$this->belongsTo($rel2::class);
+    }
+
+    public function scopeActive(\$query)
+    {
+        return \$query->where('status', 'active');
+    }
+}
+PHP);
+}
+
+// ─── events ──────────────────────────────────────────────────────────────────
+for ($i = 0; $i < $counts['events']; $i++) {
+    $name = 'Event'.$pad($i);
+    put("$outDir/app/Events/$name.php", <<<PHP
+<?php
+
+namespace App\Events;
+
+class $name
+{
+    public function __construct(public int \$id) {}
+}
+PHP);
+}
+
+// ─── repositories (call models) ──────────────────────────────────────────────
+for ($i = 0; $i < $counts['repositories']; $i++) {
+    $name = 'Repository'.$pad($i);
+    $m = $model($i);
+    $body = [];
+    for ($k = 0; $k < 5; $k++) {
+        $body[] = <<<M
+    public function fetch$k(int \$id)
+    {
+        return \\App\\Models\\{$model($i + $k)}::query()->where('id', \$id)->first();
+    }
+M;
+    }
+    $body = implode("\n\n", $body);
+    put("$outDir/app/Repositories/$name.php", <<<PHP
+<?php
+
+namespace App\Repositories;
+
+class $name
+{
+$body
+}
+PHP);
+}
+
+// ─── services (call other services, repos, models, jobs, events) ─────────────
+for ($i = 0; $i < $counts['services']; $i++) {
+    $name = 'Service'.$pad($i);
+    $svcDep = $svc($i + 1);
+    $repoDep = $repo($i);
+    $methods = [];
+    for ($k = 0; $k < 5; $k++) {
+        $calls = $bodyCalls($i * 3 + $k, 4);
+        $methods[] = <<<M
+    public function handle$k(int \$id): void
+    {
+$calls
+    }
+M;
+    }
+    // one call-free getter (pure overhead to trace)
+    $methods[] = <<<M
+    public function label(): string
+    {
+        return '$name';
+    }
+M;
+    $methods = implode("\n\n", $methods);
+    put("$outDir/app/Services/$name.php", <<<PHP
+<?php
+
+namespace App\Services;
+
+use App\Services\\$svcDep;
+use App\Repositories\\$repoDep;
+
+class $name
+{
+    public function __construct(
+        private \\App\\Services\\$svcDep \$svcA,
+        private \\App\\Repositories\\$repoDep \$repo,
+    ) {}
+
+$methods
+}
+PHP);
+}
+
+// ─── controllers (constructor inject services, methods call them) ────────────
+$routeLines = ['web' => [], 'api' => []];
+for ($i = 0; $i < $counts['controllers']; $i++) {
+    $name = 'Controller'.$pad($i);
+    $svcDep = $svc($i);
+    $svcDep2 = $svc($i + 2);
+    $methods = [];
+    $actions = ['index', 'show', 'store', 'update'];
+    foreach ($actions as $ai => $action) {
+        $calls = $bodyCalls($i * 5 + $ai, 4);
+        $methods[] = <<<M
+    public function $action(int \$id)
+    {
+$calls
+        return response()->json(['ok' => true]);
+    }
+M;
+        $verb = ['index' => 'get', 'show' => 'get', 'store' => 'post', 'update' => 'put'][$action];
+        $bucket = $i % 2 === 0 ? 'web' : 'api';
+        $routeLines[$bucket][] = "Route::$verb('/$name/$action/{id}', [\\App\\Http\\Controllers\\$name::class, '$action']);";
+    }
+    $methods = implode("\n\n", $methods);
+    put("$outDir/app/Http/Controllers/$name.php", <<<PHP
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\\$svcDep;
+use App\Services\\$svcDep2;
+
+class $name
+{
+    public function __construct(
+        private \\App\\Services\\$svcDep \$svcA,
+        private \\App\\Services\\$svcDep2 \$svcB,
+    ) {}
+
+$methods
+}
+PHP);
+}
+
+// ─── jobs (handle + private helpers, call shared services) ───────────────────
+for ($i = 0; $i < $counts['jobs']; $i++) {
+    $name = 'Job'.$pad($i);
+    $svcDep = $svc($i);
+    $calls = $bodyCalls($i * 11, 4);
+    $calls2 = $bodyCalls($i * 11 + 3, 3);
+    put("$outDir/app/Jobs/$name.php", <<<PHP
+<?php
+
+namespace App\Jobs;
+
+use App\Services\\$svcDep;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class $name implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(private int \$id) {}
+
+    public function handle(\\App\\Services\\$svcDep \$svcA): void
+    {
+$calls
+        \$this->finalize();
+    }
+
+    private function finalize(): void
+    {
+$calls2
+    }
+
+    public function tags(): array
+    {
+        return ['$name'];
+    }
+}
+PHP);
+}
+
+// ─── listeners ───────────────────────────────────────────────────────────────
+for ($i = 0; $i < $counts['listeners']; $i++) {
+    $name = 'Listener'.$pad($i);
+    $svcDep = $svc($i + 4);
+    $calls = $bodyCalls($i * 13, 4);
+    put("$outDir/app/Listeners/$name.php", <<<PHP
+<?php
+
+namespace App\Listeners;
+
+use App\Services\\$svcDep;
+
+class $name
+{
+    public function __construct(private \\App\\Services\\$svcDep \$svcA) {}
+
+    public function handle(\$event): void
+    {
+$calls
+    }
+}
+PHP);
+}
+
+// ─── console commands ─────────────────────────────────────────────────────────
+for ($i = 0; $i < $counts['commands']; $i++) {
+    $name = 'Command'.$pad($i);
+    $svcDep = $svc($i + 6);
+    $calls = $bodyCalls($i * 17, 5);
+    put("$outDir/app/Console/Commands/$name.php", <<<PHP
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\\$svcDep;
+use Illuminate\Console\Command;
+
+class $name extends Command
+{
+    protected \$signature = 'app:cmd$i {id}';
+
+    protected \$description = 'Command $i';
+
+    public function handle(\\App\\Services\\$svcDep \$svcA): int
+    {
+        \$id = (int) \$this->argument('id');
+$calls
+        return self::SUCCESS;
+    }
+}
+PHP);
+}
+
+// ─── middleware ────────────────────────────────────────────────────────────────
+for ($i = 0; $i < $counts['middleware']; $i++) {
+    $name = 'Middleware'.$pad($i);
+    $svcDep = $svc($i + 8);
+    $calls = $bodyCalls($i * 19, 3);
+    put("$outDir/app/Http/Middleware/$name.php", <<<PHP
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Services\\$svcDep;
+use Closure;
+
+class $name
+{
+    public function __construct(private \\App\\Services\\$svcDep \$svcA) {}
+
+    public function handle(\$request, Closure \$next)
+    {
+        \$id = (int) \$request->input('id');
+$calls
+        return \$next(\$request);
+    }
+}
+PHP);
+}
+
+// ─── livewire components ────────────────────────────────────────────────────────
+for ($i = 0; $i < $counts['livewire']; $i++) {
+    $name = 'Component'.$pad($i);
+    $svcDep = $svc($i + 10);
+    $methods = [];
+    for ($k = 0; $k < 5; $k++) {
+        $calls = $bodyCalls($i * 23 + $k, 3);
+        $methods[] = <<<M
+    public function action$k(int \$id): void
+    {
+$calls
+    }
+M;
+    }
+    $methods[] = <<<M
+    public function getTitleProperty(): string
+    {
+        return '$name';
+    }
+M;
+    $methods = implode("\n\n", $methods);
+    put("$outDir/app/Livewire/$name.php", <<<PHP
+<?php
+
+namespace App\Livewire;
+
+use App\Services\\$svcDep;
+use Livewire\Component;
+
+class $name extends Component
+{
+    public function __construct(private \\App\\Services\\$svcDep \$svcA) {}
+
+$methods
+
+    public function render()
+    {
+        return view('livewire.$name');
+    }
+}
+PHP);
+}
+
+// ─── observers ─────────────────────────────────────────────────────────────────
+for ($i = 0; $i < $counts['observers']; $i++) {
+    $name = 'Observer'.$pad($i);
+    $svcDep = $svc($i + 12);
+    $calls = $bodyCalls($i * 29, 3);
+    put("$outDir/app/Observers/$name.php", <<<PHP
+<?php
+
+namespace App\Observers;
+
+use App\Services\\$svcDep;
+
+class $name
+{
+    public function __construct(private \\App\\Services\\$svcDep \$svcA) {}
+
+    public function created(\$model): void
+    {
+$calls
+    }
+
+    public function updated(\$model): void
+    {
+$calls
+    }
+}
+PHP);
+}
+
+// ─── routes ────────────────────────────────────────────────────────────────────
+$webRoutes = "<?php\n\nuse Illuminate\\Support\\Facades\\Route;\n\n".implode("\n", $routeLines['web'])."\n";
+$apiRoutes = "<?php\n\nuse Illuminate\\Support\\Facades\\Route;\n\n".implode("\n", $routeLines['api'])."\n";
+put("$outDir/routes/web.php", $webRoutes);
+put("$outDir/routes/api.php", $apiRoutes);
+
+// ─── composer.json (psr-4) ──────────────────────────────────────────────────────
+put("$outDir/composer.json", <<<'JSON'
+{
+    "name": "bench/app",
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    }
+}
+JSON);
+
+// ─── vendor/composer/autoload_psr4.php ──────────────────────────────────────────
+// Real apps always ship this (Composer-generated); GraphBuilder::buildFullPsr4Map reads
+// it to resolve FQCN -> file. Without it, GraphBuilder falls back to a full recursive
+// directory walk per class — a fixture-only artifact that must not skew the benchmark.
+// buildFullPsr4Map pre-sets $baseDir = projectRoot before requiring this file.
+put("$outDir/vendor/composer/autoload_psr4.php", <<<'PHP'
+<?php
+
+// @generated fixture — mirrors Composer's autoload_psr4.php shape
+return array(
+    'App\\' => array($baseDir . '/app'),
+);
+PHP);
+
+// ─── report ──────────────────────────────────────────────────────────────────
+$total = array_sum($counts);
+$files = iterator_count(new RecursiveIteratorIterator(new RecursiveDirectoryIterator($outDir.'/app', FilesystemIterator::SKIP_DOTS)));
+fwrite(STDERR, "Generated corpus at $outDir (scale $scale)\n");
+foreach ($counts as $k => $v) {
+    fwrite(STDERR, sprintf("  %-14s %d\n", $k, $v));
+}
+fwrite(STDERR, "  TOTAL classes ≈ $total, php files under app/ = $files\n");

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
             "@test:lint",
             "@test:unit",
             "@test:types"
-        ]
+        ],
+        "benchmark": "php benchmark/benchmark.php"
     },
     "extra": {
         "laravel": {

--- a/tests/Unit/BenchmarkComparisonTest.php
+++ b/tests/Unit/BenchmarkComparisonTest.php
@@ -1,0 +1,308 @@
+<?php
+
+/**
+ * The benchmark comparison decides what a pull request comment claims, so the
+ * claims are tested: a count difference must be reported, an identical run must
+ * not invent one, a timing delta inside the machine's own spread must be labelled
+ * as such, and an arm whose counts did not reproduce must be flagged loudly.
+ *
+ * compare.php is run as its own process, the way CI runs it.
+ */
+$compare = dirname(__DIR__, 2).'/benchmark/compare.php';
+
+/**
+ * One round of one arm, in the shape benchmark.php writes.
+ *
+ * @param  list<float>  $times
+ * @param  array<string, int>  $counts
+ */
+function benchmarkRound(array $times, array $counts, bool $stable = true, ?array $phases = null): array
+{
+    return [
+        'meta' => ['php' => '8.4.0', 'reps' => count($times), 'warmups' => 1],
+        'scenarios' => [
+            'scan-small' => [
+                'label' => 'Full scan — 395 files',
+                'times_ms' => $times,
+                'median_ms' => $times[0],
+                'counts' => $counts,
+                'counts_stable' => $stable,
+                'phases_ms' => $phases ?? ['graph' => 40.0, 'facades' => 20.0],
+            ],
+        ],
+    ];
+}
+
+/** The phase split's row for one phase. */
+function benchmarkPhaseRow(string $markdown, string $phase): string
+{
+    $split = substr($markdown, (int) strpos($markdown, 'Phase split'));
+
+    foreach (explode("\n", $split) as $line) {
+        if (str_starts_with($line, '| '.$phase.' |')) {
+            return $line;
+        }
+    }
+
+    throw new RuntimeException("no phase row for {$phase} in:\n".$markdown);
+}
+
+/** Remove a directory tree written by one of these tests. */
+function removeBenchmarkFixture(string $dir): void
+{
+    if (! is_dir($dir)) {
+        return;
+    }
+
+    $entries = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST,
+    );
+
+    foreach ($entries as $entry) {
+        $entry->isDir() ? rmdir($entry->getPathname()) : unlink($entry->getPathname());
+    }
+
+    rmdir($dir);
+}
+
+/** Run compare.php the way CI runs it, and return stdout plus stderr. */
+function runCompare(string $baseDir, string $headDir, array $extra = []): array
+{
+    $cmd = sprintf(
+        '%s %s %s %s',
+        escapeshellarg(PHP_BINARY),
+        escapeshellarg(dirname(__DIR__, 2).'/benchmark/compare.php'),
+        escapeshellarg($baseDir),
+        escapeshellarg($headDir),
+    );
+
+    foreach ($extra as $arg) {
+        $cmd .= ' '.escapeshellarg($arg);
+    }
+
+    exec($cmd.' 2>&1', $output, $status);
+
+    return [implode("\n", $output), $status];
+}
+
+/**
+ * Write both arms to disk and return what compare.php prints.
+ *
+ * @param  list<array>  $baseRounds
+ * @param  list<array>  $headRounds
+ */
+function runBenchmarkComparison(array $baseRounds, array $headRounds): string
+{
+    $root = sys_get_temp_dir().'/brain-compare-'.bin2hex(random_bytes(6));
+
+    foreach (['base' => $baseRounds, 'head' => $headRounds] as $arm => $rounds) {
+        mkdir($root.'/'.$arm, 0755, true);
+
+        foreach ($rounds as $i => $round) {
+            file_put_contents(sprintf('%s/%s/round-%d.json', $root, $arm, $i + 1), json_encode($round));
+        }
+    }
+
+    [$markdown, $status] = runCompare($root.'/base', $root.'/head');
+
+    removeBenchmarkFixture($root);
+
+    expect($status)->toBe(0);
+
+    return $markdown;
+}
+
+/**
+ * The scenario's row from the timing table — not from the counts table above it,
+ * and not from the phase split below, both of which mention the same scenario.
+ */
+function benchmarkTimingRow(string $markdown, string $label = 'Full scan — 395 files'): string
+{
+    $timing = substr($markdown, (int) strpos($markdown, '### Timing'));
+
+    foreach (explode("\n", $timing) as $line) {
+        if (str_starts_with($line, '| '.$label.' |')) {
+            return $line;
+        }
+    }
+
+    throw new RuntimeException("no timing row for {$label} in:\n".$markdown);
+}
+
+/**
+ * Four rounds of the same numbers, which is what a quiet machine looks like.
+ *
+ * @param  array<string, int>  $counts
+ */
+function benchmarkArm(float $ms, array $counts, bool $stable = true): array
+{
+    return array_fill(0, 4, benchmarkRound([$ms, $ms], $counts, $stable));
+}
+
+it('reports a count difference and says which counts moved', function () {
+    $markdown = runBenchmarkComparison(
+        benchmarkArm(100.0, ['nodes' => 700, 'edges' => 1900, 'parse_calls' => 300]),
+        benchmarkArm(100.0, ['nodes' => 712, 'edges' => 1900, 'parse_calls' => 300]),
+    );
+
+    expect($markdown)
+        ->toContain('712 **+12**')
+        ->toContain('`scan-small` / `nodes`: 700 → **712**')
+        ->not->toContain('No count changed');
+});
+
+it('does not invent a count difference when nothing moved', function () {
+    $counts = ['nodes' => 700, 'edges' => 1900, 'parse_calls' => 300];
+
+    $markdown = runBenchmarkComparison(benchmarkArm(100.0, $counts), benchmarkArm(100.0, $counts));
+
+    expect($markdown)->toContain('No count changed on either corpus');
+});
+
+it('reports a count that only one arm has', function () {
+    $markdown = runBenchmarkComparison(
+        benchmarkArm(100.0, ['nodes' => 700]),
+        benchmarkArm(100.0, ['nodes' => 700, 'node_type:listener' => 22]),
+    );
+
+    expect($markdown)->toContain('`scan-small` / `node_type:listener`: (absent) → **22**');
+});
+
+it('labels a timing delta inside the machine\'s own spread as noise', function () {
+    // The base arm's repetitions themselves range over ±20%, so a 10% delta is
+    // not something this run can resolve.
+    $noisy = [
+        benchmarkRound([80.0, 80.0], ['nodes' => 700]),
+        benchmarkRound([100.0, 100.0], ['nodes' => 700]),
+        benchmarkRound([120.0, 120.0], ['nodes' => 700]),
+        benchmarkRound([100.0, 100.0], ['nodes' => 700]),
+    ];
+
+    $markdown = runBenchmarkComparison($noisy, benchmarkArm(110.0, ['nodes' => 700]));
+
+    expect(benchmarkTimingRow($markdown))->toContain('+10.0% _(within noise)_');
+});
+
+it('calls out a timing delta that is bigger than the noise', function () {
+    $markdown = runBenchmarkComparison(
+        benchmarkArm(100.0, ['nodes' => 700]),
+        benchmarkArm(140.0, ['nodes' => 700]),
+    );
+
+    expect(benchmarkTimingRow($markdown))
+        ->toContain('**+40.0%**')
+        ->not->toContain('within noise');
+});
+
+it('refuses to judge a timing delta measured over too few repetitions', function () {
+    $markdown = runBenchmarkComparison(
+        [benchmarkRound([100.0], ['nodes' => 700])],
+        [benchmarkRound([140.0], ['nodes' => 700])],
+    );
+
+    expect(benchmarkTimingRow($markdown))->toContain('too few repetitions to judge');
+});
+
+it('holds a phase to its own noise floor, not to the scan\'s', function () {
+    // The facade phase is the volatile one: base repetitions ranging over 2x
+    // make a halved head median unreadable, however steady the total looks.
+    $volatile = [
+        benchmarkRound([100.0, 100.0], ['nodes' => 700], phases: ['graph' => 40.0, 'facades' => 70.0]),
+        benchmarkRound([100.0, 100.0], ['nodes' => 700], phases: ['graph' => 40.0, 'facades' => 33.0]),
+        benchmarkRound([100.0, 100.0], ['nodes' => 700], phases: ['graph' => 40.0, 'facades' => 71.0]),
+        benchmarkRound([100.0, 100.0], ['nodes' => 700], phases: ['graph' => 40.0, 'facades' => 130.0]),
+    ];
+
+    $steadyHead = array_fill(0, 4, benchmarkRound(
+        [100.0, 100.0],
+        ['nodes' => 700],
+        phases: ['graph' => 40.0, 'facades' => 34.0],
+    ));
+
+    $markdown = runBenchmarkComparison($volatile, $steadyHead);
+
+    expect(benchmarkPhaseRow($markdown, 'facades'))->toContain('within noise');
+    // The steady phase in the same run still reads as steady.
+    expect(benchmarkPhaseRow($markdown, 'graph'))->toContain('±0.0%');
+});
+
+it('warns when an arm did not reproduce its own counts', function () {
+    $markdown = runBenchmarkComparison(
+        benchmarkArm(100.0, ['nodes' => 700]),
+        benchmarkArm(100.0, ['nodes' => 700], stable: false),
+    );
+
+    expect($markdown)
+        ->toContain('[!WARNING]')
+        ->toContain('not reproducible for `scan-small`');
+});
+
+it('does not treat process memory as a count that failed to reproduce', function () {
+    // Peak memory is the process's, so it climbs from round to round while the
+    // build is perfectly reproducible. Reading that as instability would put a
+    // warning on every comparison.
+    $markdown = runBenchmarkComparison(
+        benchmarkArm(100.0, ['nodes' => 700, 'process_peak_mem_mb' => 40]),
+        [
+            benchmarkRound([100.0, 100.0], ['nodes' => 700, 'process_peak_mem_mb' => 40]),
+            benchmarkRound([100.0, 100.0], ['nodes' => 700, 'process_peak_mem_mb' => 58]),
+            benchmarkRound([100.0, 100.0], ['nodes' => 700, 'process_peak_mem_mb' => 61]),
+            benchmarkRound([100.0, 100.0], ['nodes' => 700, 'process_peak_mem_mb' => 61]),
+        ],
+    );
+
+    expect($markdown)
+        ->not->toContain('[!WARNING]')
+        ->not->toContain('process_peak_mem_mb')
+        ->toContain('No count changed on either corpus');
+});
+
+it('warns when an arm reported different counts in different rounds', function () {
+    $markdown = runBenchmarkComparison(
+        benchmarkArm(100.0, ['nodes' => 700]),
+        [
+            benchmarkRound([100.0, 100.0], ['nodes' => 700]),
+            benchmarkRound([100.0, 100.0], ['nodes' => 701]),
+            benchmarkRound([100.0, 100.0], ['nodes' => 700]),
+            benchmarkRound([100.0, 100.0], ['nodes' => 700]),
+        ],
+    );
+
+    expect($markdown)->toContain('not reproducible for `scan-small`');
+});
+
+it('carries the shas it was given, and a marker the comment job can find', function () {
+    $root = sys_get_temp_dir().'/brain-compare-'.bin2hex(random_bytes(6));
+
+    foreach (['base', 'head'] as $arm) {
+        mkdir($root.'/'.$arm, 0755, true);
+        file_put_contents($root.'/'.$arm.'/round-1.json', json_encode(benchmarkRound([100.0, 100.0], ['nodes' => 700])));
+    }
+
+    [$markdown, $status] = runCompare($root.'/base', $root.'/head', [
+        '--base-sha=1234567890abcdef',
+        '--head-sha=fedcba0987654321',
+    ]);
+
+    removeBenchmarkFixture($root);
+
+    expect($status)->toBe(0);
+
+    expect($markdown)
+        ->toStartWith('<!-- laravel-brain-benchmark -->')
+        ->toContain('base `1234567` → head `fedcba0`');
+});
+
+it('fails instead of rendering half a comparison when an arm is missing', function () {
+    $root = sys_get_temp_dir().'/brain-compare-'.bin2hex(random_bytes(6));
+    mkdir($root.'/head', 0755, true);
+    file_put_contents($root.'/head/round-1.json', json_encode(benchmarkRound([100.0], ['nodes' => 700])));
+
+    [$output, $status] = runCompare($root.'/missing', $root.'/head');
+
+    removeBenchmarkFixture($root);
+
+    expect($status)->toBe(1);
+    expect($output)->toContain('no benchmark result files');
+});


### PR DESCRIPTION
Every pull request that touches `src/` gets a comment with what the change did to a scan: what Brain detects, and what the scan costs.

## Two kinds of number, kept apart

The counts (nodes, edges, tabs, routes, security issues, `parse()` calls, and a breakdown per node type) are deterministic. Both arms scan the same generated application, so a difference means Brain's output changed, not that the runner was busy. The benchmark checks that every repetition produced the same counts and the comment says so when they disagree. A moved count is not automatically a regression, since an analyzer that detects more will move one by design, but it should not move by accident without anyone noticing.

Timing is a median wall clock, and every delta is shown against a noise floor taken from the base arm's own repetitions. A delta inside that floor is labelled not measurable rather than reported as a result. Each phase gets a floor from its own repetitions, because a phase is noisier than the scan around it: the facade phase was measured ranging from 33 to 132 ms between repetitions of identical code, which reads as a 50% improvement if you give it the scan's floor instead.

## What it scans

`benchmark/generate-corpus.php` writes a deterministic synthetic Laravel application at two scales, roughly 400 and 1,200 PHP files: a service, repository and model layer shared by many entry points, chains four deep, private helpers and call-free getters. It is shaped to stress the scan rather than to look like an average app, so read the absolute times that way. No real application is involved, so there is nothing to keep private and nothing to keep in sync.

Both arms scan the same generated tree, which is why a count delta can only come from the code change.

## How the comparison runs

`benchmark.yml` checks out the pull request and its merge base, not the tip of the base branch (which would report other people's merges as this pull request's differences), installs both, generates the application once, and alternates the arms round by round so machine load lands on both. Five rounds of two timed repetitions per arm, each after a warmup.

The pull request's own copy of the harness measures both arms: `BRAIN_BENCH_AUTOLOAD` points `bootstrap.php` at each checkout's autoloader in turn. The harness code is therefore identical across arms, only `src/` differs, and the benchmark does not need to exist on the base ref, which is why this pull request can measure itself.

`benchmark-comment.yml` posts the result from a separate `workflow_run` job, because the job that runs pull request code holds a read-only token. Its artifact is untrusted input: the pull request number is validated as a number before it addresses anything, the body is passed as a file rather than interpolated into a command, and the comment to replace is found by a fixed marker rather than by text read out of the artifact.

## What it reported on an unchanged tree

Run against a merge base with identical `src/`, ten repetitions per arm:

- no count changed on either scale, including the per-node-type breakdown
- every timing delta came back within noise, the facade phase included: its 52% median difference sat inside a floor of the same size, so the comment marked it unreadable

The comparison logic has tests, and each was mutation-checked. Breaking the count diff, the noise floor, the per-phase floors, the stability warning or the comment marker fails a test.

## Running it locally

```
composer benchmark
```

`benchmark/README.md` covers the options, how to reproduce a CI comparison against a merge base, and how to read the two tables.

## Notes for review

- The comment needs one change outside this pull request. `workflow_run` workflows only run from the repository's default branch, and that is `v2.x` while work merges to `main`. Until `benchmark-comment.yml` sits on the default branch, pull requests get both tables on the run's summary page but no comment. `v2.x` is 34 commits behind `main` with nothing `main` lacks, so switching the default branch to `main` fixes it, and seems worth doing anyway.
- `benchmark/` is deliberately outside `phpstan.neon`'s paths. The harness feature-detects the caches it clears because it also runs against the merge base's `src/`, and analysing this checkout reads those guards as always true. The README says so where someone would go looking.
- No `.gitattributes` `export-ignore`, so `benchmark/` ships in the dist tarball, as `tests/` already does. If we want to trim the package, better to do it for both at once than for one directory here.
- Nothing at release time yet. The same runner would produce a table for release notes if that is wanted.
