### PR TITLE
Support Route::match([...], ...) in RouteAnalyzer

### DIFF
--- a/src/Analysis/RouteAnalyzer.php
+++ b/src/Analysis/RouteAnalyzer.php
@@ -1224,12 +1224,22 @@ class RouteAnalyzer
                 if ($methodsValue === null) {
                     return;
                 }
-                $methods = $this->extractMiddlewareList($methodsValue);
+
+                // extractMiddlewareList() resolves a ClassConstFetch to its class name, which is
+                // right for `SomeMiddleware::class` but wrong for a verb written as a class
+                // constant (e.g. Request::METHOD_GET) — that would come back as the class's FQCN,
+                // not a verb. Filtering to the verbs this analyzer actually understands drops such
+                // an entry instead of registering a bogus route, matching how an unrecognised verb
+                // was already handled before Route::match() support existed: silently ignored.
+                $methods = array_values(array_intersect(
+                    array_unique(array_map('strtolower', $this->extractMiddlewareList($methodsValue))),
+                    [...self::HTTP_METHODS, 'head'],
+                ));
                 if ($methods === []) {
                     return;
                 }
 
-                foreach (array_unique(array_map('strtolower', $methods)) as $method) {
+                foreach ($methods as $method) {
                     $this->handleHttpRoute($node, $method, $extraMiddlewares, 1);
                 }
             }

