### PR TITLE
Fix: a scoped-rebuild test fails whenever a second passes between two writes

### DIFF
--- a/tests/Unit/ScopedRebuildTest.php
+++ b/tests/Unit/ScopedRebuildTest.php
@@ -82,6 +82,8 @@ afterEach(function () {
 function writeScopedSource(string $path, string $code): void
 {
     static $age = 900;
+    static $base = null;
+    $base ??= time();
 
     file_put_contents($path, $code);
 
@@ -91,7 +93,13 @@ function writeScopedSource(string $path, string $code): void
     // version's parse. The age used to walk toward the present and stop 10 seconds short of it,
     // which collided as soon as a run made enough writes to get there; walking the other way
     // cannot, and never reaches the present, which the cache treats as unsettled.
-    touch($path, time() - $age);
+    //
+    // The base is read once rather than per write. `time() - $age` moves both terms in the same
+    // direction: a write landing a second after the previous one repeats its mtime exactly, and
+    // a full build runs between the two writes in most of these tests, which on a slow runner
+    // takes that second. That is a real failure — twice in one CI matrix, `ScopedRebuildNotApplicable
+    // not thrown`, because the second build was answered from the first version's parse.
+    touch($path, $base - $age);
     $age++;
     clearstatcache(true, $path);
 }


### PR DESCRIPTION
## A test that fails on a slow runner and nowhere else

`ScopedRebuildTest > it refuses an edit that moved a call` failed on two jobs of one CI matrix while the other twelve passed on the same commit, with:

```
Exception "LaraMint\LaravelBrain\Analysis\Incremental\ScopedRebuildNotApplicable" not thrown.
```

It is the helper, not the code under test.

```php
static $age = 900;
touch($path, time() - $age);
$age++;
```

Both terms rise by one per write, so a write landing a second after the previous one repeats its mtime exactly:

```
write 3: clock 1001, age 902 -> mtime 99
write 4: clock 1001, age 903 -> mtime 98
write 5: clock 1002, age 904 -> mtime 98   <- repeats
```

Most of these tests write once in `beforeEach`, run a **full build**, and write again. That build is what burns the second on a loaded runner.

The two versions the failing test writes, `controllerCalling('run')` and `controllerCalling('log')`, are both exactly 200 bytes, and `PhpFileParser` keys its cache on `path : mtime : size`. A repeated mtime hands the second build the first version's parse, so the moved call is invisible, the soundness check has nothing to refuse, and the exception never fires.

## The change

Read the clock once. `$age` still rises per write, so the mtimes now fall strictly no matter how long the run takes.

```php
static $age = 900;
static $base = null;
$base ??= time();
...
touch($path, $base - $age);
```

## Verified by forcing the condition, not by waiting for it

A `sleep(1)` inside the helper reproduces a slow runner exactly. On `main`:

```
⨯ it refuses an edit that moved a call
  Exception "…ScopedRebuildNotApplicable" not thrown.
```

the same failure CI reported. With this change and the same `sleep(1)` still in place, the whole file passes:

```
✓ it refuses an edit that moved a call
Tests: 10 passed (16 assertions)
```

The probe is not part of the diff; it was removed before committing.

`405 passed (1121 assertions)`, PHPStan level 5 clean, Pint clean, and six full runs in random order with no failure.

## Scope

One helper in one test file. The three other places that pin an mtime — `PhpFileParserSharedCacheTest`, `ValidationRulesExtractorTest`, `BuildFingerprintTest` — take the mtime from the caller, so none of them can drift into this.
