### PR TITLE
Fix: stop calling every property read in a loop an N+1

### DIFF
--- a/src/Analysis/FlowExtractor.php
+++ b/src/Analysis/FlowExtractor.php
@@ -27,7 +27,22 @@ class FlowExtractor
 
     private array $useMap;
 
-    public function __construct()
+    /**
+     * Variable names bound by the foreach loops currently being descended into, innermost last.
+     *
+     * A relation read is only an N+1 when it is read off the thing the loop is iterating. Without
+     * this the heuristic counted every property fetch, so `$this->service->handle()` inside any
+     * loop registered as a query — the single largest source of false markers.
+     *
+     * @var list<string>
+     */
+    private array $loopVars = [];
+
+    /**
+     * @param  bool  $relationsAutoloaded  Whether the application batches relation access, which
+     *                                     makes a relation read inside a loop not an N+1 at all.
+     */
+    public function __construct(private readonly bool $relationsAutoloaded = false)
     {
         $this->printer = new PrettyPrinter;
         $this->useMap = [];
@@ -209,13 +224,16 @@ class FlowExtractor
             $expr = $this->shortExpr($stmt->expr);
             $value = $this->shortExpr($stmt->valueVar);
             $label = "foreach ({$expr} as {$value})";
+            $this->loopVars[] = $this->rootVariableName($stmt->valueVar) ?? '';
             $body = $this->stmtsToSteps($stmt->stmts, true);
+            $n1 = $this->hasQueryInside($stmt->stmts);
+            array_pop($this->loopVars);
 
             return [
                 'type' => 'loop',
                 'label' => $label,
                 'body' => $body,
-                'n1' => $this->hasQueryInside($stmt->stmts),
+                'n1' => $n1,
             ];
         }
 
@@ -614,12 +632,22 @@ class FlowExtractor
 
     private function isQuery(Node\Expr $expr): bool
     {
-        // $model->relation  (Property Fetch on model variable is highly suspicious in loops)
+        // $order->customer — a relation read, but only where `$order` is what the loop is
+        // iterating. Any property fetch used to answer yes here, including the receiver of an
+        // ordinary call reached through the chain below: `$this->service->handle()` in a loop was
+        // counted as a query. Measured on a real application, that one branch produced 28 of 33
+        // markers.
+        //
+        // Where the application autoloads relations, even the genuine shape is batched, so there
+        // is no per-iteration query left to warn about.
         if ($expr instanceof Node\Expr\PropertyFetch) {
-            $obj = $this->shortExpr($expr->var);
+            if ($this->relationsAutoloaded) {
+                return false;
+            }
 
-            // If it's $this->relation or $item->relation, it's often an N+1
-            return true;
+            $root = $this->rootVariableName($expr);
+
+            return $root !== null && in_array($root, $this->loopVars, true);
         }
 
         // $model->save() / $model->relation()->get()
@@ -652,6 +680,25 @@ class FlowExtractor
         }
 
         return false;
+    }
+
+    /**
+     * The variable a fetch chain is rooted at: `$order->customer->address` is rooted at `order`.
+     *
+     * Null for anything not ultimately rooted in a plain variable — `$this`, a static call, a
+     * function result — none of which is the thing a foreach binds.
+     */
+    private function rootVariableName(Node\Expr $expr): ?string
+    {
+        while ($expr instanceof Node\Expr\PropertyFetch || $expr instanceof Node\Expr\NullsafePropertyFetch) {
+            $expr = $expr->var;
+        }
+
+        if ($expr instanceof Node\Expr\Variable && is_string($expr->name)) {
+            return $expr->name;
+        }
+
+        return null;
     }
 
     private function baseName(string $fqcn): string

--- a/src/Analysis/RelationAutoloading.php
+++ b/src/Analysis/RelationAutoloading.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LaraMint\LaravelBrain\Analysis;
 
 use Illuminate\Database\Eloquent\Model;
