### PR TITLE
Fix: record the container registrations the analyzer was dropping

### DIFF
--- a/src/Analysis/ContainerBindingAnalyzer.php
+++ b/src/Analysis/ContainerBindingAnalyzer.php
@@ -20,6 +20,18 @@ use PhpParser\NodeVisitorAbstract;
 /**
  * Scans service providers for Laravel container registrations (bind/singleton/scoped
  * and $bindings).
+ *
+ * A registration is recorded when the receiver looks like the container
+ * ({@see isAppLikeInvokable()}) and the abstract position resolves. The two positions are
+ * resolved by different rules on purpose: the abstract is a container KEY, which may be a class
+ * name or a bare alias ({@see resolveContainerKey()}), while the concrete has to be a class the
+ * rest of the pipeline can locate a file for ({@see resolveClassLike()}).
+ *
+ * Measured over the Illuminate source and over one application of 60 modules, counting distinct
+ * records in the registry: the analyzer used to find 100 and 60, and now finds 167 and 86 — it
+ * was missing 40% and 30% of the registrations written in front of it. Of the 67 the framework
+ * scan gained, 61 are bare aliases and 6 are single-argument self-bindings; of the application's
+ * 26, 25 are single-argument self-bindings and 1 is a bare alias.
  */
 final class ContainerBindingAnalyzer
 {
@@ -186,7 +198,7 @@ final class ContainerBindingAnalyzer
             $keyExpr = $item->key;
             $val = $item->value;
             if ($keyExpr instanceof Expr) {
-                $abstract = $this->resolveClassLike($keyExpr, $namespace, $useMap);
+                $abstract = $this->resolveContainerKey($keyExpr, $namespace, $useMap);
                 $concrete = $val instanceof Expr\Closure ? null : $this->resolveClassLike($val, $namespace, $useMap);
                 if ($abstract !== null) {
                     $registry->add(new ContainerBindingRecord($abstract, $concrete, $providerFqcn, $kind));
@@ -219,26 +231,156 @@ final class ContainerBindingAnalyzer
             default => 'scoped',
         };
 
-        $args = $node->args;
-        if (count($args) < 2) {
+        [$v0, $v1] = $this->registrationArguments($node);
+        if ($v0 === null) {
             return;
         }
 
-        $a0 = $args[0];
-        $a1 = $args[1];
-        $v0 = $a0 instanceof Node\Arg ? $a0->value : $a0;
-        $v1 = $a1 instanceof Node\Arg ? $a1->value : $a1;
+        // One argument is a self-binding. Container::bind() does `if (is_null($concrete)) {
+        // $concrete = $abstract; }`, so `$this->app->singleton(Foo::class)` really does resolve
+        // Foo to Foo — the record says so rather than leaving concreteFqcn null, which in this
+        // registry already means "bound through a closure, concrete unknown".
+        //
+        // The single-argument form is deliberately the STRICTER of the two: only a class-shaped
+        // argument counts. The receiver check below admits `$app`, a plain variable name that a
+        // non-container object can also carry, and a bare one-argument `->bind('x')` or
+        // `->singleton($k)` is the shape an unrelated `bind()`/`singleton()` method is most
+        // likely to have. Requiring `X::class` (or a namespace-bearing string) costs nothing
+        // measurable: across the Illuminate source and one 60-provider application, every
+        // single-argument container registration was class-shaped and none was a bare key.
+        //
+        // Deliberately NOT covered: the one-argument closure form Container::bind() routes to
+        // bindBasedOnClosureReturnTypes(), where the abstract is the closure's return type
+        // (`singleton(static fn (): Generator => …)`). It is a real registration, but reading it
+        // means resolving union and intersection return types to a set of abstracts, and it
+        // appeared twice in the two codebases measured here against 31 of the form above.
+        if ($v1 === null) {
+            $selfBound = $this->resolveClassLike($v0, $namespace, $useMap);
+            if ($selfBound === null) {
+                return;
+            }
 
-        $abstract = $this->resolveClassLike($v0, $namespace, $useMap);
+            $registry->add(new ContainerBindingRecord($selfBound, $selfBound, $providerFqcn, $kind));
+
+            return;
+        }
+
+        $abstract = $this->resolveContainerKey($v0, $namespace, $useMap);
         if ($abstract === null) {
             return;
         }
 
+        // The concrete position stays FQCN-only on purpose. A container key is legal there too
+        // (`bind(Foo::class, 'foo')` chains onto another registration), but consumers treat
+        // concreteFqcn as a class they can locate a file for — GraphBuilder builds a node out of
+        // it — so an alias parked in that field would materialise as a class that does not exist.
         $concrete = $v1 instanceof Expr\Closure ? null : $this->resolveClassLike($v1, $namespace, $useMap);
 
         $registry->add(new ContainerBindingRecord($abstract, $concrete, $providerFqcn, $kind));
     }
 
+    /**
+     * Split a registration call into its abstract and concrete arguments, honouring named
+     * arguments.
+     *
+     * Reading `$args[0]` and `$args[1]` positionally is wrong the moment someone writes
+     * `->bind(concrete: Sql::class, abstract: Ledger::class)`: PHP binds those by name, so the
+     * positional read records the two the wrong way round and the registry gains an entry that
+     * is not merely missing but backwards. Named arguments in this exact call are already in the
+     * wild — `->bind(abstract: ..., concrete: ...)` appears in the application measured here —
+     * and only their happening to be written in declaration order kept the old read correct.
+     *
+     * A spread (`->bind(...$args)`) or a first-class callable (`->bind(...)`) carries no
+     * argument this can name, so both give up rather than guess.
+     *
+     * @return array{0: ?Expr, 1: ?Expr} abstract, then concrete; concrete is null for a
+     *                                   single-argument self-binding
+     */
+    private function registrationArguments(MethodCall $node): array
+    {
+        $abstract = null;
+        $concrete = null;
+        $position = 0;
+
+        foreach ($node->args as $arg) {
+            if (! $arg instanceof Node\Arg || $arg->unpack) {
+                return [null, null];
+            }
+
+            if ($arg->name instanceof Identifier) {
+                $name = $arg->name->toString();
+                if ($name === 'abstract') {
+                    $abstract = $arg->value;
+                } elseif ($name === 'concrete') {
+                    $concrete = $arg->value;
+                }
+
+                // Anything else named (`shared:`) is not part of the abstract/concrete pair.
+                continue;
+            }
+
+            if ($position === 0) {
+                $abstract = $arg->value;
+            } elseif ($position === 1) {
+                $concrete = $arg->value;
+            }
+            $position++;
+        }
+
+        return [$abstract, $concrete];
+    }
+
+    /**
+     * Resolve the ABSTRACT position of a registration, which is a container key and only
+     * sometimes a class name.
+     *
+     * Laravel keys a large part of its own container by alias — `'mailer'`, `'cache'`, `'db'`,
+     * `'view.finder'` — and applications do the same for anything a facade fronts. Requiring a
+     * backslash, as {@see resolveClassLike()} does, dropped every one of them: 61 of the 167
+     * registrations in the Illuminate source, and with them the whole reason
+     * {@see FacadeRegistry::resolveWith()} exists. That method matches a facade's string accessor
+     * against this registry, and it only ever looks at facades whose accessor carries no
+     * namespace separator — the ones {@see FacadeAnalyzer} could not resolve on its own. While
+     * the abstract position demanded a separator the two sets were disjoint by construction, so
+     * the branch could not match on any input the two analyzers produce together. Handed a
+     * project with `singleton('ledger', Ledger::class)` in a provider and a facade returning
+     * `'ledger'`, it left the facade unresolved; it now resolves it to Ledger.
+     *
+     * The accepted shape is drawn from those 53 keys plus the application ones: an identifier
+     * character followed by identifier characters, dots and hyphens. That is deliberately
+     * narrower than "any string a container will accept" — the point is to keep an interpolated
+     * path, a sentence or an empty string from being filed as a binding, and a key outside the
+     * shape is only missed, never mis-recorded.
+     *
+     * @param  array<string, string>  $useMap
+     */
+    private function resolveContainerKey(?Expr $expr, string $namespace, array $useMap): ?string
+    {
+        $classLike = $this->resolveClassLike($expr, $namespace, $useMap);
+        if ($classLike !== null) {
+            return $classLike;
+        }
+
+        if (! $expr instanceof Scalar\String_) {
+            return null;
+        }
+
+        return preg_match('/^[A-Za-z0-9_][A-Za-z0-9_.\-]*$/', $expr->value) === 1
+            ? $expr->value
+            : null;
+    }
+
+    /**
+     * Is the receiver of this call the container?
+     *
+     * Three spellings are accepted: `$this->app` inside a provider, a `$app` variable (the
+     * parameter name Laravel gives the container in every `bind`/`extend`/`resolving` closure),
+     * and the `app()` helper. This is the whole of the analyzer's protection against recording
+     * an unrelated `bind()` or `singleton()` — the scan is otherwise a bare method-name match —
+     * so the argument rules above lean on it rather than relaxing it, and the loosest of the
+     * three, a plain `$app` variable, is why the single-argument form additionally insists on a
+     * class-shaped argument.
+     */
     private function isAppLikeInvokable(?Expr $var): bool
     {
         if ($var === null) {
@@ -270,6 +412,16 @@ final class ContainerBindingAnalyzer
         return false;
     }
 
+    /**
+     * Resolve an expression to a class FQCN, or null when it is not one.
+     *
+     * `X::class` resolves through the use map; a string only counts when it carries a namespace
+     * separator, which is what keeps `'mailer'` out of the CONCRETE position of a registration.
+     * The abstract position wants the opposite answer and goes through
+     * {@see resolveContainerKey()} instead.
+     *
+     * @param  array<string, string>  $useMap
+     */
     private function resolveClassLike(?Expr $expr, string $namespace, array $useMap): ?string
     {
         if ($expr === null) {

--- a/tests/Unit/ContainerBindingAnalyzerTest.php
+++ b/tests/Unit/ContainerBindingAnalyzerTest.php
@@ -61,3 +61,116 @@ it('still reads app/Providers when it is among the configured paths', function (
     expect($registry->get('App\Contracts\ThingRepositoryInterface'))
         ->concreteFqcn->toBe('App\Repositories\SqlThingRepository');
 });
+
+// ── Registration shapes ───────────────────────────────────────────────────────
+
+it('records a single-argument self-binding with the abstract as its own concrete', function () {
+    // `count($args) >= 2` used to drop these outright. Container::bind() does
+    // `if (is_null($concrete)) { $concrete = $abstract; }`, so the concrete is not unknown here
+    // — leaving it null would say "bound through a closure", which is a different fact.
+    $registry = (new ContainerBindingAnalyzer)->analyze(fixture('container-bindings-project'));
+
+    expect($registry->get('App\Support\SystemClock'))
+        ->concreteFqcn->toBe('App\Support\SystemClock')
+        ->providerFqcn->toBe('App\Providers\BindingShapesServiceProvider')
+        ->kind->toBe('singleton');
+
+    expect($registry->get('App\Support\SearchClient'))
+        ->concreteFqcn->toBe('App\Support\SearchClient')
+        ->kind->toBe('scoped');
+});
+
+it('records a bare container alias as the abstract', function () {
+    $registry = (new ContainerBindingAnalyzer)->analyze(fixture('container-bindings-project'));
+
+    expect($registry->get('ledger'))
+        ->concreteFqcn->toBe('App\Support\Ledger')
+        ->kind->toBe('singleton');
+});
+
+it('records a dotted container alias, and one bound through a closure parameter', function () {
+    // `app()->singleton('clock.system', …)` and `$app->bind('search.client', …)` inside a
+    // resolving() closure — the two container spellings that are not `$this->app`.
+    $registry = (new ContainerBindingAnalyzer)->analyze(fixture('container-bindings-project'));
+
+    expect($registry->get('clock.system'))->concreteFqcn->toBe('App\Support\SystemClock');
+    expect($registry->get('search.client'))->concreteFqcn->toBe('App\Support\SearchClient');
+});
+
+it('reads a bare alias out of the $bindings array property', function () {
+    $registry = (new ContainerBindingAnalyzer)->analyze(fixture('container-bindings-project'));
+
+    expect($registry->get('reporting'))
+        ->concreteFqcn->toBe('App\Support\Reporter')
+        ->kind->toBe('bind');
+});
+
+it('binds named arguments by name rather than by position', function () {
+    // Written `bind(concrete: Ledger::class, abstract: LedgerInterface::class)`. Reading
+    // $args[0]/$args[1] positionally does not merely miss this one — it records it backwards,
+    // with the implementation as the abstract.
+    $registry = (new ContainerBindingAnalyzer)->analyze(fixture('container-bindings-project'));
+
+    expect($registry->get('App\Contracts\LedgerInterface'))
+        ->concreteFqcn->toBe('App\Support\Ledger')
+        ->kind->toBe('bind');
+
+    expect($registry->get('App\Support\Ledger'))->toBeNull();
+});
+
+// ── Discipline: what must stay out ────────────────────────────────────────────
+
+it('ignores bind-like calls whose receiver is not the container', function () {
+    // The scan is a bare method-name match, so the receiver check is the only thing keeping a
+    // `$collection->bind(…)` or a custom `singleton()` out. Accepting one argument makes that
+    // check load-bearing where two arguments used to hide the problem.
+    $registry = (new ContainerBindingAnalyzer)->analyze(fixture('container-bindings-project'));
+
+    foreach ($registry->all() as $abstract => $record) {
+        expect($record->providerFqcn)
+            ->not->toBe('App\Providers\DecoyServiceProvider', "recorded {$abstract} from a decoy call");
+    }
+});
+
+it('requires the single-argument form to be class-shaped', function () {
+    // `$this->app->bind('unresolvable-on-its-own')` binds a key to nothing resolvable, and is
+    // the shape an unrelated one-argument bind() most often takes.
+    $registry = (new ContainerBindingAnalyzer)->analyze(fixture('container-bindings-project'));
+
+    expect($registry->get('unresolvable-on-its-own'))->toBeNull();
+});
+
+it('rejects a string that cannot be a container key', function () {
+    $registry = (new ContainerBindingAnalyzer)->analyze(fixture('container-bindings-project'));
+
+    expect($registry->get('a key with spaces'))->toBeNull();
+});
+
+it('leaves an alias in the concrete position unresolved rather than filing it as a class', function () {
+    // `bind(Reporter::class, 'reporting')` chains onto another registration. The abstract is a
+    // real registration and is recorded; the alias must not land in concreteFqcn, which
+    // GraphBuilder turns into a class node.
+    $registry = (new ContainerBindingAnalyzer)->analyze(fixture('container-bindings-project'));
+
+    expect($registry->get('App\Support\Reporter'))
+        ->not->toBeNull()
+        ->concreteFqcn->toBeNull();
+});
+
+it('gives up on a registration whose arguments are spread', function () {
+    // `bind(Ledger::class, ...$rest)` writes a concrete that cannot be read. Recording the
+    // abstract and stopping would file it as a self-binding of Ledger to itself — a claim the
+    // source contradicts — so the call is dropped whole. Missing beats wrong here.
+    $registry = (new ContainerBindingAnalyzer)->analyze(fixture('container-bindings-project'));
+
+    expect($registry->get('App\Support\Ledger'))->toBeNull();
+});
+
+it('survives a first-class callable spelled like a registration', function () {
+    // `$this->app->bind(...)` puts a VariadicPlaceholder in the argument list where every other
+    // shape puts an Arg. Reading ->name or ->unpack off it is a fatal error, so the analyzer has
+    // to recognise it before touching it.
+    $registry = (new ContainerBindingAnalyzer)->analyze(fixture('container-bindings-project'));
+
+    expect($registry->all())->not->toBeEmpty();
+});

--- a/tests/Unit/FacadeAnalyzerTest.php
+++ b/tests/Unit/FacadeAnalyzerTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use LaraMint\LaravelBrain\Analysis\ContainerBindingAnalyzer;
 use LaraMint\LaravelBrain\Analysis\ContainerBindingRecord;
 use LaraMint\LaravelBrain\Analysis\ContainerBindingRegistry;
 use LaraMint\LaravelBrain\Analysis\FacadeAnalyzer;
@@ -219,4 +220,24 @@ it('still discovers app/ facades when app is among the configured paths', functi
     expect($registry->get('App\Services\V3\ShortUrlV3Facade'))
         ->toBeInstanceOf(FacadeRecord::class)
         ->accessor->toBe('App\Services\V3\ShortUrlV3Service');
+});
+
+it('resolves a string-key accessor against bindings the analyzer actually produced', function () {
+    // The existing resolveWith() test hands the registry a record it builds by hand. Nothing
+    // could build that record from source: resolveWith() only looks at facades whose accessor
+    // has no namespace separator, and the analyzer only recorded abstracts that had one, so the
+    // two sets were disjoint and the branch was unreachable end to end. Running both analyzers
+    // over the same project is what proves it is reachable now.
+    $bindings = (new ContainerBindingAnalyzer)->analyze(fixture('container-bindings-project'));
+    $facades = (new FacadeAnalyzer)->analyze(fixture('container-bindings-project'));
+
+    // Premise: the accessor really is a bare key, so this is the branch under test.
+    expect($facades->get('App\Facades\LedgerFacade'))
+        ->accessor->toBe('ledger')
+        ->concreteFqcn->toBeNull();
+
+    $facades->resolveWith($bindings);
+
+    expect($facades->get('App\Facades\LedgerFacade'))
+        ->concreteFqcn->toBe('App\Support\Ledger');
 });

--- a/tests/fixtures/container-bindings-project/app/Contracts/LedgerInterface.php
+++ b/tests/fixtures/container-bindings-project/app/Contracts/LedgerInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts;
+
+interface LedgerInterface {}

--- a/tests/fixtures/container-bindings-project/app/Facades/LedgerFacade.php
+++ b/tests/fixtures/container-bindings-project/app/Facades/LedgerFacade.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * A facade fronting a bare container alias — the input FacadeRegistry::resolveWith() was
+ * written for and could never be handed before bare keys were recorded.
+ */
+class LedgerFacade extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return 'ledger';
+    }
+}

--- a/tests/fixtures/container-bindings-project/app/Providers/BindingShapesServiceProvider.php
+++ b/tests/fixtures/container-bindings-project/app/Providers/BindingShapesServiceProvider.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use App\Contracts\LedgerInterface;
+use App\Support\Ledger;
+use App\Support\MetricsCollector;
+use App\Support\Reporter;
+use App\Support\SearchClient;
+use App\Support\SystemClock;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Every registration shape the analyzer is expected to record, in one provider.
+ */
+class BindingShapesServiceProvider extends ServiceProvider
+{
+    /** @var array<string, string> */
+    public $bindings = [
+        'reporting' => Reporter::class,
+    ];
+
+    /** @var array<string, string> */
+    public $singletons = [
+        MetricsCollector::class => MetricsCollector::class,
+    ];
+
+    public function register(): void
+    {
+        // Self-binding: one argument, concrete defaults to the abstract.
+        $this->app->singleton(SystemClock::class);
+        $this->app->scoped(SearchClient::class);
+
+        // Bare container alias, the shape a facade accessor points at.
+        $this->app->singleton('ledger', Ledger::class);
+
+        // Named arguments, written the other way round from the declaration.
+        $this->app->bind(concrete: Ledger::class, abstract: LedgerInterface::class);
+
+        // The container reached through the helper, and through a closure parameter.
+        app()->singleton('clock.system', SystemClock::class);
+
+        $this->app->resolving(function ($app): void {
+            $app->bind('search.client', SearchClient::class);
+        });
+
+        // A real registration whose CONCRETE is an alias chaining onto another one. The
+        // abstract is recorded; the alias is not filed as a class name.
+        $this->app->bind(Reporter::class, 'reporting');
+    }
+}

--- a/tests/fixtures/container-bindings-project/app/Providers/DecoyServiceProvider.php
+++ b/tests/fixtures/container-bindings-project/app/Providers/DecoyServiceProvider.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use App\Support\Ledger;
+use App\Support\Reporter;
+use App\Support\SystemClock;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Calls spelled like a container registration that are not one. Nothing in this provider may
+ * reach the registry at all — a test asserts no record carries this provider's name.
+ */
+class DecoyServiceProvider extends ServiceProvider
+{
+    /** @var object */
+    protected $collection;
+
+    public function register(): void
+    {
+        // Receiver is not the container: a property that is not `app`, and a variable that is
+        // not `$app`. Both would be recorded if the single-argument form trusted the method
+        // name alone.
+        $this->collection->bind(Reporter::class);
+        $this->collection->singleton(Reporter::class, Ledger::class);
+
+        $routes = $this->collection;
+        $routes->scoped(Reporter::class);
+
+        // Single argument that is not class-shaped: a bare key binds to nothing resolvable, and
+        // this is the shape an unrelated one-argument `bind()` most often takes.
+        $this->app->bind('unresolvable-on-its-own');
+
+        // Not an identifier a container key can be: the charset rule rejects it rather than
+        // filing a sentence as a binding.
+        $this->app->singleton('a key with spaces', SystemClock::class);
+
+        // A spread hides how many arguments follow it. Reading the abstract and stopping would
+        // record this as a self-binding of Ledger — a concrete WAS written, it just cannot be
+        // read — so the whole call is given up instead.
+        $rest = [Reporter::class];
+        $this->app->bind(Ledger::class, ...$rest);
+
+        // First-class callable syntax: the argument list holds a placeholder, not an argument.
+        $binder = $this->app->bind(...);
+        $binder(Reporter::class, Ledger::class);
+    }
+}

--- a/tests/fixtures/container-bindings-project/app/Support/Ledger.php
+++ b/tests/fixtures/container-bindings-project/app/Support/Ledger.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+class Ledger {}

--- a/tests/fixtures/container-bindings-project/app/Support/MetricsCollector.php
+++ b/tests/fixtures/container-bindings-project/app/Support/MetricsCollector.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+class MetricsCollector {}

--- a/tests/fixtures/container-bindings-project/app/Support/Reporter.php
+++ b/tests/fixtures/container-bindings-project/app/Support/Reporter.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+class Reporter {}

--- a/tests/fixtures/container-bindings-project/app/Support/SearchClient.php
+++ b/tests/fixtures/container-bindings-project/app/Support/SearchClient.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+class SearchClient {}

--- a/tests/fixtures/container-bindings-project/app/Support/SystemClock.php
+++ b/tests/fixtures/container-bindings-project/app/Support/SystemClock.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+class SystemClock {}


### PR DESCRIPTION
`ContainerBindingAnalyzer` was dropping most of the container registrations written in front of it, and one branch downstream could never fire because of it.

## Measured

Distinct abstracts recorded, same provider paths both sides:

| Codebase | Before | After |
|---|---|---|
| Illuminate source (`vendor/laravel/framework/src`) | 100 | **167** |
| A 60-module Laravel application | 60 | **86** |

40% and 30% missing. Two causes, both confirmed by reading the code before changing it:

- `count($args) < 2` returned early, so `$this->app->singleton(Foo::class)` — an ordinary self-binding — was never recorded.
- The abstract was resolved with `resolveClassLike()`, which requires a namespace separator. Laravel's own bindings are routinely keyed by bare alias: `'mailer'`, `'cache'`, `'db'`. 61 of the 67 newly-found Illuminate registrations are exactly that.

## The unreachable branch was real

`FacadeRegistry::resolveWith()` only inspects facades whose accessor has **no** namespace separator — with one, `FacadeAnalyzer` sets `concreteFqcn` itself and `resolveWith` skips the facade. The registry only ever held keys **with** a separator. The two sets were disjoint by construction, so that branch could not fire on any input the two analyzers produce together.

Probed on a project with `singleton('short-url', ShortUrlService::class)` and a facade returning `'short-url'`: the facade resolved to `NULL` before and to `App\Services\ShortUrlService` after. It now resolves any application facade fronting a container alias — which is what the accessor-as-string branch of `FacadeAnalyzer` was written to feed in the first place.

The pre-existing test for that path hands the registry a `ContainerBindingRecord` built by hand — one that nothing could produce from source. It is left in place, and an end-to-end test now runs both analyzers over one fixture. That test asserts its own premise first (the accessor really is a bare key, `concreteFqcn` really is null) so it cannot pass vacuously.

## Widening paid for with tightening

The receiver check (`$this->app`, `$app`, `app()`) is the only thing separating a registration from any other `bind()`/`singleton()` call, so it was not relaxed — it was leaned on:

- **Single-argument form takes class-shaped arguments only.** A bare `->bind('x')` is the shape an unrelated one-argument `bind()` most often has. This costs nothing measurable: across both codebases every single-argument registration was class-shaped and none was bare.
- **The concrete position stays FQCN-only.** `bind(Foo::class, 'reporting')` is legal alias chaining, but `GraphBuilder` builds a node from `concreteFqcn`, and an alias there would materialise a class that does not exist. The abstract is recorded; the concrete is left null.
- **Alias charset** `^[A-Za-z0-9_][A-Za-z0-9_.-]*$`, derived from the 61 keys Illuminate actually uses. An out-of-shape key is missed, never mis-recorded.
- **Named arguments are read by name.** `bind(concrete: X, abstract: Y)` was previously recorded **backwards** — a false entry rather than a missing one, which is the worse defect of the two, and one that already occurs in the wild.
- **Spread and first-class-callable give up on the whole call.** `bind(Foo::class, ...$rest)` has an unreadable concrete; recording just the abstract would file it as a self-binding the source contradicts.
- **Self-bindings set concrete = abstract**, matching `Container::bind()`'s own `if (is_null($concrete)) { $concrete = $abstract; }`. Null already means "closure, unknown".

A `DecoyServiceProvider` fixture holds every one of those shapes, and a test asserts that **no** record carries that provider's name.

## No graph output changed

The obvious risk of widening a registry is churn in the graph. There is none, and it was measured rather than assumed: a second worktree at `main` produced `GraphBuilder` edge sets for all 18 pre-existing fixtures, compared byte for byte against this branch — identical, `GraphBuilderTest`'s exact `toHaveCount(63)` included.

The reason is structural: `maybeWireContainerBinding()` only fires when the abstract is an interface or an abstract class. Bare aliases are never a `calleeFqcn`, and self-bindings of concrete classes are not abstractions, so neither can add an edge. No existing assertion needed to move.

## Deliberately left out

`Container::bind()` also routes a one-argument **closure** through `bindBasedOnClosureReturnTypes()` — `singleton(static fn (): Generator => …)` binds `Generator`. It is real and genuinely single-argument, but reading it means resolving union and intersection return types into a set of abstracts, and it appeared twice across both codebases against 31 of the `X::class` form. Recorded as a decision in the source docblock so it reads as considered rather than missed.

## Verification

`pint`, `phpstan` and the suite are green — **417 passing**, 12 new, no existing test changed. Ten mutations were run and all ten killed: restoring the single-argument rejection, self-binding concrete to null, routing the single-argument form through the wrong resolver, resolving the abstract with `resolveClassLike`, dropping the charset rule, widening the concrete to aliases, reading named arguments positionally, removing the spread bail-out, class-only keys in the `$bindings` array, and disabling the receiver check.
