### PR TITLE
Give the benchmark application facades and the imports a real app has

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -38,9 +38,10 @@ A default run â€” three scenarios, one warmup and five timed repetitions each â€
 takes a few seconds once the applications have been generated.
 
 The application is synthetic and deliberately awkward: a service, repository and
-model layer shared by many entry points, chains four deep, and classes with
-private helpers and call-free getters. It is a workload, not an average app, so
-read the absolute times as such.
+model layer shared by many entry points, chains four deep, classes with private
+helpers and call-free getters, and two application facades so the facade scan
+is not idle. It is a workload, not an average app, so read the absolute times
+as such.
 
 ## Reading the two kinds of number
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -39,9 +39,9 @@ takes a few seconds once the applications have been generated.
 
 The application is synthetic and deliberately awkward: a service, repository and
 model layer shared by many entry points, chains four deep, classes with private
-helpers and call-free getters, and two application facades so the facade scan
-is not idle. It is a workload, not an average app, so read the absolute times
-as such.
+helpers and call-free getters, two application facades, and a framework facade
+import on almost every class so the prefilter has something to skip. It is a
+workload, not an average app, so read the absolute times as such.
 
 ## Reading the two kinds of number
 

--- a/benchmark/generate-corpus.php
+++ b/benchmark/generate-corpus.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
  *   - entry classes (jobs, listeners, commands, middleware, Livewire
  *     components, observers) with several methods each, including private
  *     helpers and call-free getters
+ *   - two application facades (unscaled), so the facade scan is not idle: one
+ *     ordinary `extends Facade`, and one child that never names Facade, reaching
+ *     the base through an app-level parent. A controller calls each.
  *
  * Output is byte-identical for a given scale — there is no randomness — so both
  * arms of a comparison can scan the same generated tree.
@@ -226,6 +229,11 @@ for ($i = 0; $i < $counts['controllers']; $i++) {
     $actions = ['index', 'show', 'store', 'update'];
     foreach ($actions as $ai => $action) {
         $calls = $bodyCalls($i * 5 + $ai, 4);
+        if ($i === 0 && $action === 'index') {
+            $calls .= "\n        \\App\\Facades\\Catalog::handle0(\$id);";
+        } elseif ($i === 1 && $action === 'index') {
+            $calls .= "\n        \\App\\Support\\Reporting::handle0(\$id);";
+        }
         $methods[] = <<<M
     public function $action(int \$id)
     {
@@ -450,6 +458,54 @@ $calls
 PHP);
 }
 
+// ─── application facades (unscaled) ───────────────────────────────────────────
+// Two concrete facades, three files. The count is fixed so a larger scale does
+// not invent more of them; one of each shape is enough for the facade scan to
+// run its second pass and for a missed resolution to drop a graph edge.
+put("$outDir/app/Facades/Catalog.php", <<<'PHP'
+<?php
+
+namespace App\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+class Catalog extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return \App\Services\Service000::class;
+    }
+}
+PHP);
+
+put("$outDir/app/Support/Facades/Base.php", <<<'PHP'
+<?php
+
+namespace App\Support\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+abstract class Base extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return \App\Services\Service001::class;
+    }
+}
+PHP);
+
+put("$outDir/app/Support/Reporting.php", <<<'PHP'
+<?php
+
+namespace App\Support;
+
+use App\Support\Facades\Base;
+
+class Reporting extends Base
+{
+}
+PHP);
+
 // ─── routes ────────────────────────────────────────────────────────────────────
 $webRoutes = "<?php\n\nuse Illuminate\\Support\\Facades\\Route;\n\n".implode("\n", $routeLines['web'])."\n";
 $apiRoutes = "<?php\n\nuse Illuminate\\Support\\Facades\\Route;\n\n".implode("\n", $routeLines['api'])."\n";
@@ -489,4 +545,5 @@ fwrite(STDERR, "Generated corpus at $outDir (scale $scale)\n");
 foreach ($counts as $k => $v) {
     fwrite(STDERR, sprintf("  %-14s %d\n", $k, $v));
 }
+fwrite(STDERR, "  facades        2 (plus 1 abstract base, unscaled)\n");
 fwrite(STDERR, "  TOTAL classes ≈ $total, php files under app/ = $files\n");

--- a/benchmark/generate-corpus.php
+++ b/benchmark/generate-corpus.php
@@ -16,6 +16,8 @@ declare(strict_types=1);
  *   - two application facades (unscaled), so the facade scan is not idle: one
  *     ordinary `extends Facade`, and one child that never names Facade, reaching
  *     the base through an app-level parent. A controller calls each.