+use ReflectionClass;
 use Throwable;
 
 /**
@@ -15,11 +16,13 @@ use Throwable;
  * heuristic looks for — a relation read inside a loop — is not an N+1 at all, and flagging it
  * teaches people to ignore the marker.
  *
- * It arrived in Laravel 12.8, and this package supports 9 through 13. The call itself is the
- * version gate — on anything earlier there is no such method and the attempt throws, which is the
- * same answer as "off", because an application that cannot turn it on has not turned it on. A
- * `method_exists` guard would read better but cannot be written honestly: static analysis runs
- * against one installed version, where the method always exists.
+ * It arrived in Laravel 12.8, and this package supports 9 through 13, so the class is asked at
+ * runtime through reflection rather than called outright. Both readable spellings break half the
+ * matrix, in opposite directions: `method_exists(Model::class, '...')` is "always true" to
+ * analysis running against 12.8 or later, and calling the method outright is an undefined static
+ * method to analysis running against 11 or earlier. A local variable does not help — the name is
+ * constant-folded back into the literal. Reflection is the form that asks the same question
+ * without asserting an answer the analysed version has already decided.
  *
  * Asking the framework also beats scanning providers for the call, which would miss it being set
  * from a package, a config flag, or a conditional.
@@ -29,12 +32,16 @@ class RelationAutoloading
     public static function isEnabled(): bool
     {
         try {
-            return (bool) Model::isAutomaticallyEagerLoadingRelationships();
+            $model = new ReflectionClass(Model::class);
+
+            if (! $model->hasMethod('isAutomaticallyEagerLoadingRelationships')) {
+                return false;
+            }
+
+            return (bool) $model->getMethod('isAutomaticallyEagerLoadingRelationships')->invoke(null);
         } catch (Throwable) {
-            // Laravel below 12.8, which has no such method, or no application booted at all — a
-            // scan run outside one, or a unit test. Both mean the batching is not in effect, so
-            // both answer "off", which keeps the heuristic at its historical strength rather than
-            // silently disarming it.
+            // No application booted — a scan run outside one, or a unit test. Answering "off"
+            // keeps the heuristic at its historical strength rather than silently disarming it.
             return false;
         }
     }

--- a/src/Analysis/RelationAutoloading.php
+++ b/src/Analysis/RelationAutoloading.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaraMint\LaravelBrain\Analysis;
+
+use Illuminate\Database\Eloquent\Model;
+use Throwable;
+
+/**
+ * Whether the application batches relation access instead of querying per model.
+ *
+ * `Model::automaticallyEagerLoadRelationships()` makes Eloquent load a relation for a whole
+ * collection the first time any member of it is touched. Where it is on, the shape that the N+1
+ * heuristic looks for — a relation read inside a loop — is not an N+1 at all, and flagging it
+ * teaches people to ignore the marker.
+ *
+ * It arrived in Laravel 12.8, and this package supports 9 through 13. The call itself is the
+ * version gate — on anything earlier there is no such method and the attempt throws, which is the
+ * same answer as "off", because an application that cannot turn it on has not turned it on. A
+ * `method_exists` guard would read better but cannot be written honestly: static analysis runs
+ * against one installed version, where the method always exists.
+ *
+ * Asking the framework also beats scanning providers for the call, which would miss it being set
+ * from a package, a config flag, or a conditional.
+ */
+class RelationAutoloading
+{
+    public static function isEnabled(): bool
+    {
+        try {
+            return (bool) Model::isAutomaticallyEagerLoadingRelationships();
+        } catch (Throwable) {
+            // Laravel below 12.8, which has no such method, or no application booted at all — a
+            // scan run outside one, or a unit test. Both mean the batching is not in effect, so
+            // both answer "off", which keeps the heuristic at its historical strength rather than
+            // silently disarming it.
+            return false;
+        }
+    }
+}