--- a/src/Analysis/RouteAnalyzer.php
+++ b/src/Analysis/RouteAnalyzer.php
@@ -1075,6 +1075,8 @@ class RouteAnalyzer
 
                     if (in_array($methodName, self::HTTP_METHODS, true)) {
                         $this->handleHttpRoute($node, $methodName);
+                    } elseif ($methodName === 'match') {
+                        $this->handleMatchRoute($node);
                     } elseif ($methodName === 'group') {
                         $this->enterGroupFromStaticCall($node);
                     } elseif (in_array($methodName, ['resource', 'apiResource'], true)) {
@@ -1095,6 +1097,8 @@ class RouteAnalyzer
                         $this->enterGroupFromMethodChain($node);
                     } elseif (in_array($methodName, self::HTTP_METHODS, true)) {
                         $this->handleHttpRoute($node, $methodName);
+                    } elseif ($methodName === 'match') {
+                        $this->handleMatchRoute($node);
                     } elseif (in_array($methodName, ['resource', 'apiResource'], true)) {
                         $this->handleResource($node, $methodName);
                     } elseif ($methodName === 'livewire') {
@@ -1139,10 +1143,13 @@ class RouteAnalyzer
             /**
              * @param  string[]  $extraMiddlewares  Middleware collected from post-route chaining
              *                                      (e.g. Route::get(...)->middleware('ability:...'))
+             * @param  int  $argOffset  Index of the URI argument. 0 for Route::get('/uri', ...);
+             *                          1 for Route::match(['get','post'], '/uri', ...), whose first
+             *                          argument is the methods array rather than the URI.
              */
-            private function handleHttpRoute(Node\Expr\StaticCall|Node\Expr\MethodCall $node, string $method, array $extraMiddlewares = []): void
+            private function handleHttpRoute(Node\Expr\StaticCall|Node\Expr\MethodCall $node, string $method, array $extraMiddlewares = [], int $argOffset = 0): void
             {
-                $uri = $this->extractString($node->args[0] ?? null);
+                $uri = $this->extractString($node->args[$argOffset] ?? null);
                 if ($uri === null) {
                     return;
                 }
@@ -1159,10 +1166,10 @@ class RouteAnalyzer
                 $stackController = end($this->controllerStack) ?: '';
                 $controllerContext = $chainController !== '' ? $chainController : $stackController;
 
-                [$controller, $actionMethod, $closureNode, $mayPrependNamespace] = $this->extractAction($node->args[1] ?? null, $controllerContext);
+                [$controller, $actionMethod, $closureNode, $mayPrependNamespace] = $this->extractAction($node->args[$argOffset + 1] ?? null, $controllerContext);
 
                 // An array action can carry its own middleware alongside `uses`.
-                $actionArg = $node->args[1] ?? null;
+                $actionArg = $node->args[$argOffset + 1] ?? null;
                 $actionValue = $actionArg instanceof Node\Arg ? $actionArg->value : $actionArg;
                 if ($actionValue !== null) {
                     $actionMiddleware = $this->arrayValueFor($actionValue, 'middleware');
@@ -1200,6 +1207,31 @@ class RouteAnalyzer
                     closureNode: $closureNode,
                     closureUseMap: $closureNode !== null ? $this->useMap : null,
                 );
+            }
+
+            /**
+             * Handles Route::match(['get', 'post'], '/uri', $action) — registers one
+             * RouteDefinition per HTTP verb named in the methods array, mirroring how
+             * Laravel's router itself expands a match() call.
+             *
+             * @param  string[]  $extraMiddlewares  Middleware collected from post-route chaining
+             *                                      (e.g. Route::match([...], ...)->middleware('auth'))
+             */
+            private function handleMatchRoute(Node\Expr\StaticCall|Node\Expr\MethodCall $node, array $extraMiddlewares = []): void
+            {
+                $methodsArg = $node->args[0] ?? null;
+                $methodsValue = $methodsArg instanceof Node\Arg ? $methodsArg->value : $methodsArg;
+                if ($methodsValue === null) {
+                    return;
+                }
+                $methods = $this->extractMiddlewareList($methodsValue);
+                if ($methods === []) {
+                    return;
+                }
+
+                foreach (array_unique(array_map('strtolower', $methods)) as $method) {
+                    $this->handleHttpRoute($node, $method, $extraMiddlewares, 1);
+                }
             }
 
             /**
@@ -1287,6 +1319,12 @@ class RouteAnalyzer
                         return true;
                     }
 
+                    if ($name === 'match') {
+                        $this->handleMatchRoute($current, $postMiddlewares);
+
+                        return true;
+                    }
+
                     $current = $current->var;
                 }
 
@@ -1304,6 +1342,12 @@ class RouteAnalyzer
 
                         if ($name === 'livewire') {
                             $this->handleLivewireRoute($current, $postMiddlewares);
+
+                            return true;
+                        }
+
+                        if ($name === 'match') {
+                            $this->handleMatchRoute($current, $postMiddlewares);
 
                             return true;
                         }

--- a/tests/Unit/RouteAnalyzerTest.php
+++ b/tests/Unit/RouteAnalyzerTest.php
@@ -134,6 +134,47 @@ PHP
     }
 });
 
+it('expands Route::match into one route per HTTP verb', function () {
+    $tmp = sys_get_temp_dir().'/lb-route-analyzer-'.uniqid('', true);
+    mkdir($tmp.'/routes/web', 0777, true);
+    file_put_contents(
+        $tmp.'/routes/web/gateway.php',
+        <<<'PHP'
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+Route::prefix('gateway')->middleware(['throttle:api'])->group(function () {
+    Route::match(['get', 'post'], '/token', [\App\Http\Controllers\AuthController::class, 'token'])
+        ->middleware('log.requests');
+});
+
+PHP
+    );
+
+    try {
+        $routes = (new RouteAnalyzer(['routes/*/*.php']))->analyze($tmp);
+        expect($routes)->toHaveCount(2);
+
+        $get = findRoute($routes, fn ($r) => $r->method === 'GET');
+        $post = findRoute($routes, fn ($r) => $r->method === 'POST');
+
+        expect($get)->toBeInstanceOf(RouteDefinition::class)
+            ->uri->toBe('/gateway/token')
+            ->controller->toBe('App\Http\Controllers\AuthController')
+            ->action->toBe('token');
+        expect($get->middlewares)->toContain('throttle:api')->toContain('log.requests');
+
+        expect($post)->toBeInstanceOf(RouteDefinition::class)
+            ->uri->toBe('/gateway/token')
+            ->controller->toBe('App\Http\Controllers\AuthController')
+            ->action->toBe('token');
+        expect($post->middlewares)->toContain('throttle:api')->toContain('log.requests');
+    } finally {
+        routeAnalyzerTestDeleteTree($tmp);
+    }
+});
+
 it('auto-discover mode pulls routes from the live router', function () {
     $router = makeAutoDiscoverRouter();
 

--- a/tests/Unit/RouteAnalyzerTest.php
+++ b/tests/Unit/RouteAnalyzerTest.php
@@ -144,6 +144,8 @@ it('expands Route::match into one route per HTTP verb', function () {
 
 use Illuminate\Support\Facades\Route;
 
+Route::match(['get', 'put'], '/plain', [\App\Http\Controllers\AuthController::class, 'plain']);
+
 Route::prefix('gateway')->middleware(['throttle:api'])->group(function () {
     Route::match(['get', 'post'], '/token', [\App\Http\Controllers\AuthController::class, 'token'])
         ->middleware('log.requests');
@@ -154,10 +156,20 @@ PHP
 
     try {
         $routes = (new RouteAnalyzer(['routes/*/*.php']))->analyze($tmp);
-        expect($routes)->toHaveCount(2);
+        expect($routes)->toHaveCount(4);
 
-        $get = findRoute($routes, fn ($r) => $r->method === 'GET');
-        $post = findRoute($routes, fn ($r) => $r->method === 'POST');
+        // Plain, unchained Route::match([...], $uri, $action) — no group, no post-chain.
+        $plainGet = findRoute($routes, fn ($r) => $r->uri === '/plain' && $r->method === 'GET');
+        $plainPut = findRoute($routes, fn ($r) => $r->uri === '/plain' && $r->method === 'PUT');
+        expect($plainGet)->toBeInstanceOf(RouteDefinition::class)
+            ->controller->toBe('App\Http\Controllers\AuthController')
+            ->action->toBe('plain');
+        expect($plainPut)->toBeInstanceOf(RouteDefinition::class)
+            ->controller->toBe('App\Http\Controllers\AuthController')
+            ->action->toBe('plain');
+
+        $get = findRoute($routes, fn ($r) => $r->uri === '/gateway/token' && $r->method === 'GET');
+        $post = findRoute($routes, fn ($r) => $r->uri === '/gateway/token' && $r->method === 'POST');
 
         expect($get)->toBeInstanceOf(RouteDefinition::class)
             ->uri->toBe('/gateway/token')
@@ -170,6 +182,42 @@ PHP
             ->controller->toBe('App\Http\Controllers\AuthController')
             ->action->toBe('token');
         expect($post->middlewares)->toContain('throttle:api')->toContain('log.requests');
+    } finally {
+        routeAnalyzerTestDeleteTree($tmp);
+    }
+});
+
+it('ignores a Route::match verb written as a class constant instead of a string', function () {
+    $tmp = sys_get_temp_dir().'/lb-route-analyzer-'.uniqid('', true);
+    mkdir($tmp.'/routes/web', 0777, true);
+    file_put_contents(
+        $tmp.'/routes/web/constant-verb.php',
+        <<<'PHP'
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+Route::match([Request::METHOD_GET], '/constant', [\App\Http\Controllers\AuthController::class, 'constant']);
+Route::match(['get', Request::METHOD_POST], '/mixed', [\App\Http\Controllers\AuthController::class, 'mixed']);
+
+PHP
+    );
+
+    try {
+        $routes = (new RouteAnalyzer(['routes/*/*.php']))->analyze($tmp);
+
+        // A verb given only as a class constant can't be resolved to a real HTTP
+        // method, so the whole route is dropped rather than registered under a
+        // bogus "method" (the class's FQCN).
+        expect(findRoute($routes, fn ($r) => $r->uri === '/constant'))->toBeNull();
+
+        // A route mixing a literal verb with a class-constant verb keeps the
+        // verb it could resolve and drops the one it couldn't.
+        $mixed = findRoute($routes, fn ($r) => $r->uri === '/mixed');
+        expect($mixed)->toBeInstanceOf(RouteDefinition::class)
+            ->method->toBe('GET');
+        expect(findRoute($routes, fn ($r) => $r->uri === '/mixed' && $r->method !== 'GET'))->toBeNull();
     } finally {
         routeAnalyzerTestDeleteTree($tmp);
     }


### PR DESCRIPTION
## Summary

`Route::match([...], $uri, $action)` is not in `RouteAnalyzer::HTTP_METHODS` and has no dedicated branch in `enterNode()`, so `brain:scan` silently drops every route declared with it — no route count, no lifecycle/graph entry, no Filament/command chain tracing, nothing.

Fixes #113.

## Change

- Added `handleMatchRoute()`, which reads the methods array (`Route::match`'s first argument), and delegates to `handleHttpRoute()` once per verb.
- Gave `handleHttpRoute()` an `$argOffset` parameter, since `match()`'s URI/action arguments are shifted by one position compared to `get()`/`post()`/etc.
- Wired `match` handling into both the `StaticCall` and `MethodCall` branches of `enterNode()`, alongside the existing `resource`/`apiResource`/`livewire` special-casing.
- Also handled `match` as the base call inside `tryHandlePostChainedRoute()`, so `Route::match([...], '/uri', $action)->middleware(...)` style post-route chaining works too.

## Test plan

- Added a new test (`expands Route::match into one route per HTTP verb`) covering: multiple HTTP verbs, a wrapping `prefix()`/`middleware()` group, and post-chain `->middleware(...)`.
- `vendor/bin/pest tests/Unit/RouteAnalyzerTest.php` — all 26 tests pass.
- `vendor/bin/pest --order-by=random` — full suite passes except 4 pre-existing, unrelated failures in `DatabaseGraphStoreTest` caused by a missing `pdo_sqlite` driver in my local PHP 8.4 build (reproducible on `v2.x` before this change too).
- `vendor/bin/pint --test` on the touched files — passes.