+ *   - a framework facade import on almost every class (`Log`, `Cache`, `DB`, …),
+ *     which is the shape the prefilter has to skip
  *
  * Output is byte-identical for a given scale — there is no randomness — so both
  * arms of a comparison can scan the same generated tree.
@@ -67,6 +69,19 @@ function put(string $path, string $contents): void
     file_put_contents($path, $contents);
 }
 
+/**
+ * Most files in a Laravel application import a framework facade. The facade
+ * prefilter has to skip `Facades\` so those imports are not treated as
+ * definitions. Without this line the generated tree cannot catch a regression
+ * of that skip: almost nothing under app/ mentioned Facade at all.
+ */
+function frameworkFacadeImport(int $i): string
+{
+    $names = ['Log', 'Cache', 'DB', 'Auth', 'Session', 'Storage'];
+
+    return 'use Illuminate\\Support\\Facades\\'.$names[$i % count($names)].';';
+}
+
 rmrf($outDir);
 mkdir($outDir, 0755, true);
 
@@ -106,12 +121,14 @@ for ($i = 0; $i < $counts['models']; $i++) {
     $name = 'Model'.$pad($i);
     $rel1 = 'Model'.$pad(($i + 1) % $counts['models']);
     $rel2 = 'Model'.$pad(($i + 2) % $counts['models']);
+    $fw = frameworkFacadeImport($i);
     put("$outDir/app/Models/$name.php", <<<PHP
 <?php
 
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+$fw
 
 class $name extends Model
 {
@@ -138,10 +155,13 @@ PHP);
 // ─── events ──────────────────────────────────────────────────────────────────
 for ($i = 0; $i < $counts['events']; $i++) {
     $name = 'Event'.$pad($i);
+    $fw = frameworkFacadeImport($i);
     put("$outDir/app/Events/$name.php", <<<PHP
 <?php
 
 namespace App\Events;
+
+$fw
 
 class $name
 {
@@ -164,10 +184,13 @@ for ($i = 0; $i < $counts['repositories']; $i++) {
 M;
     }
     $body = implode("\n\n", $body);
+    $fw = frameworkFacadeImport($i);
     put("$outDir/app/Repositories/$name.php", <<<PHP
 <?php
 
 namespace App\Repositories;
+
+$fw
 
 class $name
 {
@@ -199,6 +222,7 @@ M;
     }
 M;
     $methods = implode("\n\n", $methods);
+    $fw = frameworkFacadeImport($i);
     put("$outDir/app/Services/$name.php", <<<PHP
 <?php
 
@@ -206,6 +230,7 @@ namespace App\Services;
 
 use App\Services\\$svcDep;
 use App\Repositories\\$repoDep;
+$fw
 
 class $name
 {
@@ -246,6 +271,7 @@ M;
         $routeLines[$bucket][] = "Route::$verb('/$name/$action/{id}', [\\App\\Http\\Controllers\\$name::class, '$action']);";
     }
     $methods = implode("\n\n", $methods);
+    $fw = frameworkFacadeImport($i);
     put("$outDir/app/Http/Controllers/$name.php", <<<PHP
 <?php
 
@@ -253,6 +279,7 @@ namespace App\Http\Controllers;
 
 use App\Services\\$svcDep;
 use App\Services\\$svcDep2;
+$fw
 
 class $name
 {
@@ -272,6 +299,7 @@ for ($i = 0; $i < $counts['jobs']; $i++) {
     $svcDep = $svc($i);
     $calls = $bodyCalls($i * 11, 4);
     $calls2 = $bodyCalls($i * 11 + 3, 3);
+    $fw = frameworkFacadeImport($i);
     put("$outDir/app/Jobs/$name.php", <<<PHP
 <?php
 
@@ -280,6 +308,7 @@ namespace App\Jobs;
 use App\Services\\$svcDep;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+$fw
 
 class $name implements ShouldQueue
 {
@@ -311,12 +340,14 @@ for ($i = 0; $i < $counts['listeners']; $i++) {
     $name = 'Listener'.$pad($i);
     $svcDep = $svc($i + 4);
     $calls = $bodyCalls($i * 13, 4);
+    $fw = frameworkFacadeImport($i);
     put("$outDir/app/Listeners/$name.php", <<<PHP
 <?php
 
 namespace App\Listeners;
 
 use App\Services\\$svcDep;
+$fw
 
 class $name
 {
@@ -335,6 +366,7 @@ for ($i = 0; $i < $counts['commands']; $i++) {
     $name = 'Command'.$pad($i);
     $svcDep = $svc($i + 6);
     $calls = $bodyCalls($i * 17, 5);
+    $fw = frameworkFacadeImport($i);
     put("$outDir/app/Console/Commands/$name.php", <<<PHP
 <?php
 
@@ -342,6 +374,7 @@ namespace App\Console\Commands;
 
 use App\Services\\$svcDep;
 use Illuminate\Console\Command;
+$fw
 
 class $name extends Command
 {
@@ -364,6 +397,7 @@ for ($i = 0; $i < $counts['middleware']; $i++) {
     $name = 'Middleware'.$pad($i);
     $svcDep = $svc($i + 8);
     $calls = $bodyCalls($i * 19, 3);
+    $fw = frameworkFacadeImport($i);
     put("$outDir/app/Http/Middleware/$name.php", <<<PHP
 <?php
 
@@ -371,6 +405,7 @@ namespace App\Http\Middleware;
 
 use App\Services\\$svcDep;
 use Closure;
+$fw
 
 class $name
 {
@@ -407,6 +442,7 @@ M;
     }
 M;
     $methods = implode("\n\n", $methods);
+    $fw = frameworkFacadeImport($i);
     put("$outDir/app/Livewire/$name.php", <<<PHP
 <?php
 
@@ -414,6 +450,7 @@ namespace App\Livewire;
 
 use App\Services\\$svcDep;
 use Livewire\Component;
+$fw
 
 class $name extends Component
 {
@@ -434,12 +471,14 @@ for ($i = 0; $i < $counts['observers']; $i++) {
     $name = 'Observer'.$pad($i);
     $svcDep = $svc($i + 12);
     $calls = $bodyCalls($i * 29, 3);
+    $fw = frameworkFacadeImport($i);
     put("$outDir/app/Observers/$name.php", <<<PHP
 <?php
 
 namespace App\Observers;
 
 use App\Services\\$svcDep;
+$fw
 
 class $name
 {

--- a/tests/Unit/BenchmarkCorpusFacadesTest.php
+++ b/tests/Unit/BenchmarkCorpusFacadesTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use LaraMint\LaravelBrain\Analysis\FacadeAnalyzer;
+use LaraMint\LaravelBrain\Analysis\FacadeRecord;
+
+function removeBenchmarkCorpus(string $dir): void
+{
+    if (! is_dir($dir)) {
+        return;
+    }
+
+    $entries = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST,
+    );
+
+    foreach ($entries as $entry) {
+        $entry->isDir() ? rmdir($entry->getPathname()) : unlink($entry->getPathname());
+    }
+
+    rmdir($dir);
+}
+
+it('generates an ordinary facade and one whose own file never mentions Facade', function () {
+    $root = sys_get_temp_dir().'/brain-bench-facades-'.uniqid();
+
+    $cmd = sprintf(
+        '%s %s %s 1.0',
+        escapeshellarg(PHP_BINARY),
+        escapeshellarg(dirname(__DIR__, 2).'/benchmark/generate-corpus.php'),
+        escapeshellarg($root),
+    );
+    exec($cmd.' 2>/dev/null', $output, $code);
+    expect($code)->toBe(0);
+
+    $reporting = (string) file_get_contents($root.'/app/Support/Reporting.php');
+    expect(str_contains(str_replace('Facades\\', '', $reporting), 'Facade'))->toBeFalse();
+
+    expect((string) file_get_contents($root.'/app/Http/Controllers/Controller000.php'))
+        ->toContain('\\App\\Facades\\Catalog::handle0');
+    expect((string) file_get_contents($root.'/app/Http/Controllers/Controller001.php'))
+        ->toContain('\\App\\Support\\Reporting::handle0');
+
+    $registry = (new FacadeAnalyzer)->analyze($root);
+
+    expect($registry->get('App\Facades\Catalog'))
+        ->toBeInstanceOf(FacadeRecord::class)
+        ->accessor->toBe('App\Services\Service000')
+        ->concreteFqcn->toBe('App\Services\Service000');
+
+    expect($registry->get('App\Support\Reporting'))
+        ->toBeInstanceOf(FacadeRecord::class)
+        ->accessor->toBe('App\Services\Service001')
+        ->concreteFqcn->toBe('App\Services\Service001');
+
+    expect($registry->get('App\Support\Facades\Base'))->toBeNull();
+
+    removeBenchmarkCorpus($root);
+});

--- a/tests/Unit/BenchmarkCorpusFacadesTest.php
+++ b/tests/Unit/BenchmarkCorpusFacadesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use LaraMint\LaravelBrain\Analysis\FacadeAnalyzer;
 use LaraMint\LaravelBrain\Analysis\FacadeRecord;
+use LaraMint\LaravelBrain\Parser\PhpFileParser;
 
 function removeBenchmarkCorpus(string $dir): void
 {
@@ -43,7 +44,32 @@ it('generates an ordinary facade and one whose own file never mentions Facade', 
     expect((string) file_get_contents($root.'/app/Http/Controllers/Controller001.php'))
         ->toContain('\\App\\Support\\Reporting::handle0');
 
+    $appFiles = 0;
+    $frameworkFacadeImports = 0;
+    $bareFacadeHits = 0;
+    $it = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($root.'/app', FilesystemIterator::SKIP_DOTS),
+    );
+    foreach ($it as $file) {
+        if ($file->getExtension() !== 'php') {
+            continue;
+        }
+        $appFiles++;
+        $code = (string) file_get_contents($file->getPathname());
+        if (str_contains($code, 'Illuminate\\Support\\Facades\\')) {
+            $frameworkFacadeImports++;
+        }
+        if (str_contains(str_replace('Facades\\', '', $code), 'Facade')) {
+            $bareFacadeHits++;
+        }
+    }
+
+    expect($frameworkFacadeImports)->toBeGreaterThan((int) ($appFiles * 0.9));
+    expect($bareFacadeHits)->toBeLessThan(10);
+
+    $before = PhpFileParser::$parseCount;
     $registry = (new FacadeAnalyzer)->analyze($root);
+    $parses = PhpFileParser::$parseCount - $before;
 
     expect($registry->get('App\Facades\Catalog'))
         ->toBeInstanceOf(FacadeRecord::class)
@@ -56,6 +82,7 @@ it('generates an ordinary facade and one whose own file never mentions Facade', 
         ->concreteFqcn->toBe('App\Services\Service001');
 
     expect($registry->get('App\Support\Facades\Base'))->toBeNull();
+    expect($parses)->toBeLessThan(10);
 
     removeBenchmarkCorpus($root);
 });


### PR DESCRIPTION
## What

The generator wrote no application facade. The facade phase on CI is a 15 ms first-read of a tree that has none, so a broken `FacadeAnalyzer` would not move counts. #134's timing claim is idle there for the same reason.

It now emits two, unscaled. `App\Facades\Catalog` is the ordinary `extends Facade`. `App\Support\Reporting` reaches the base through an abstract parent and its own file never names `Facade`, which is the second pass. `Controller000` and `Controller001` call them.

Almost every other generated class now has `use Illuminate\Support\Facades\Log` (or Cache, DB, Auth, Session, Storage). That is the line a real app file carries, and the line the prefilter has to skip. The imports are unused; class bodies are unchanged.

## Why this shape

One of each application facade is enough for the second pass to run. Scaling them with the tree would add more without making the scan more like a real app.

The imports close a different gap. On a tree that only had the two definitions, reverting the `Facades\` skip still only admitted a handful of files. With the imports, the same revert sends `FacadeAnalyzer` from 6 parses to 399.

`MethodTracer` does not hop a static call on an application facade, so `facade-resolves-to` edges still do not appear.

## Cost

Nothing timed. Unused `use` lines. The suite's facade phase is 15 ms with a ±16% floor; this will not make a second-pass I/O win visible there.

## Gate

Same Brain, old tree vs this tree, scale 1, PHP 8.5: files 395 → 398, facades found 0 → 2, parse() 216 → 222, nodes / edges / tabs / routes unchanged (719 / 1,953 / 195 / 160). The import lines do not add parses: `scan-small` is still 222 against the first commit of this PR.

This PR's CI comment will still show identical counts between arms. Both scan the new tree with the same analyzer. The next PR that drops the `Facades\` skip is the one that will move parse calls, by hundreds.

## Tests

`406 passed (1135 assertions)` · PHPStan level 5 + larastan **No errors** · Pint clean.

The test dies if `Reporting.php` is missing, if `Controller000` no longer calls `Catalog`, if fewer than 90% of app files import a framework facade, or if `FacadeAnalyzer` parses 10 or more files on that tree.

Mutations: empty `frameworkFacadeImport` → `2 is not greater than 358`. Raw `str_contains($code, 'Facade')` in `mightDefineFacade` → `399 is not less than 10`.

Made with [Cursor](https://cursor.com)