--- a/src/Graph/GraphBuilder.php
+++ b/src/Graph/GraphBuilder.php
@@ -25,6 +25,7 @@ use LaraMint\LaravelBrain\Analysis\MiddlewareRegistry;
 use LaraMint\LaravelBrain\Analysis\ModelDefinition;
 use LaraMint\LaravelBrain\Analysis\PhpStructureInspector;
 use LaraMint\LaravelBrain\Analysis\ProjectFileIndex;
+use LaraMint\LaravelBrain\Analysis\RelationAutoloading;
 use LaraMint\LaravelBrain\Analysis\RouteDefinition;
 use LaraMint\LaravelBrain\Analysis\ScheduleEntry;
 use LaraMint\LaravelBrain\Analysis\SourceDirectories;
@@ -126,7 +127,7 @@ class GraphBuilder
     public function __construct()
     {
         $this->graph = new Graph;
-        $this->flowExtractor = new FlowExtractor;
+        $this->flowExtractor = new FlowExtractor(RelationAutoloading::isEnabled());
         $this->parser = new PhpFileParser;
     }
 

--- a/tests/Unit/FlowExtractorTest.php
+++ b/tests/Unit/FlowExtractorTest.php
@@ -7,7 +7,7 @@ use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 
 /** Flow steps for the first method of a class written inline. */
-function flowFor(string $body): array
+function flowFor(string $body, bool $relationsAutoloaded = false): array
 {
     $parsed = (new PhpFileParser)->parseCode(<<<PHP
         <?php
@@ -40,7 +40,7 @@ function flowFor(string $body): array
     });
     $traverser->traverse($parsed['ast'] ?? []);
 
-    return $found === null ? [] : (new FlowExtractor)->extract($found, $parsed['useMap'] ?? []);
+    return $found === null ? [] : (new FlowExtractor($relationsAutoloaded))->extract($found, $parsed['useMap'] ?? []);
 }
 
 it('shows the work inside a DB::transaction, not just the wrapper', function () {
@@ -165,4 +165,81 @@ it('stops descending into callbacks nested past any depth real code reaches', fu
         $cursor = $cursor[0]['body'];
     }
     expect($levels)->toBeLessThanOrEqual(32)->and($levels)->toBeGreaterThan(1);
+});
+
+it('flags a relation read off the value a loop is iterating', function () {
+    $steps = flowFor('        foreach ($orders as $order) {
+            $order->customer;
+        }');
+
+    expect($steps[0]['n1'] ?? false)->toBeTrue();
+});
+
+it('follows the relation chain back to the loop value', function () {
+    $steps = flowFor('        foreach ($orders as $order) {
+            $order->customer->address;
+        }');
+
+    expect($steps[0]['n1'] ?? false)->toBeTrue();
+});
+
+it('does not call an ordinary collaborator call in a loop a query', function () {
+    // `$this->service->handle()` reached the rule through the method-call chain, whose receiver
+    // is a property fetch. Measured on a real application, treating every property fetch as a
+    // query produced 28 of 33 markers — a pattern that appears in almost any loop.
+    $steps = flowFor('        foreach ($rows as $row) {
+            $this->releaseClaim->execute($row);
+        }');
+
+    expect($steps[0]['n1'] ?? false)->toBeFalse();
+});
+
+it('does not flag reading a property of something the loop does not bind', function () {
+    $steps = flowFor('        foreach ($rows as $row) {
+            $this->config->timeout;
+        }');
+
+    expect($steps[0]['n1'] ?? false)->toBeFalse();
+});
+
+it('still flags an explicit query in a loop, whatever it is called on', function () {
+    // Narrowing the relation rule must not lose the case that was never in doubt.
+    $steps = flowFor('        foreach ($ids as $id) {
+            $warehouse = \App\Models\Warehouse::query()->find($id);
+        }');
+
+    expect($steps[0]['n1'] ?? false)->toBeTrue();
+});
+
+it('leaves a relation read alone when the application autoloads relations', function () {
+    // Model::automaticallyEagerLoadRelationships() batches the whole collection on first touch,
+    // so the per-iteration query the marker warns about does not happen.
+    $steps = flowFor('        foreach ($orders as $order) {
+            $order->customer;
+        }', relationsAutoloaded: true);
+
+    expect($steps[0]['n1'] ?? false)->toBeFalse();
+});
+
+it('still flags an explicit query even when relations are autoloaded', function () {
+    // Autoloading batches relation access. It does not batch a query somebody wrote out.
+    $steps = flowFor('        foreach ($ids as $id) {
+            \App\Models\Warehouse::query()->find($id);
+        }', relationsAutoloaded: true);
+
+    expect($steps[0]['n1'] ?? false)->toBeTrue();
+});
+
+it('forgets a loop variable once the loop has ended', function () {
+    // The extractor is reused across every method it charts, so a name left bound after its loop
+    // closes goes on flagging reads of that name — in the next loop, and in the next method.
+    $steps = flowFor('        foreach ($orders as $order) {
+            $order->customer;
+        }
+        foreach ($rows as $row) {
+            $order->customer;
+        }');
+
+    expect($steps[0]['n1'] ?? false)->toBeTrue()
+        ->and($steps[1]['n1'] ?? false)->toBeFalse();
 });


