### PR TITLE
Keep the first facade-scan read for the second pass

### DIFF
--- a/src/Analysis/FacadeAnalyzer.php
+++ b/src/Analysis/FacadeAnalyzer.php
@@ -77,15 +77,19 @@ final class FacadeAnalyzer
             false,
         );
 
-        // Round one: only files that name Facade at all. A facade reaches Illuminate's Facade
-        // through `extends`, and naming that class — imported, aliased or fully qualified —
-        // leaves the token behind.
+        // One read per file. The second pass used to throw the bytes away and open every
+        // remaining file again whenever a chain name turned up.
+        /** @var array<string, string> path => source, files not yet parsed */
         $pending = [];
         foreach ($files as $path) {
-            if ($this->mightDefineFacade($path)) {
+            $code = @file_get_contents($path);
+            if ($code === false) {
+                continue;
+            }
+            if ($this->codeMightDefineFacade($code)) {
                 $this->scanFile($path, $registry);
             } else {
-                $pending[] = $path;
+                $pending[$path] = $code;
             }
         }
 
@@ -103,11 +107,7 @@ final class FacadeAnalyzer
             $seen = array_merge($seen, $bases);
 
             $stillPending = [];
-            foreach ($pending as $path) {
-                $code = @file_get_contents($path);
-                if ($code === false) {
-                    continue;
-                }
+            foreach ($pending as $path => $code) {
                 $mentions = false;
                 foreach ($bases as $base) {
                     if (str_contains($code, $base)) {
@@ -118,7 +118,7 @@ final class FacadeAnalyzer
                 if ($mentions) {
                     $this->scanFile($path, $registry);
                 } else {
-                    $stillPending[] = $path;
+                    $stillPending[$path] = $code;
                 }
             }
             $pending = $stillPending;
@@ -134,21 +134,30 @@ final class FacadeAnalyzer
      *
      * Naming the class is the real test, but `Facade` on its own is not that test: the import
      * `use Illuminate\Support\Facades\Log;` contains it, and most files in a Laravel application
-     * carry a line like that. Dropping the framework's `Facades\` path segment first leaves the
-     * bare mention that only a file defining or extending a facade has — 22% of one application
-     * admitted down to 1%, and the base class itself survives, since
-     * `Illuminate\Support\Facades\Facade` still reads `Illuminate\Support\Facade` afterwards.
+     * carry a line like that. Skipping a `Facades\` match leaves the bare mention that only a
+     * file defining or extending a facade has — 22% of one application admitted down to 1%.
+     * The base class still matches: after skipping `Facades\` in
+     * `Illuminate\Support\Facades\Facade`, the trailing `Facade` remains.
      *
      * On its own this misses a facade that reaches the base through an app-level intermediate;
      * {@see analyze()} closes that with a second pass rather than assuming it away.
      */
-    private function mightDefineFacade(string $file): bool
+    private function codeMightDefineFacade(string $code): bool
     {
-        $code = @file_get_contents($file);
-
         // Case-sensitive, unlike the `extends` keyword this replaced: `Facade` is a class name,
         // and PHP class names are matched case-sensitively by the autoloader in practice.
-        return $code !== false && str_contains(str_replace('Facades\\', '', $code), 'Facade');
+        $offset = 0;
+        while (($p = strpos($code, 'Facade', $offset)) !== false) {
+            if (substr($code, $p, 8) === 'Facades\\') {
+                $offset = $p + 8;
+
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
     }
 
     private function scanFile(string $file, FacadeRegistry $registry): void


### PR DESCRIPTION
## What

The facade scan's second pass exists so a child that never names `Facade` is still found when it extends an app-level base that does. After reading a file in round one it discarded the bytes and opened every remaining file again the moment a chain name turned up.

Completeness does not need that second open. The first pass already has the source.

## Cost

Medians of four interleaved runs in one session, warm, against this branch's merge-base. Lifecycle runs before facades and is the canary. Parse counts do not move.

| application | php files in app/ | facades | facade phase | scan |
|---|---:|---:|---:|---:|
| A | 1,121 | 0 | 59 → 66 ms | 1,996 → 2,027 ms |
| B | 1,951 | 6 | 208 → 152 ms | 1,433 → 1,371 ms |
| C | 4,309 | 0 | 445 → 441 ms | 1,540 → 1,528 ms |

B is the application that has facades, so it is the one that actually runs the second pass. That is where the 56 ms comes from. A and C have none; their facade phase remains a single read of every PHP file under `app/`.

During the phase the unread sources occupy about 6 MB / 6 MB / 16 MB. Peak RSS of the whole scan is unchanged on A and B, and +2 MB on C; the graph phase still dominates it.

## Why this shape

#80 left this phase reading every file once to apply the filter. Parallel reads did not help. A filename filter on `*Facade.php` misses application facades that are not named that way.

The `Facades\` skip is unchanged. It no longer copies each file to do it; compared with `str_replace('Facades\\', '', $code)` it admits the same 3 / 15 / 8 files on 1,121 / 1,951 / 4,309 files under `app/`.

## Gate

Full build output — graph, all subgraphs, manifest, totals, the tracer's edge list — is **byte-identical on all three applications**, 40.2 MB, 16.4 MB and 20.4 MB of dump apiece. Parse counts 733 / 1,098 / 746 on both arms.

## Tests

`397 passed (1107 assertions)` · PHPStan level 5 + larastan **No errors** · Pint clean.

No new tests. Removing the second pass fails `it discovers a facade whose own file never mentions Facade`. Re-reading the pending files from disk leaves the suite green, so the speed claim is the wall-clock table, not an assertion.

Made with [Cursor](https://cursor.com)