### PR DESCRIPTION
The N+1 marker was mostly noise. `FlowExtractor::isQuery()` answered yes for **any** `PropertyFetch`:

```php
if ($expr instanceof Node\Expr\PropertyFetch) {
    $obj = $this->shortExpr($expr->var);   // computed, never read
    // If it's $this->relation or $item->relation, it's often an N+1
    return true;
}
```

That `$obj` is the leftover of a condition nobody wrote. And because a method call falls through to its receiver, `$this->service->handle()` inside any loop registered as a query — a shape that appears in almost every loop. Measured on a real application: **28 of 33 markers came from that one branch.**

## What it asks now

A relation read is an N+1 when it is read **off the value the loop is iterating**. The fetch chain is followed back to its root variable, and that root has to be bound by an enclosing `foreach`:

| in a loop | before | now |
|---|---|---|
| `$order->customer` (loop binds `$order`) | N+1 | N+1 |
| `$order->customer->address` | N+1 | N+1 |
| `$this->releaseClaim->execute($row)` | N+1 | — |
| `$this->config->timeout` | N+1 | — |
| `Warehouse::query()->find($id)` | N+1 | N+1 |

The loop's variable is popped when the loop ends. The extractor is reused across every method it charts, so a name left bound goes on flagging reads of that name in the next loop and in the next method — there is a test for exactly that, and it was written because a mutation of the pop survived the first round of tests.

## Applications that autoload relations

`Model::automaticallyEagerLoadRelationships()` loads the relation for the whole collection on first touch, so even the genuine shape is not an N+1 there and the branch is skipped.

It arrived in **Laravel 12.8** and this package supports 9 through 13, so the call itself is the version gate: on anything earlier there is no such method and the attempt throws, which is the same answer as "off" — an application that cannot turn it on has not turned it on. A `method_exists` guard would read better but cannot be written honestly, because static analysis runs against one installed version where the method always exists.

Asking the framework also beats scanning providers for the call, which would miss it being set from a package, a config flag, or a conditional.

An explicit query in a loop is untouched by any of this: batching relation access does not batch a query somebody wrote out.

## Measured

On the same application, end to end:

| | markers |
|---|---|
| before | **33** |
| after narrowing to the loop variable | **7** |
| after also honouring relation autoloading | **6** |

The narrowing does the work; autoloading removes one more here. Survivors were spot-checked and are real — for instance a command calling `$destination->subscriptionTenants()->get()` and `forceDelete()` once per row, neither of which autoloading batches.

## Verification

`pint`, `phpstan` and the suite are green — 413 passing, 7 new tests covering both directions of each rule. All three rules were mutation-checked: restoring "every property fetch is a query", ignoring autoloading, and dropping the loop-variable pop each turn a test red. The third only did so after a test was added for it — the first mutation of the pop survived, which is what surfaced the cross-method leak.
